### PR TITLE
Match Organizer side back office form to public form

### DIFF
--- a/exhibition/forms.py
+++ b/exhibition/forms.py
@@ -63,10 +63,6 @@ class ExhibitorInfoForm(I18nModelForm):
         required=False,
         label=_("Sponsor Group"),
     )
-    not_an_exhibitor = forms.BooleanField(
-        required=False,
-        label=_("This Partner is Not an Exhibitor"),
-    )
     allow_voucher_access = forms.BooleanField(
         required=False,
         label=_("Allowed to access voucher data"),
@@ -133,6 +129,7 @@ class ExhibitorInfoForm(I18nModelForm):
             "logo_url",
             "header_image",
             "header_image_url",
+            "is_exhibitor",
             "is_sponsor",
             "sponsor_group",
             "booth_id",
@@ -152,6 +149,7 @@ class ExhibitorInfoForm(I18nModelForm):
             "logo": _("Logo"),
             "header_image": _("Header Image"),
             "url": _("Organization Website"),
+            "is_exhibitor": _("Mark this partner as an exhibitor"),
             "is_sponsor": _("Mark this partner as an event sponsor"),
             "booth_name": _("Preferred booth name"),
             "lead_scanning_enabled": _("Allow lead scanning"),
@@ -181,8 +179,6 @@ class ExhibitorInfoForm(I18nModelForm):
         "allow_lead_access",
         "lead_scanning_scope_by_device",
     )
-    TYPE_TOGGLE_FIELDS = ("is_sponsor", "not_an_exhibitor")
-
     def __init__(self, *args, **kwargs):
         self.partner_type = kwargs.pop("partner_type", None)
         event = kwargs.get("event")
@@ -190,9 +186,9 @@ class ExhibitorInfoForm(I18nModelForm):
         super().__init__(*args, **kwargs)
         self.event = event or getattr(instance, "event", None)
         if self.partner_type == "sponsor":
-            self._drop_fields(self.EXHIBITOR_ONLY_FIELDS + self.TYPE_TOGGLE_FIELDS)
+            self._drop_fields(self.EXHIBITOR_ONLY_FIELDS + ("is_sponsor",))
         elif self.partner_type == "exhibitor":
-            self._drop_fields(self.SPONSOR_ONLY_FIELDS + self.TYPE_TOGGLE_FIELDS)
+            self._drop_fields(self.SPONSOR_ONLY_FIELDS + ("is_exhibitor",))
         if "sponsor_group" in self.fields:
             self.fields["sponsor_group"].queryset = SponsorGroup.objects.filter(event=self.event).order_by("pk")
             self.fields["sponsor_group"].empty_label = _("No sponsor group")
@@ -201,7 +197,6 @@ class ExhibitorInfoForm(I18nModelForm):
         self.fields["slides"].widget.attrs.setdefault("accept", ".pdf,application/pdf")
         if self.instance and self.instance.pk:
             self.initial["lead_scanning_scope_by_device"] = self.instance.lead_scanning_scope_by_device
-            self.initial["not_an_exhibitor"] = not self.instance.is_exhibitor
         description_field = self.fields.get("description")
         if description_field:
             widget = description_field.widget
@@ -332,16 +327,17 @@ class ExhibitorInfoForm(I18nModelForm):
             if image_url:
                 cleaned_data[url_field] = normalize_url_scheme(image_url)
 
-        editing_existing = bool(self.instance and self.instance.pk)
         if self.partner_type == "sponsor":
             is_sponsor = True
-            is_exhibitor = self.instance.is_exhibitor if editing_existing else False
+            is_exhibitor = bool(cleaned_data.get("is_exhibitor"))
         elif self.partner_type == "exhibitor":
-            is_sponsor = self.instance.is_sponsor if editing_existing else False
+            is_sponsor = bool(cleaned_data.get("is_sponsor"))
             is_exhibitor = True
         else:
             is_sponsor = bool(cleaned_data.get("is_sponsor"))
-            is_exhibitor = not cleaned_data.get("not_an_exhibitor", False)
+            is_exhibitor = bool(cleaned_data.get("is_exhibitor"))
+            if not is_sponsor and not is_exhibitor:
+                self.add_error(None, _("A partner must be marked as an exhibitor, a sponsor, or both."))
         self._resolved_is_sponsor = is_sponsor
         cleaned_data["is_exhibitor"] = is_exhibitor
 
@@ -363,7 +359,7 @@ class ExhibitorInfoForm(I18nModelForm):
             cleaned_data["allow_lead_access"] = False
             cleaned_data["lead_scanning_scope_by_device"] = False
 
-        for name in self.TYPE_TOGGLE_FIELDS + self.SPONSOR_ONLY_FIELDS + self.EXHIBITOR_ONLY_FIELDS:
+        for name in ("is_exhibitor", "is_sponsor") + self.SPONSOR_ONLY_FIELDS + self.EXHIBITOR_ONLY_FIELDS:
             if name not in self.fields:
                 cleaned_data.pop(name, None)
 

--- a/exhibition/forms.py
+++ b/exhibition/forms.py
@@ -153,9 +153,24 @@ class ExhibitorInfoForm(I18nModelForm):
             "header_image": _("Header Image"),
             "url": _("Organization Website"),
             "is_sponsor": _("Mark this partner as an event sponsor"),
