### PR TITLE
Add drag-and-drop ordering for proposal form fields

### DIFF
--- a/exhibition/forms.py
+++ b/exhibition/forms.py
@@ -611,6 +611,7 @@ class ExhibitionProposalForm(ExhibitionQuestionFieldsMixin, I18nModelForm):
                 widget.attrs.setdefault("rows", 4)
         if self.event:
             self.apply_proposal_field_settings()
+            self.apply_proposal_field_order()
             self.inject_exhibition_questions(
                 event=self.event,
                 proposal=instance,
@@ -646,6 +647,16 @@ class ExhibitionProposalForm(ExhibitionQuestionFieldsMixin, I18nModelForm):
             for field_name in form_fields:
                 if field_name in self.fields:
                     self.fields[field_name].required = is_required
+
+    def apply_proposal_field_order(self):
+        if not self.exhibition_settings:
+            return
+        ordered_field_names = []
+        for key in self.exhibition_settings.ordered_proposal_field_keys:
+            for field_name in self.setting_field_map.get(key, ()):
+                if field_name in self.fields:
+                    ordered_field_names.append(field_name)
+        self.order_fields(ordered_field_names)
 
     def field_setting_is_active(self, key):
         return self.active_proposal_fields.get(key, True)

--- a/exhibition/models.py
+++ b/exhibition/models.py
@@ -141,13 +141,17 @@ PROPOSAL_DEFAULT_FIELDS = (
 )
 
 
+PROPOSAL_DEFAULT_FIELD_KEYS = tuple(field["key"] for field in PROPOSAL_DEFAULT_FIELDS)
+
+
 def default_proposal_field_settings():
     return {
         field["key"]: {
             "active": field.get("active", True),
             "required": field.get("required", False),
+            "position": index,
         }
-        for field in PROPOSAL_DEFAULT_FIELDS
+        for index, field in enumerate(PROPOSAL_DEFAULT_FIELDS)
     }
 
 
@@ -194,11 +198,12 @@ class ExhibitorSettings(models.Model):
     def normalized_proposal_field_settings(self):
         stored_settings = self.proposal_field_settings or {}
         normalized = default_proposal_field_settings()
-        for field in PROPOSAL_DEFAULT_FIELDS:
+        for index, field in enumerate(PROPOSAL_DEFAULT_FIELDS):
             key = field["key"]
             stored_field = stored_settings.get(key, {})
             normalized[key]["active"] = bool(stored_field.get("active", normalized[key]["active"]))
             normalized[key]["required"] = bool(stored_field.get("required", normalized[key]["required"]))
+            normalized[key]["position"] = stored_field.get("position", index)
             if field.get("active_locked"):
                 normalized[key]["active"] = True
             if field.get("required_locked"):
@@ -208,6 +213,15 @@ class ExhibitorSettings(models.Model):
             if not normalized[key]["active"]:
                 normalized[key]["required"] = False
         return normalized
+
+    @property
+    def ordered_proposal_field_keys(self):
+        normalized = self.normalized_proposal_field_settings
+        default_index = {key: i for i, key in enumerate(PROPOSAL_DEFAULT_FIELD_KEYS)}
+        return sorted(
+            PROPOSAL_DEFAULT_FIELD_KEYS,
+            key=lambda key: (normalized[key]["position"], default_index[key]),
+        )
 
     def proposal_field_is_active(self, key):
         return self.normalized_proposal_field_settings[key]["active"]

--- a/exhibition/models.py
+++ b/exhibition/models.py
@@ -143,6 +143,8 @@ PROPOSAL_DEFAULT_FIELDS = (
 
 PROPOSAL_DEFAULT_FIELD_KEYS = tuple(field["key"] for field in PROPOSAL_DEFAULT_FIELDS)
 
+PROPOSAL_FORMSET_FIELD_KEYS = ("social_links", "extra_links")
+
 
 def default_proposal_field_settings():
     return {

--- a/exhibition/static/exhibition/css/proposal-field-order.css
+++ b/exhibition/static/exhibition/css/proposal-field-order.css
@@ -1,0 +1,4 @@
+.proposal-field-order {
+    --color-text-lighter: rgb(0 0 0 / 0.6);
+    --color-grey-lighter: #eef0f2;
+}

--- a/exhibition/static/exhibition/css/proposal-field-order.css
+++ b/exhibition/static/exhibition/css/proposal-field-order.css
@@ -1,4 +1,33 @@
-.proposal-field-order {
-    --color-text-lighter: rgb(0 0 0 / 0.6);
-    --color-grey-lighter: #eef0f2;
+.proposal-field-order tr[dragsort-id].drag-indicator.insert-before th,
+.proposal-field-order tr[dragsort-id].drag-indicator.insert-before td {
+    border-top: 2px solid rgba(0, 0, 0, 0.6);
+}
+
+.proposal-field-order tr[dragsort-id].drag-indicator.insert-after th,
+.proposal-field-order tr[dragsort-id].drag-indicator.insert-after td {
+    border-bottom: 2px solid rgba(0, 0, 0, 0.6);
+}
+
+.proposal-field-order thead.drag-indicator.insert-after {
+    box-shadow: 0 2px rgba(0, 0, 0, 0.6);
+}
+
+.proposal-field-order tr[dragsort-id].dragging td {
+    background-color: #eef0f2;
+}
+
+.proposal-field-order .dragsort-button:not(:disabled) {
+    cursor: grab;
+}
+
+.proposal-field-order .dragsort-button:not(:disabled):active {
+    cursor: grabbing;
+}
+
+body.dragging {
+    cursor: grabbing !important;
+}
+
+body.dragging .dragsort-button {
+    transform: translate(-9999px);
 }

--- a/exhibition/static/exhibition/css/proposal-field-order.css
+++ b/exhibition/static/exhibition/css/proposal-field-order.css
@@ -24,10 +24,6 @@
     cursor: grabbing;
 }
 
-body.dragging {
-    cursor: grabbing !important;
-}
-
 body.dragging .dragsort-button {
     transform: translate(-9999px);
 }

--- a/exhibition/templates/exhibitors/call_questions.html
+++ b/exhibition/templates/exhibitors/call_questions.html
@@ -7,7 +7,6 @@
 {% block custom_header %}
     {{ block.super }}
     <link rel="stylesheet" href="{% static 'pretixcontrol/css/order-form-toggles.css' %}">
-    <link rel="stylesheet" href="{% static 'orga/css/dragsort.css' %}">
     <link rel="stylesheet" href="{% static 'exhibition/css/proposal-field-order.css' %}">
     <script defer src="{% static 'orga/js/dragsort.js' %}"></script>
 {% endblock %}
@@ -30,7 +29,7 @@
                         <th class="text-center">{% trans "Active" %}</th>
                         <th class="text-center">{% trans "Required" %}</th>
                         <th class="text-center">{% trans "Answers" %}</th>
-                        <th></th>
+                        <th class="text-right">{% trans "Settings" %}</th>
                     </tr>
                     </thead>
                     <tbody dragsort-url="{% url 'plugins:exhibition:call.questions' organizer=request.event.organizer.slug event=request.event.slug %}">

--- a/exhibition/templates/exhibitors/call_questions.html
+++ b/exhibition/templates/exhibitors/call_questions.html
@@ -34,7 +34,7 @@
                     </thead>
                     <tbody dragsort-url="{% url 'plugins:exhibition:call.questions' organizer=request.event.organizer.slug event=request.event.slug %}">
                     {% for field in default_fields %}
-                        <tr dragsort-id="{{ field.key }}">
+                        <tr {% if field.orderable %}dragsort-id="{{ field.key }}"{% endif %}>
                             <th>{{ field.label }}</th>
                             <td class="text-center">
                                 <label class="toggle-switch {% if field.active_locked %}always-on{% endif %}" aria-label="{% blocktrans trimmed with field=field.label %}Toggle active state for {{ field }}{% endblocktrans %}">
@@ -54,9 +54,15 @@
                             </td>
                             <td class="text-center">{{ field.answer_count }}</td>
                             <td class="text-right">
-                                <button type="button" draggable="true" class="btn btn-primary btn-sm dragsort-button" title="{% trans 'Move field' %}">
-                                    <i class="fa fa-arrows"></i>
-                                </button>
+                                {% if field.orderable %}
+                                    <button type="button" draggable="true" class="btn btn-primary btn-sm dragsort-button" title="{% trans 'Move field' %}">
+                                        <i class="fa fa-arrows"></i>
+                                    </button>
+                                {% else %}
+                                    <span class="text-muted" title="{% trans 'This field always appears at the end of the form.' %}">
+                                        <i class="fa fa-thumb-tack"></i>
+                                    </span>
+                                {% endif %}
                             </td>
                         </tr>
                     {% endfor %}

--- a/exhibition/templates/exhibitors/call_questions.html
+++ b/exhibition/templates/exhibitors/call_questions.html
@@ -7,6 +7,9 @@
 {% block custom_header %}
     {{ block.super }}
     <link rel="stylesheet" href="{% static 'pretixcontrol/css/order-form-toggles.css' %}">
+    <link rel="stylesheet" href="{% static 'orga/css/dragsort.css' %}">
+    <link rel="stylesheet" href="{% static 'exhibition/css/proposal-field-order.css' %}">
+    <script defer src="{% static 'orga/js/dragsort.js' %}"></script>
 {% endblock %}
 
 {% block exhibitors_header %}
@@ -20,7 +23,7 @@
             <legend>{% trans "Proposal information" %}</legend>
             <p>{% trans "Choose which default fields are shown on the exhibitor and sponsor proposal form." %}</p>
             <div class="table-responsive table-responsive-always mw-100">
-                <table class="table table-hover">
+                <table class="table table-hover proposal-field-order">
                     <thead>
                     <tr>
                         <th>{% trans "Field" %}</th>
@@ -30,9 +33,9 @@
                         <th></th>
                     </tr>
                     </thead>
-                    <tbody>
+                    <tbody dragsort-url="{% url 'plugins:exhibition:call.questions' organizer=request.event.organizer.slug event=request.event.slug %}">
                     {% for field in default_fields %}
-                        <tr>
+                        <tr dragsort-id="{{ field.key }}">
                             <th>{{ field.label }}</th>
                             <td class="text-center">
                                 <label class="toggle-switch {% if field.active_locked %}always-on{% endif %}" aria-label="{% blocktrans trimmed with field=field.label %}Toggle active state for {{ field }}{% endblocktrans %}">
@@ -51,7 +54,11 @@
                                 {% endif %}
                             </td>
                             <td class="text-center">{{ field.answer_count }}</td>
-                            <td></td>
+                            <td class="text-right">
+                                <button type="button" draggable="true" class="btn btn-primary btn-sm dragsort-button" title="{% trans 'Move field' %}">
+                                    <i class="fa fa-arrows"></i>
+                                </button>
+                            </td>
                         </tr>
                     {% endfor %}
                     </tbody>

--- a/exhibition/templates/exhibitors/call_questions.html
+++ b/exhibition/templates/exhibitors/call_questions.html
@@ -55,7 +55,7 @@
                             <td class="text-center">{{ field.answer_count }}</td>
                             <td class="text-right">
                                 {% if field.orderable %}
-                                    <button type="button" draggable="true" class="btn btn-primary btn-sm dragsort-button" title="{% trans 'Move field' %}">
+                                    <button type="button" draggable="true" class="btn btn-primary btn-sm dragsort-button" title="{% trans 'Move field' %}" aria-label="{% trans 'Move field' %}">
                                         <i class="fa fa-arrows"></i>
                                     </button>
                                 {% else %}

--- a/exhibition/templates/exhibitors/public_proposal_form.html
+++ b/exhibition/templates/exhibitors/public_proposal_form.html
@@ -28,90 +28,93 @@
         {% bootstrap_form form layout="control" %}
 
         {% if can_edit and show_social_links %}
-            <fieldset>
-                <legend>{% trans "Social Media" %}</legend>
-                <div id="social-links-formset" class="partner-link-formset formset" data-formset-prefix="{{ social_media_formset.prefix }}" data-social-link-prefixes='{{ social_link_prefixes|escapejson_dumps }}'>
-                    {{ social_media_formset.management_form }}
-                    {{ social_media_formset.non_form_errors }}
-                    <div data-formset-body>
-                        {% for social_form in social_media_formset %}
+            <div class="form-group">
+                <div class="col-md-3 control-label partner-link-group-label">{% trans "Social Media" %}</div>
+                <div class="col-md-9">
+                    <div id="social-links-formset" class="partner-link-formset formset" data-formset-prefix="{{ social_media_formset.prefix }}" data-social-link-prefixes='{{ social_link_prefixes|escapejson_dumps }}'>
+                        {{ social_media_formset.management_form }}
+                        {{ social_media_formset.non_form_errors }}
+                        <div data-formset-body>
+                            {% for social_form in social_media_formset %}
+                                <div class="row partner-link-row" data-formset-form data-social-link-row>
+                                    <div class="sr-only">{{ social_form.id }} {{ social_form.DELETE }}</div>
+                                    <div class="col-md-3">{{ social_form.network.errors }}{{ social_form.network }}</div>
+                                    <div class="col-md-8">
+                                        {{ social_form.path.errors }}
+                                        <div class="input-group">
+                                            <span class="input-group-addon partner-link-prefix" data-social-prefix>https://</span>
+                                            {{ social_form.path }}
+                                        </div>
+                                    </div>
+                                    <div class="col-md-1 text-right">
+                                        <button type="button" class="btn btn-delete btn-danger btn-sm partner-link-remove" data-formset-delete-button><i class="fa fa-minus"></i></button>
+                                    </div>
+                                </div>
+                            {% endfor %}
+                        </div>
+                        <template data-formset-empty-form>
                             <div class="row partner-link-row" data-formset-form data-social-link-row>
-                                <div class="sr-only">{{ social_form.id }} {{ social_form.DELETE }}</div>
-                                <div class="col-md-3">{{ social_form.network.errors }}{{ social_form.network }}</div>
+                                <div class="sr-only">{{ social_media_formset.empty_form.id }} {{ social_media_formset.empty_form.DELETE }}</div>
+                                <div class="col-md-3">{{ social_media_formset.empty_form.network.errors }}{{ social_media_formset.empty_form.network }}</div>
                                 <div class="col-md-8">
-                                    {{ social_form.path.errors }}
+                                    {{ social_media_formset.empty_form.path.errors }}
                                     <div class="input-group">
                                         <span class="input-group-addon partner-link-prefix" data-social-prefix>https://</span>
-                                        {{ social_form.path }}
+                                        {{ social_media_formset.empty_form.path }}
                                     </div>
                                 </div>
                                 <div class="col-md-1 text-right">
                                     <button type="button" class="btn btn-delete btn-danger btn-sm partner-link-remove" data-formset-delete-button><i class="fa fa-minus"></i></button>
                                 </div>
                             </div>
-                        {% endfor %}
-                    </div>
-                    <template data-formset-empty-form>
-                        <div class="row partner-link-row" data-formset-form data-social-link-row>
-                            <div class="sr-only">{{ social_media_formset.empty_form.id }} {{ social_media_formset.empty_form.DELETE }}</div>
-                            <div class="col-md-3">{{ social_media_formset.empty_form.network.errors }}{{ social_media_formset.empty_form.network }}</div>
-                            <div class="col-md-8">
-                                {{ social_media_formset.empty_form.path.errors }}
-                                <div class="input-group">
-                                    <span class="input-group-addon partner-link-prefix" data-social-prefix>https://</span>
-                                    {{ social_media_formset.empty_form.path }}
-                                </div>
-                            </div>
-                            <div class="col-md-1 text-right">
-                                <button type="button" class="btn btn-delete btn-danger btn-sm partner-link-remove" data-formset-delete-button><i class="fa fa-minus"></i></button>
-                            </div>
+                        </template>
+                        <div class="partner-link-actions">
+                            <button type="button" class="btn btn-default btn-sm partner-link-add" data-formset-add>
+                                <i class="fa fa-plus"></i> {% trans "Add social media link" %}
+                            </button>
                         </div>
-                    </template>
-                    <div class="partner-link-actions">
-                        <button type="button" class="btn btn-default btn-sm partner-link-add" data-formset-add>
-                            <i class="fa fa-plus"></i> {% trans "Add social media link" %}
-                        </button>
                     </div>
                 </div>
-            </fieldset>
-
+            </div>
         {% endif %}
 
         {% if can_edit and show_extra_links %}
-            <fieldset>
-                <legend>{% trans "Extra Links" %}</legend>
-                <div id="extra-links-formset" class="partner-link-formset formset" data-formset-prefix="{{ extra_links_formset.prefix }}">
-                    {{ extra_links_formset.management_form }}
-                    {{ extra_links_formset.non_form_errors }}
-                    <div data-formset-body>
-                        {% for extra_form in extra_links_formset %}
+            <div class="form-group">
+                <div class="col-md-3 control-label partner-link-group-label">{% trans "Extra Links" %}</div>
+                <div class="col-md-9">
+                    <div id="extra-links-formset" class="partner-link-formset formset" data-formset-prefix="{{ extra_links_formset.prefix }}">
+                        {{ extra_links_formset.management_form }}
+                        {{ extra_links_formset.non_form_errors }}
+                        <div data-formset-body>
+                            {% for extra_form in extra_links_formset %}
+                                <div class="row partner-link-row" data-formset-form>
+                                    <div class="sr-only">{{ extra_form.id }} {{ extra_form.DELETE }}</div>
+                                    <div class="col-md-4">{{ extra_form.label.errors }}{{ extra_form.label }}</div>
+                                    <div class="col-md-7">{{ extra_form.url.errors }}{{ extra_form.url }}</div>
+                                    <div class="col-md-1 text-right">
+                                        <button type="button" class="btn btn-delete btn-danger btn-sm partner-link-remove" data-formset-delete-button><i class="fa fa-minus"></i></button>
+                                    </div>
+                                </div>
+                            {% endfor %}
+                        </div>
+                        <template data-formset-empty-form>
                             <div class="row partner-link-row" data-formset-form>
-                                <div class="sr-only">{{ extra_form.id }} {{ extra_form.DELETE }}</div>
-                                <div class="col-md-4">{{ extra_form.label.errors }}{{ extra_form.label }}</div>
-                                <div class="col-md-7">{{ extra_form.url.errors }}{{ extra_form.url }}</div>
+                                <div class="sr-only">{{ extra_links_formset.empty_form.id }} {{ extra_links_formset.empty_form.DELETE }}</div>
+                                <div class="col-md-4">{{ extra_links_formset.empty_form.label.errors }}{{ extra_links_formset.empty_form.label }}</div>
+                                <div class="col-md-7">{{ extra_links_formset.empty_form.url.errors }}{{ extra_links_formset.empty_form.url }}</div>
                                 <div class="col-md-1 text-right">
                                     <button type="button" class="btn btn-delete btn-danger btn-sm partner-link-remove" data-formset-delete-button><i class="fa fa-minus"></i></button>
                                 </div>
                             </div>
-                        {% endfor %}
-                    </div>
-                    <template data-formset-empty-form>
-                        <div class="row partner-link-row" data-formset-form>
-                            <div class="sr-only">{{ extra_links_formset.empty_form.id }} {{ extra_links_formset.empty_form.DELETE }}</div>
-                            <div class="col-md-4">{{ extra_links_formset.empty_form.label.errors }}{{ extra_links_formset.empty_form.label }}</div>
-                            <div class="col-md-7">{{ extra_links_formset.empty_form.url.errors }}{{ extra_links_formset.empty_form.url }}</div>
-                            <div class="col-md-1 text-right">
-                                <button type="button" class="btn btn-delete btn-danger btn-sm partner-link-remove" data-formset-delete-button><i class="fa fa-minus"></i></button>
-                            </div>
+                        </template>
+                        <div class="partner-link-actions">
+                            <button type="button" class="btn btn-default btn-sm partner-link-add" data-formset-add>
+                                <i class="fa fa-plus"></i> {% trans "Add extra link" %}
+                            </button>
                         </div>
-                    </template>
-                    <div class="partner-link-actions">
-                        <button type="button" class="btn btn-default btn-sm partner-link-add" data-formset-add>
-                            <i class="fa fa-plus"></i> {% trans "Add extra link" %}
-                        </button>
                     </div>
                 </div>
-            </fieldset>
+            </div>
         {% endif %}
 
         {% if can_edit %}

--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -30,6 +30,7 @@ from .forms import (
 from .models import (
     PROPOSAL_DEFAULT_FIELD_KEYS,
     PROPOSAL_DEFAULT_FIELDS,
+    PROPOSAL_FORMSET_FIELD_KEYS,
     ExhibitionProposal,
     ExhibitionProposalState,
     ExhibitionQuestion,
@@ -725,15 +726,19 @@ class ExhibitionQuestionListView(EventPermissionRequiredMixin, ListView):
         field_settings = settings.normalized_proposal_field_settings
         answer_counts = self.get_default_field_answer_counts()
         field_definitions = {field["key"]: field for field in PROPOSAL_DEFAULT_FIELDS}
+        ordered_keys = [
+            key for key in settings.ordered_proposal_field_keys if key not in PROPOSAL_FORMSET_FIELD_KEYS
+        ] + [key for key in PROPOSAL_DEFAULT_FIELD_KEYS if key in PROPOSAL_FORMSET_FIELD_KEYS]
         context["default_fields"] = [
             {
                 **field_definitions[key],
                 "active": field_settings[key]["active"],
                 "required": field_settings[key]["required"],
                 "supports_required": field_definitions[key].get("supports_required", True),
+                "orderable": key not in PROPOSAL_FORMSET_FIELD_KEYS,
                 "answer_count": answer_counts.get(key, 0),
             }
-            for key in settings.ordered_proposal_field_keys
+            for key in ordered_keys
         ]
         return context
 

--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -812,9 +812,7 @@ class ExhibitionQuestionListView(EventPermissionRequiredMixin, ListView):
 
     def save_field_order(self, settings, order_str):
         proposal_field_settings = settings.normalized_proposal_field_settings
-        orderable_keys = [
-            key for key in PROPOSAL_DEFAULT_FIELD_KEYS if key not in PROPOSAL_FORMSET_FIELD_KEYS
-        ]
+        orderable_keys = [key for key in PROPOSAL_DEFAULT_FIELD_KEYS if key not in PROPOSAL_FORMSET_FIELD_KEYS]
         orderable_key_set = set(orderable_keys)
         seen = set()
         position = 0

--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -812,18 +812,24 @@ class ExhibitionQuestionListView(EventPermissionRequiredMixin, ListView):
 
     def save_field_order(self, settings, order_str):
         proposal_field_settings = settings.normalized_proposal_field_settings
-        valid_keys = set(PROPOSAL_DEFAULT_FIELD_KEYS)
+        orderable_keys = [
+            key for key in PROPOSAL_DEFAULT_FIELD_KEYS if key not in PROPOSAL_FORMSET_FIELD_KEYS
+        ]
+        orderable_key_set = set(orderable_keys)
         seen = set()
         position = 0
         for key in order_str.split(","):
-            if key in valid_keys and key not in seen:
+            if key in orderable_key_set and key not in seen:
                 seen.add(key)
                 proposal_field_settings[key]["position"] = position
                 position += 1
-        for key in PROPOSAL_DEFAULT_FIELD_KEYS:
+        for key in orderable_keys:
             if key not in seen:
                 proposal_field_settings[key]["position"] = position
                 position += 1
+        for key in PROPOSAL_FORMSET_FIELD_KEYS:
+            proposal_field_settings[key]["position"] = position
+            position += 1
         settings.proposal_field_settings = proposal_field_settings
         settings.save(update_fields=["proposal_field_settings"])
 

--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -28,6 +28,7 @@ from .forms import (
     social_link_prefixes,
 )
 from .models import (
+    PROPOSAL_DEFAULT_FIELD_KEYS,
     PROPOSAL_DEFAULT_FIELDS,
     ExhibitionProposal,
     ExhibitionProposalState,
@@ -723,15 +724,16 @@ class ExhibitionQuestionListView(EventPermissionRequiredMixin, ListView):
         settings = ExhibitorSettings.objects.get_or_create(event=self.request.event)[0]
         field_settings = settings.normalized_proposal_field_settings
         answer_counts = self.get_default_field_answer_counts()
+        field_definitions = {field["key"]: field for field in PROPOSAL_DEFAULT_FIELDS}
         context["default_fields"] = [
             {
-                **field,
-                "active": field_settings[field["key"]]["active"],
-                "required": field_settings[field["key"]]["required"],
-                "supports_required": field.get("supports_required", True),
-                "answer_count": answer_counts.get(field["key"], 0),
+                **field_definitions[key],
+                "active": field_settings[key]["active"],
+                "required": field_settings[key]["required"],
+                "supports_required": field_definitions[key].get("supports_required", True),
+                "answer_count": answer_counts.get(key, 0),
             }
-            for field in PROPOSAL_DEFAULT_FIELDS
+            for key in settings.ordered_proposal_field_keys
         ]
         return context
 
@@ -771,6 +773,12 @@ class ExhibitionQuestionListView(EventPermissionRequiredMixin, ListView):
 
     def post(self, request, *args, **kwargs):
         settings = ExhibitorSettings.objects.get_or_create(event=request.event)[0]
+
+        order_param = request.POST.get("order")
+        if order_param:
+            self.save_field_order(settings, order_param)
+            return HttpResponse(status=204)
+
         proposal_field_settings = settings.normalized_proposal_field_settings
 
         for field in PROPOSAL_DEFAULT_FIELDS:
@@ -796,6 +804,23 @@ class ExhibitionQuestionListView(EventPermissionRequiredMixin, ListView):
 
         messages.success(request, _("Proposal form settings have been saved."))
         return redirect("plugins:exhibition:call.questions", **event_kwargs(request.event))
+
+    def save_field_order(self, settings, order_str):
+        proposal_field_settings = settings.normalized_proposal_field_settings
+        valid_keys = set(PROPOSAL_DEFAULT_FIELD_KEYS)
+        seen = set()
+        position = 0
+        for key in order_str.split(","):
+            if key in valid_keys and key not in seen:
+                seen.add(key)
+                proposal_field_settings[key]["position"] = position
+                position += 1
+        for key in PROPOSAL_DEFAULT_FIELD_KEYS:
+            if key not in seen:
+                proposal_field_settings[key]["position"] = position
+                position += 1
+        settings.proposal_field_settings = proposal_field_settings
+        settings.save(update_fields=["proposal_field_settings"])
 
 
 class ExhibitionQuestionCreateView(EventPermissionRequiredMixin, CreateView):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,9 +7,23 @@ from django.test import RequestFactory
 from rest_framework import serializers
 
 from exhibition.api import ExhibitorInfoSerializer
-from exhibition.forms import SponsorGroupForm
-from exhibition.models import ExhibitorInfo, SponsorGroup, get_next_sponsor_group_level
-from exhibition.views import SponsorGroupReorderView
+from exhibition.forms import ExhibitionProposalForm, SponsorGroupForm
+from exhibition.models import (
+    PROPOSAL_DEFAULT_FIELD_KEYS,
+    ExhibitorInfo,
+    ExhibitorSettings,
+    SponsorGroup,
+    get_next_sponsor_group_level,
+)
+from exhibition.views import ExhibitionQuestionListView, SponsorGroupReorderView
+
+
+def make_exhibitor_settings(event):
+    return ExhibitorSettings.objects.create(
+        event=event,
+        exhibitors_access_mail_subject="",
+        exhibitors_access_mail_body="",
+    )
 
 
 @pytest.mark.django_db
@@ -198,3 +212,25 @@ def test_sponsor_group_reorder_requires_complete_unique_group_ids(event):
     group_two.refresh_from_db()
     assert group_two.level == 1
     assert group_one.level == 2
+
+
+@pytest.mark.django_db
+def test_save_field_order_persists_new_order(event):
+    settings = make_exhibitor_settings(event)
+    view = ExhibitionQuestionListView()
+    view.save_field_order(settings, "logo,header_image,name")
+
+    settings.refresh_from_db()
+    assert settings.ordered_proposal_field_keys[:3] == ["logo", "header_image", "name"]
+    assert set(settings.ordered_proposal_field_keys) == set(PROPOSAL_DEFAULT_FIELD_KEYS)
+
+
+@pytest.mark.django_db
+def test_proposal_form_reflects_saved_field_order(event):
+    settings = make_exhibitor_settings(event)
+    view = ExhibitionQuestionListView()
+    view.save_field_order(settings, "description,name")
+
+    form = ExhibitionProposalForm(event=event)
+    field_names = list(form.fields.keys())
+    assert field_names.index("description") < field_names.index("name")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -218,10 +218,11 @@ def test_sponsor_group_reorder_requires_complete_unique_group_ids(event):
 def test_save_field_order_persists_new_order(event):
     settings = make_exhibitor_settings(event)
     view = ExhibitionQuestionListView()
-    view.save_field_order(settings, "logo,header_image,name")
+    view.save_field_order(settings, "social_links,logo,header_image,name")
 
     settings.refresh_from_db()
     assert settings.ordered_proposal_field_keys[:3] == ["logo", "header_image", "name"]
+    assert settings.ordered_proposal_field_keys[-2:] == ["social_links", "extra_links"]
     assert set(settings.ordered_proposal_field_keys) == set(PROPOSAL_DEFAULT_FIELD_KEYS)
 
 


### PR DESCRIPTION
fixes #53 #55 

Organizers can now reorder the default fields on the exhibitor/sponsor proposal form by dragging them on the Proposal Form config screen. The chosen order is reflected on the public proposal form and persists per event.


https://github.com/user-attachments/assets/4b9f9b9c-4a60-4d73-8177-1f6ab6517eb3

Note: the two formset fields social links and other links are non-dragable fields so those are pinned to the end of the form always


includes the work done here https://github.com/fossasia/eventyay-exhibition/pull/58 includes changes done to public_proposal_form.html only
