### PR TITLE
fix: add missing organizer kwarg to event.dashboard url

### DIFF
--- a/exhibition/templates/exhibitors/base.html
+++ b/exhibition/templates/exhibitors/base.html
@@ -51,7 +51,7 @@
           <i class="fa fa-ticket"></i> {% trans "Tickets" %}
         </a>
         {% if is_talk_event_created %}
-          <a href="{% url 'orga:event.dashboard' event=request.event.slug %}" class="header-nav btn btn-outline-success">
+          <a href="{% url 'orga:event.dashboard' organizer=request.organizer.slug event=request.event.slug %}" class="header-nav btn btn-outline-success">
             <i class="fa fa-group"></i> {% trans "Talks" %}
           </a>
         {% endif %}


### PR DESCRIPTION
This fixes a NoReverseMatch error where the 'orga:event.dashboard' URL was missing the required 'organizer' keyword argument.


https://github.com/user-attachments/assets/0de68d40-9bdc-44bd-be43-32c60171375d


## Summary by Sourcery

Bug Fixes:
- Add the missing organizer keyword argument to the orga:event.dashboard URL in the exhibitors template to prevent NoReverseMatch errors.