-            "booth_name": _("Booth name"),
+            "booth_name": _("Preferred booth name"),
             "lead_scanning_enabled": _("Allow lead scanning"),
         }
+
+    PROFILE_SETTING_FIELD_MAP = {
+        "name": ("name",),
+        "description": ("description",),
+        "email": ("email",),
+        "url": ("url",),
+        "contact_url": ("contact_url",),
+        "video_url": ("video_url",),
+        "slides": ("slides", "slides_url"),
+        "logo": ("logo", "logo_url"),
+        "header_image": ("header_image", "header_image_url"),
+        "booth_name": ("booth_name",),
+    }
+    PROFILE_FORMSET_KEYS = ("social_links", "extra_links")
+    PROFILE_COMPOSITE_KEYS = ("slides", "logo", "header_image")
 
     SPONSOR_ONLY_FIELDS = ("sponsor_group",)
     EXHIBITOR_ONLY_FIELDS = (
@@ -195,6 +210,55 @@ class ExhibitorInfoForm(I18nModelForm):
                     sub_widget.attrs.setdefault("rows", 4)
             else:
                 widget.attrs.setdefault("rows", 4)
+        self.profile_field_settings = {}
+        self.ordered_profile_keys = []
+        if self.event:
+            settings = ExhibitorSettings.objects.get_or_create(event=self.event)[0]
+            self.profile_field_settings = settings.normalized_proposal_field_settings
+            self._apply_profile_field_settings()
+            self.ordered_profile_keys = [
+                key for key in settings.ordered_proposal_field_keys if self.profile_key_is_active(key)
+            ]
+            self._apply_profile_field_order()
+
+    def _apply_profile_field_settings(self):
+        for key, field_names in self.PROFILE_SETTING_FIELD_MAP.items():
+            if self.profile_key_is_active(key):
+                if key in self.PROFILE_COMPOSITE_KEYS:
+                    continue
+                for field_name in field_names:
+                    if field_name in self.fields:
+                        self.fields[field_name].required = self.profile_field_settings[key]["required"]
+            else:
+                self._drop_fields(field_names)
+
+    def _apply_profile_field_order(self):
+        ordered_field_names = []
+        for key in self.ordered_profile_keys:
+            for field_name in self.PROFILE_SETTING_FIELD_MAP.get(key, ()):
+                if field_name in self.fields:
+                    ordered_field_names.append(field_name)
+        self.order_fields(ordered_field_names)
+
+    def profile_key_is_active(self, key):
+        setting = self.profile_field_settings.get(key)
+        return bool(setting["active"]) if setting else False
+
+    @property
+    def profile_items(self):
+        items = []
+        for key in self.ordered_profile_keys:
+            if key in self.PROFILE_FORMSET_KEYS:
+                items.append({"kind": key, "key": key})
+                continue
+            field_names = [name for name in self.PROFILE_SETTING_FIELD_MAP.get(key, ()) if name in self.fields]
+            if not field_names:
+                continue
+            if key in self.PROFILE_COMPOSITE_KEYS:
+                items.append({"kind": key, "key": key})
+            else:
+                items.append({"kind": "field", "key": key, "field": self[field_names[0]]})
+        return items
 
     def _drop_fields(self, names):
         for name in names:

--- a/exhibition/forms.py
+++ b/exhibition/forms.py
@@ -179,6 +179,7 @@ class ExhibitorInfoForm(I18nModelForm):
         "allow_lead_access",
         "lead_scanning_scope_by_device",
     )
+
     def __init__(self, *args, **kwargs):
         self.partner_type = kwargs.pop("partner_type", None)
         event = kwargs.get("event")

--- a/exhibition/forms.py
+++ b/exhibition/forms.py
@@ -224,7 +224,7 @@ class ExhibitorInfoForm(I18nModelForm):
     def _apply_profile_field_settings(self):
         for key, field_names in self.PROFILE_SETTING_FIELD_MAP.items():
             if self.profile_key_is_active(key):
-                if key in self.PROFILE_COMPOSITE_KEYS:
+                if key in self.PROFILE_COMPOSITE_KEYS or key == "booth_name":
                     continue
                 for field_name in field_names:
                     if field_name in self.fields:
@@ -243,6 +243,10 @@ class ExhibitorInfoForm(I18nModelForm):
     def profile_key_is_active(self, key):
         setting = self.profile_field_settings.get(key)
         return bool(setting["active"]) if setting else False
+
+    def profile_key_is_required(self, key):
+        setting = self.profile_field_settings.get(key)
+        return bool(setting["active"] and setting["required"]) if setting else False
 
     @property
     def profile_items(self):
@@ -344,7 +348,14 @@ class ExhibitorInfoForm(I18nModelForm):
         if not is_sponsor:
             cleaned_data["sponsor_group"] = None
 
-        if not is_exhibitor:
+        if is_exhibitor:
+            if (
+                self.profile_key_is_required("booth_name")
+                and "booth_name" in self.fields
+                and not cleaned_data.get("booth_name")
+            ):
+                self.add_error("booth_name", _("This field is required."))
+        else:
             cleaned_data["booth_name"] = ""
             cleaned_data["booth_id"] = None
             cleaned_data["lead_scanning_enabled"] = False

--- a/exhibition/forms.py
+++ b/exhibition/forms.py
@@ -272,11 +272,13 @@ class ExhibitorInfoForm(I18nModelForm):
             cleaned_data["video_url"] = normalize_url_scheme(video_url)
 
         slides_url = cleaned_data.get("slides_url") or ""
-        submitted_slides = self.fields["slides"].widget.value_from_datadict(
-            self.data,
-            self.files,
-            self.add_prefix("slides"),
-        )
+        submitted_slides = None
+        if "slides" in self.fields:
+            submitted_slides = self.fields["slides"].widget.value_from_datadict(
+                self.data,
+                self.files,
+                self.add_prefix("slides"),
+            )
         has_new_slides_upload = isinstance(submitted_slides, UploadedFile)
         if slides_url and has_new_slides_upload:
             message = _("Either upload a PDF or enter an external PDF URL, not both.")
@@ -305,12 +307,16 @@ class ExhibitorInfoForm(I18nModelForm):
         for image_field, url_field in self.file_url_fields.items():
             if image_field == "slides":
                 continue
+            if image_field not in self.fields and url_field not in self.fields:
+                continue
             image_url = cleaned_data.get(url_field) or ""
-            submitted_image = self.fields[image_field].widget.value_from_datadict(
-                self.data,
-                self.files,
-                self.add_prefix(image_field),
-            )
+            submitted_image = None
+            if image_field in self.fields:
+                submitted_image = self.fields[image_field].widget.value_from_datadict(
+                    self.data,
+                    self.files,
+                    self.add_prefix(image_field),
+                )
             has_new_upload = isinstance(submitted_image, UploadedFile)
 
             if image_url and has_new_upload:

--- a/exhibition/static/exhibition/js/exhibitors-add.js
+++ b/exhibition/static/exhibition/js/exhibitors-add.js
@@ -9,7 +9,7 @@
         var previewObjectUrls = new WeakMap()
         var sponsorCheckbox = document.getElementById('id_is_sponsor')
         var sponsorGroupWrapper = document.getElementById('sponsor-group-wrapper')
-        var notExhibitorCheckbox = document.getElementById('id_not_an_exhibitor')
+        var exhibitorCheckbox = document.getElementById('id_is_exhibitor')
         var boothNameWrapper = document.getElementById('booth-name-wrapper')
         var boothIdWrapper = document.getElementById('booth-id-wrapper')
         var leadScanningSection = document.getElementById('lead-scanning-section')
@@ -172,10 +172,10 @@
         }
 
         function toggleExhibitorFields() {
-            if (!notExhibitorCheckbox) {
+            if (!exhibitorCheckbox) {
                 return
             }
-            var hideExhibitorFields = notExhibitorCheckbox.checked
+            var hideExhibitorFields = !exhibitorCheckbox.checked
             ;[boothNameWrapper, boothIdWrapper, leadScanningSection].forEach(function (element) {
                 if (element) {
                     element.classList.toggle('hidden', hideExhibitorFields)
@@ -190,8 +190,8 @@
             sponsorCheckbox.addEventListener('change', toggleSponsorGroup)
         }
 
-        if (notExhibitorCheckbox) {
-            notExhibitorCheckbox.addEventListener('change', toggleExhibitorFields)
+        if (exhibitorCheckbox) {
+            exhibitorCheckbox.addEventListener('change', toggleExhibitorFields)
         }
 
         document.querySelectorAll('[data-partner-image-source-pair]').forEach(initImageSourcePair)

--- a/exhibition/static/exhibition/js/exhibitors-add.js
+++ b/exhibition/static/exhibition/js/exhibitors-add.js
@@ -176,9 +176,11 @@
                 return
             }
             var hideExhibitorFields = notExhibitorCheckbox.checked
-            boothNameWrapper.classList.toggle('hidden', hideExhibitorFields)
-            boothIdWrapper.classList.toggle('hidden', hideExhibitorFields)
-            leadScanningSection.classList.toggle('hidden', hideExhibitorFields)
+            ;[boothNameWrapper, boothIdWrapper, leadScanningSection].forEach(function (element) {
+                if (element) {
+                    element.classList.toggle('hidden', hideExhibitorFields)
+                }
+            })
         }
 
         toggleSponsorGroup()

--- a/exhibition/templates/exhibitors/add.html
+++ b/exhibition/templates/exhibitors/add.html
@@ -40,164 +40,176 @@
     {% bootstrap_form_errors form %}
 
     <fieldset>
-        <legend>{% trans "General information" %}</legend>
-        {% bootstrap_field form.name layout="control" %}
-        {% bootstrap_field form.description layout="control" %}
-        {% bootstrap_field form.email layout="control" %}
-        {% bootstrap_field form.contact_url layout="control" %}
-        {% bootstrap_field form.video_url layout="control" %}
-        {% bootstrap_field form.slides layout="control" %}
-        {% bootstrap_field form.slides_url layout="control" %}
-        <div class="form-group">
-            <label class="col-md-3 control-label partner-link-group-label">{% trans "Social Media" %}</label>
-            <div class="col-md-9">
-                <div id="social-links-formset" class="partner-link-formset formset" data-formset-prefix="{{ social_media_formset.prefix }}" data-social-link-prefixes='{{ social_link_prefixes|escapejson_dumps }}'>
-                    {{ social_media_formset.management_form }}
-                    {{ social_media_formset.non_form_errors }}
-                    <div data-formset-body>
-                        {% for social_form in social_media_formset %}
-                            <div class="row partner-link-row" data-formset-form data-social-link-row>
-                                <div class="sr-only">{{ social_form.id }} {{ social_form.DELETE }}</div>
-                                <div class="col-md-3">
-                                    {{ social_form.network.errors }}
-                                    {{ social_form.network }}
-                                </div>
-                                <div class="col-md-8">
-                                    {{ social_form.path.errors }}
-                                    <div class="input-group">
-                                        <span class="input-group-addon partner-link-prefix" data-social-prefix>https://</span>
-                                        {{ social_form.path }}
+        <legend>{% trans "Profile" %}</legend>
+        {% for item in form.profile_items %}
+            {% if item.kind == 'social_links' %}
+                <div class="form-group">
+                    <label class="col-md-3 control-label partner-link-group-label">{% trans "Social Media" %}</label>
+                    <div class="col-md-9">
+                        <div id="social-links-formset" class="partner-link-formset formset" data-formset-prefix="{{ social_media_formset.prefix }}" data-social-link-prefixes='{{ social_link_prefixes|escapejson_dumps }}'>
+                            {{ social_media_formset.management_form }}
+                            {{ social_media_formset.non_form_errors }}
+                            <div data-formset-body>
+                                {% for social_form in social_media_formset %}
+                                    <div class="row partner-link-row" data-formset-form data-social-link-row>
+                                        <div class="sr-only">{{ social_form.id }} {{ social_form.DELETE }}</div>
+                                        <div class="col-md-3">
+                                            {{ social_form.network.errors }}
+                                            {{ social_form.network }}
+                                        </div>
+                                        <div class="col-md-8">
+                                            {{ social_form.path.errors }}
+                                            <div class="input-group">
+                                                <span class="input-group-addon partner-link-prefix" data-social-prefix>https://</span>
+                                                {{ social_form.path }}
+                                            </div>
+                                        </div>
+                                        <div class="col-md-1 text-right">
+                                            <button type="button" class="btn btn-delete btn-danger btn-sm partner-link-remove" data-formset-delete-button>
+                                                <i class="fa fa-minus"></i>
+                                            </button>
+                                        </div>
+                                    </div>
+                                {% endfor %}
+                            </div>
+                            <template data-formset-empty-form>
+                                <div class="row partner-link-row" data-formset-form data-social-link-row>
+                                    <div class="sr-only">{{ social_media_formset.empty_form.id }} {{ social_media_formset.empty_form.DELETE }}</div>
+                                    <div class="col-md-3">
+                                        {{ social_media_formset.empty_form.network.errors }}
+                                        {{ social_media_formset.empty_form.network }}
+                                    </div>
+                                    <div class="col-md-8">
+                                        {{ social_media_formset.empty_form.path.errors }}
+                                        <div class="input-group">
+                                            <span class="input-group-addon partner-link-prefix" data-social-prefix>https://</span>
+                                            {{ social_media_formset.empty_form.path }}
+                                        </div>
+                                    </div>
+                                    <div class="col-md-1 text-right">
+                                        <button type="button" class="btn btn-delete btn-danger btn-sm partner-link-remove" data-formset-delete-button>
+                                            <i class="fa fa-minus"></i>
+                                        </button>
                                     </div>
                                 </div>
-                                <div class="col-md-1 text-right">
-                                    <button type="button" class="btn btn-delete btn-danger btn-sm partner-link-remove" data-formset-delete-button>
-                                        <i class="fa fa-minus"></i>
-                                    </button>
-                                </div>
-                            </div>
-                        {% endfor %}
-                    </div>
-                    <template data-formset-empty-form>
-                        <div class="row partner-link-row" data-formset-form data-social-link-row>
-                            <div class="sr-only">{{ social_media_formset.empty_form.id }} {{ social_media_formset.empty_form.DELETE }}</div>
-                            <div class="col-md-3">
-                                {{ social_media_formset.empty_form.network.errors }}
-                                {{ social_media_formset.empty_form.network }}
-                            </div>
-                            <div class="col-md-8">
-                                {{ social_media_formset.empty_form.path.errors }}
-                                <div class="input-group">
-                                    <span class="input-group-addon partner-link-prefix" data-social-prefix>https://</span>
-                                    {{ social_media_formset.empty_form.path }}
-                                </div>
-                            </div>
-                            <div class="col-md-1 text-right">
-                                <button type="button" class="btn btn-delete btn-danger btn-sm partner-link-remove" data-formset-delete-button>
-                                    <i class="fa fa-minus"></i>
+                            </template>
+                            <div class="partner-link-actions">
+                                <button type="button" class="btn btn-default btn-sm partner-link-add" data-formset-add>
+                                    <i class="fa fa-plus"></i> {% trans "Add social media link" %}
                                 </button>
                             </div>
                         </div>
-                    </template>
-                    <div class="partner-link-actions">
-                        <button type="button" class="btn btn-default btn-sm partner-link-add" data-formset-add>
-                            <i class="fa fa-plus"></i> {% trans "Add social media link" %}
-                        </button>
                     </div>
                 </div>
-            </div>
-        </div>
+            {% elif item.kind == 'extra_links' %}
+                <div class="form-group">
+                    <label class="col-md-3 control-label partner-link-group-label">{% trans "Extra Links" %}</label>
+                    <div class="col-md-9">
+                        <div id="extra-links-formset" class="partner-link-formset formset" data-formset-prefix="{{ extra_links_formset.prefix }}">
+                            {{ extra_links_formset.management_form }}
+                            {{ extra_links_formset.non_form_errors }}
+                            <div data-formset-body>
+                                {% for extra_form in extra_links_formset %}
+                                    <div class="row partner-link-row" data-formset-form>
+                                        <div class="sr-only">{{ extra_form.id }} {{ extra_form.DELETE }}</div>
+                                        <div class="col-md-4">
+                                            {{ extra_form.label.errors }}
+                                            {{ extra_form.label }}
+                                        </div>
+                                        <div class="col-md-7">
+                                            {{ extra_form.url.errors }}
+                                            {{ extra_form.url }}
+                                        </div>
+                                        <div class="col-md-1 text-right">
+                                            <button type="button" class="btn btn-delete btn-danger btn-sm partner-link-remove" data-formset-delete-button>
+                                                <i class="fa fa-minus"></i>
+                                            </button>
+                                        </div>
+                                    </div>
+                                {% endfor %}
+                            </div>
+                            <template data-formset-empty-form>
+                                <div class="row partner-link-row" data-formset-form>
+                                    <div class="sr-only">{{ extra_links_formset.empty_form.id }} {{ extra_links_formset.empty_form.DELETE }}</div>
+                                    <div class="col-md-4">
+                                        {{ extra_links_formset.empty_form.label.errors }}
+                                        {{ extra_links_formset.empty_form.label }}
+                                    </div>
+                                    <div class="col-md-7">
+                                        {{ extra_links_formset.empty_form.url.errors }}
+                                        {{ extra_links_formset.empty_form.url }}
+                                    </div>
+                                    <div class="col-md-1 text-right">
+                                        <button type="button" class="btn btn-delete btn-danger btn-sm partner-link-remove" data-formset-delete-button>
+                                            <i class="fa fa-minus"></i>
+                                        </button>
+                                    </div>
+                                </div>
+                            </template>
+                            <div class="partner-link-actions">
+                                <button type="button" class="btn btn-default btn-sm partner-link-add" data-formset-add>
+                                    <i class="fa fa-plus"></i> {% trans "Add extra link" %}
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            {% elif item.kind == 'slides' %}
+                {% bootstrap_field form.slides layout="control" %}
+                {% bootstrap_field form.slides_url layout="control" %}
+            {% elif item.kind == 'logo' %}
+                <div
+                    data-partner-image-source-pair
+                    data-file-input-id="{{ form.logo.id_for_label }}"
+                    data-url-input-id="{{ form.logo_url.id_for_label }}"
+                    data-current-preview-url="{{ form.instance.visible_logo_url }}"
+                    data-has-current-file="{{ form.instance.logo|yesno:'true,false' }}"
+                >
+                    {% bootstrap_field form.logo layout="control" %}
+                    {% bootstrap_field form.logo_url layout="control" %}
+                    <div class="form-group" data-image-preview hidden>
+                        <label class="col-md-3 control-label">{% trans "Logo preview" %}</label>
+                        <div class="col-md-9">
+                            <a data-image-preview-link href="" target="_blank" rel="noopener noreferrer" hidden>
+                                <img loading="lazy" data-image-preview-image class="img-responsive img-thumbnail partner-image-preview partner-image-preview-logo" alt="{% trans 'Logo preview' %}" hidden>
+                            </a>
+                            <p class="help-block text-danger" data-image-preview-error hidden>{% trans "We could not load this image preview." %}</p>
+                        </div>
+                    </div>
+                </div>
+            {% elif item.kind == 'header_image' %}
+                <div
+                    data-partner-image-source-pair
+                    data-file-input-id="{{ form.header_image.id_for_label }}"
+                    data-url-input-id="{{ form.header_image_url.id_for_label }}"
+                    data-current-preview-url="{{ form.instance.visible_header_image_url }}"
+                    data-has-current-file="{{ form.instance.header_image|yesno:'true,false' }}"
+                >
+                    {% bootstrap_field form.header_image layout="control" %}
+                    {% bootstrap_field form.header_image_url layout="control" %}
+                    <div class="form-group" data-image-preview hidden>
+                        <label class="col-md-3 control-label">{% trans "Header image preview" %}</label>
+                        <div class="col-md-9">
+                            <a data-image-preview-link href="" target="_blank" rel="noopener noreferrer" hidden>
+                                <img loading="lazy" data-image-preview-image class="img-responsive img-thumbnail partner-image-preview partner-image-preview-header" alt="{% trans 'Header image preview' %}" hidden>
+                            </a>
+                            <p class="help-block text-danger" data-image-preview-error hidden>{% trans "We could not load this image preview." %}</p>
+                        </div>
+                    </div>
+                </div>
+            {% elif item.key == 'booth_name' %}
+                <div id="booth-name-wrapper">
+                    {% bootstrap_field item.field layout="control" %}
+                </div>
+            {% else %}
+                {% bootstrap_field item.field layout="control" %}
+            {% endif %}
+        {% endfor %}
+    </fieldset>
 
-        <div class="form-group">
-            <label class="col-md-3 control-label partner-link-group-label">{% trans "Extra Links" %}</label>
-            <div class="col-md-9">
-                <div id="extra-links-formset" class="partner-link-formset formset" data-formset-prefix="{{ extra_links_formset.prefix }}">
-                    {{ extra_links_formset.management_form }}
-                    {{ extra_links_formset.non_form_errors }}
-                    <div data-formset-body>
-                        {% for extra_form in extra_links_formset %}
-                            <div class="row partner-link-row" data-formset-form>
-                                <div class="sr-only">{{ extra_form.id }} {{ extra_form.DELETE }}</div>
-                                <div class="col-md-4">
-                                    {{ extra_form.label.errors }}
-                                    {{ extra_form.label }}
-                                </div>
-                                <div class="col-md-7">
-                                    {{ extra_form.url.errors }}
-                                    {{ extra_form.url }}
-                                </div>
-                                <div class="col-md-1 text-right">
-                                    <button type="button" class="btn btn-delete btn-danger btn-sm partner-link-remove" data-formset-delete-button>
-                                        <i class="fa fa-minus"></i>
-                                    </button>
-                                </div>
-                            </div>
-                        {% endfor %}
-                    </div>
-                    <template data-formset-empty-form>
-                        <div class="row partner-link-row" data-formset-form>
-                            <div class="sr-only">{{ extra_links_formset.empty_form.id }} {{ extra_links_formset.empty_form.DELETE }}</div>
-                            <div class="col-md-4">
-                                {{ extra_links_formset.empty_form.label.errors }}
-                                {{ extra_links_formset.empty_form.label }}
-                            </div>
-                            <div class="col-md-7">
-                                {{ extra_links_formset.empty_form.url.errors }}
-                                {{ extra_links_formset.empty_form.url }}
-                            </div>
-                            <div class="col-md-1 text-right">
-                                <button type="button" class="btn btn-delete btn-danger btn-sm partner-link-remove" data-formset-delete-button>
-                                    <i class="fa fa-minus"></i>
-                                </button>
-                            </div>
-                        </div>
-                    </template>
-                    <div class="partner-link-actions">
-                        <button type="button" class="btn btn-default btn-sm partner-link-add" data-formset-add>
-                            <i class="fa fa-plus"></i> {% trans "Add extra link" %}
-                        </button>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <div
-            data-partner-image-source-pair
-            data-file-input-id="{{ form.logo.id_for_label }}"
-            data-url-input-id="{{ form.logo_url.id_for_label }}"
-            data-current-preview-url="{{ form.instance.visible_logo_url }}"
-            data-has-current-file="{{ form.instance.logo|yesno:'true,false' }}"
-        >
-            {% bootstrap_field form.logo layout="control" %}
-            {% bootstrap_field form.logo_url layout="control" %}
-            <div class="form-group" data-image-preview hidden>
-                <label class="col-md-3 control-label">{% trans "Logo preview" %}</label>
-                <div class="col-md-9">
-                    <a data-image-preview-link href="" target="_blank" rel="noopener noreferrer" hidden>
-                        <img loading="lazy" data-image-preview-image class="img-responsive img-thumbnail partner-image-preview partner-image-preview-logo" alt="{% trans 'Logo preview' %}" hidden>
-                    </a>
-                    <p class="help-block text-danger" data-image-preview-error hidden>{% trans "We could not load this image preview." %}</p>
-                </div>
-            </div>
-        </div>
-        <div
-            data-partner-image-source-pair
-            data-file-input-id="{{ form.header_image.id_for_label }}"
-            data-url-input-id="{{ form.header_image_url.id_for_label }}"
-            data-current-preview-url="{{ form.instance.visible_header_image_url }}"
-            data-has-current-file="{{ form.instance.header_image|yesno:'true,false' }}"
-        >
-            {% bootstrap_field form.header_image layout="control" %}
-            {% bootstrap_field form.header_image_url layout="control" %}
-            <div class="form-group" data-image-preview hidden>
-                <label class="col-md-3 control-label">{% trans "Header image preview" %}</label>
-                <div class="col-md-9">
-                    <a data-image-preview-link href="" target="_blank" rel="noopener noreferrer" hidden>
-                        <img loading="lazy" data-image-preview-image class="img-responsive img-thumbnail partner-image-preview partner-image-preview-header" alt="{% trans 'Header image preview' %}" hidden>
-                    </a>
-                    <p class="help-block text-danger" data-image-preview-error hidden>{% trans "We could not load this image preview." %}</p>
-                </div>
-            </div>
-        </div>
-        {% bootstrap_field form.url layout="control" %}
+    {% if form.is_sponsor or form.sponsor_group or form.not_an_exhibitor or form.booth_id %}
+    <fieldset>
+        <legend>{% trans "Organizer only" %}</legend>
         {% if form.is_sponsor %}
         <div id="is-sponsor-wrapper">
             {% bootstrap_field form.is_sponsor layout="control" %}
@@ -213,17 +225,13 @@
             {% bootstrap_field form.not_an_exhibitor layout="control" %}
         </div>
         {% endif %}
-        {% if form.booth_name %}
-        <div id="booth-name-wrapper">
-            {% bootstrap_field form.booth_name layout="control" %}
-        </div>
-        {% endif %}
         {% if form.booth_id %}
         <div id="booth-id-wrapper">
             {% bootstrap_field form.booth_id layout="control" %}
         </div>
         {% endif %}
     </fieldset>
+    {% endif %}
 
     {% if form.lead_scanning_enabled %}
     <fieldset id="lead-scanning-section">

--- a/exhibition/templates/exhibitors/add.html
+++ b/exhibition/templates/exhibitors/add.html
@@ -3,17 +3,7 @@
 {% load bootstrap3 %}
 {% load static %}
 {% load escapejson %}
-{% block title %}
-    {% if action == 'edit' %}
-        {% trans "Edit Exhibitor or Sponsor" %}
-    {% elif partner_type == 'sponsor' %}
-        {% trans "Add a Sponsor" %}
-    {% elif partner_type == 'exhibitor' %}
-        {% trans "Add an Exhibitor" %}
-    {% else %}
-        {% trans "Add an Exhibitor or Sponsor" %}
-    {% endif %}
-{% endblock %}
+{% block title %}{{ page_title }}{% endblock %}
 
 {% block custom_header %}
     {{ block.super }}
@@ -21,17 +11,7 @@
 {% endblock %}
 
 {% block exhibitors_header %}
-<h1>
-    {% if action == 'edit' %}
-        {% trans "Edit Exhibitor or Sponsor" %}
-    {% elif partner_type == 'sponsor' %}
-        {% trans "Add a Sponsor" %}
-    {% elif partner_type == 'exhibitor' %}
-        {% trans "Add an Exhibitor" %}
-    {% else %}
-        {% trans "Add an Exhibitor or Sponsor" %}
-    {% endif %}
-</h1>
+<h1>{{ page_title }}</h1>
 {% endblock %}
 
 {% block exhibitors_content %}

--- a/exhibition/templates/exhibitors/add.html
+++ b/exhibition/templates/exhibitors/add.html
@@ -187,9 +187,14 @@
         {% endfor %}
     </fieldset>
 
-    {% if form.is_sponsor or form.sponsor_group or form.not_an_exhibitor or form.booth_id %}
+    {% if form.is_exhibitor or form.is_sponsor or form.sponsor_group or form.booth_id %}
     <fieldset>
         <legend>{% trans "Organizer only" %}</legend>
+        {% if form.is_exhibitor %}
+        <div id="is-exhibitor-wrapper">
+            {% bootstrap_field form.is_exhibitor layout="control" %}
+        </div>
+        {% endif %}
         {% if form.is_sponsor %}
         <div id="is-sponsor-wrapper">
             {% bootstrap_field form.is_sponsor layout="control" %}
@@ -198,11 +203,6 @@
         {% if form.sponsor_group %}
         <div id="sponsor-group-wrapper">
             {% bootstrap_field form.sponsor_group layout="control" %}
-        </div>
-        {% endif %}
-        {% if form.not_an_exhibitor %}
-        <div id="not-an-exhibitor-wrapper">
-            {% bootstrap_field form.not_an_exhibitor layout="control" %}
         </div>
         {% endif %}
         {% if form.booth_id %}

--- a/exhibition/templates/exhibitors/delete.html
+++ b/exhibition/templates/exhibitors/delete.html
@@ -1,12 +1,16 @@
 {% extends "exhibitors/base.html" %}
 {% load i18n %} 
+{% block title %}{{ page_title }}{% endblock %}
+
 {% block exhibitors_header %}
-<h1>{% trans "Delete Exhibitor or Sponsor" %}</h1>
+<h1>{{ page_title }}</h1>
 {% endblock %}
 
 {% block exhibitors_content %}
 <p>
-  {% trans "Are you sure you want to delete this exhibitor or sponsor? This action cannot be undone." %}
+  {% blocktrans trimmed with name=object.name %}
+    Are you sure you want to delete “{{ name }}”? This action cannot be undone.
+  {% endblocktrans %}
 </p>
 
 <form action="" method="post">

--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -722,6 +722,13 @@ class ExhibitorLinkFormsetMixin:
     social_formset_prefix = "social_links"
     extra_formset_prefix = "extra_links"
 
+    def get_proposal_field_settings(self):
+        settings = ExhibitorSettings.objects.get_or_create(event=self.request.event)[0]
+        return settings.normalized_proposal_field_settings
+
+    def proposal_field_is_active(self, key):
+        return self.get_proposal_field_settings()[key]["active"]
+
     def get_formset_instance(self):
         obj = getattr(self, "object", None)
         return obj if obj is not None else ExhibitorInfo(event=self.request.event)
@@ -742,22 +749,30 @@ class ExhibitorLinkFormsetMixin:
 
     def post_with_formsets(self):
         form = self.get_form()
-        self.social_media_formset = self.get_social_formset()
-        self.extra_links_formset = self.get_extra_link_formset()
+        self.social_media_formset = self.get_social_formset() if self.proposal_field_is_active("social_links") else None
+        self.extra_links_formset = (
+            self.get_extra_link_formset() if self.proposal_field_is_active("extra_links") else None
+        )
 
-        if form.is_valid() and self.social_media_formset.is_valid() and self.extra_links_formset.is_valid():
+        if (
+            form.is_valid()
+            and (self.social_media_formset is None or self.social_media_formset.is_valid())
+            and (self.extra_links_formset is None or self.extra_links_formset.is_valid())
+        ):
             return self.form_valid(form)
         return self.form_invalid(form)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        show_social_links = self.proposal_field_is_active("social_links")
+        show_extra_links = self.proposal_field_is_active("extra_links")
         context["social_media_formset"] = kwargs.get(
             "social_media_formset",
-            getattr(self, "social_media_formset", self.get_social_formset()),
+            getattr(self, "social_media_formset", self.get_social_formset() if show_social_links else None),
         )
         context["extra_links_formset"] = kwargs.get(
             "extra_links_formset",
-            getattr(self, "extra_links_formset", self.get_extra_link_formset()),
+            getattr(self, "extra_links_formset", self.get_extra_link_formset() if show_extra_links else None),
         )
         context["social_link_prefixes"] = social_link_prefixes()
         return context
@@ -766,10 +781,11 @@ class ExhibitorLinkFormsetMixin:
         return self.render_to_response(self.get_context_data(form=form))
 
     def save_link_formsets(self):
-        self.social_media_formset.instance = self.object
-        self.extra_links_formset.instance = self.object
-        self.social_media_formset.save()
-        self.extra_links_formset.save()
+        for formset in (self.social_media_formset, self.extra_links_formset):
+            if formset is None:
+                continue
+            formset.instance = self.object
+            formset.save()
 
 
 class SponsorGroupFrontPageToggleView(EventPermissionRequiredMixin, View):

--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -99,6 +99,16 @@ def queue_exhibitor_access_mail(event, exhibitor, requestor):
     return mail_helpers.queue_exhibitor_access_email(event, exhibitor, requestor=requestor)
 
 
+def partner_type_of(exhibitor):
+    if exhibitor.is_sponsor and exhibitor.is_exhibitor:
+        return "both"
+    if exhibitor.is_sponsor:
+        return "sponsor"
+    if exhibitor.is_exhibitor:
+        return "exhibitor"
+    return None
+
+
 class PublicEventLoginRequiredMixin(LoginRequiredMixin):
     def get_login_url(self):
         return reverse("cfp:event.login", kwargs=event_kwargs(self.request.event))
@@ -1401,6 +1411,10 @@ class ExhibitorCreateView(ExhibitorLinkFormsetMixin, EventPermissionRequiredMixi
         context = super().get_context_data(**kwargs)
         context["action"] = "create"
         context["partner_type"] = self.partner_type
+        context["page_title"] = {
+            "sponsor": _("Add a Sponsor"),
+            "exhibitor": _("Add an Exhibitor"),
+        }.get(self.partner_type, _("Add an Exhibitor or Sponsor"))
         return context
 
     def get_success_url(self):
@@ -1453,6 +1467,11 @@ class ExhibitorEditView(ExhibitorLinkFormsetMixin, EventPermissionRequiredMixin,
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["action"] = "edit"
+        context["page_title"] = {
+            "sponsor": _("Edit Sponsor"),
+            "exhibitor": _("Edit Exhibitor"),
+            "both": _("Edit Exhibitor & Sponsor"),
+        }.get(partner_type_of(self.object), _("Edit Exhibitor or Sponsor"))
         return context
 
     def get_success_url(self):
@@ -1470,6 +1489,15 @@ class ExhibitorDeleteView(EventPermissionRequiredMixin, DeleteView):
 
     def get_queryset(self):
         return ExhibitorInfo.objects.filter(event=self.request.event)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["page_title"] = {
+            "sponsor": _("Delete Sponsor"),
+            "exhibitor": _("Delete Exhibitor"),
+            "both": _("Delete Exhibitor & Sponsor"),
+        }.get(partner_type_of(self.object), _("Delete Exhibitor or Sponsor"))
+        return context
 
     def get_success_url(self) -> str:
         return reverse(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -304,7 +304,8 @@ def test_proposal_form_reflects_saved_field_order(event):
 def test_sponsor_form_hides_exhibitor_fields(event):
     form = ExhibitorInfoForm(event=event, partner_type="sponsor")
     assert "sponsor_group" in form.fields
-    for name in ("booth_id", "booth_name", "lead_scanning_enabled", "is_sponsor", "not_an_exhibitor"):
+    assert "is_exhibitor" in form.fields
+    for name in ("booth_id", "booth_name", "lead_scanning_enabled", "is_sponsor"):
         assert name not in form.fields
 
 
@@ -312,7 +313,8 @@ def test_sponsor_form_hides_exhibitor_fields(event):
 def test_exhibitor_form_hides_sponsor_fields(event):
     form = ExhibitorInfoForm(event=event, partner_type="exhibitor")
     assert "booth_id" in form.fields
-    for name in ("sponsor_group", "is_sponsor", "not_an_exhibitor"):
+    assert "is_sponsor" in form.fields
+    for name in ("sponsor_group", "is_exhibitor"):
         assert name not in form.fields
 
 


### PR DESCRIPTION
fixes #79 

Matches the back office form for both exhibitors and sponsors to reflect the questions ordering and active/in-active states. 
Also includes some fixes applied to the edit form and delete form.
NOTE: custom questions appears on public form only, like before (needs discussion)

https://github.com/user-attachments/assets/efec5fea-5859-4c8a-b93d-7c4e025cff59

