### PR TITLE
Add Actions  accept/reject/withdraw to proposals list

### DIFF
--- a/exhibition/models.py
+++ b/exhibition/models.py
@@ -468,6 +468,23 @@ class ExhibitionProposal(models.Model):
             ExhibitionProposalState.SUBMITTED,
         }
 
+    def approve(self, requestor=None):
+        """Accept the request, create its partner profile and queue the acceptance email."""
+        from .mail import PROPOSAL_ACCEPTED, queue_proposal_email
+        from .utils import create_exhibitor_from_proposal
+
+        exhibitor = create_exhibitor_from_proposal(self)
+        queue_proposal_email(self.event, self, PROPOSAL_ACCEPTED, requestor=requestor)
+        return exhibitor
+
+    def reject(self, requestor=None):
+        """Reject the request and queue the rejection email."""
+        from .mail import PROPOSAL_REJECTED, queue_proposal_email
+
+        self.state = ExhibitionProposalState.REJECTED
+        self.save(update_fields=["state", "updated"])
+        queue_proposal_email(self.event, self, PROPOSAL_REJECTED, requestor=requestor)
+
     @property
     def localized_booth_name(self):
         booth_name = self.booth_name

--- a/exhibition/static/exhibition/css/proposal-actions.css
+++ b/exhibition/static/exhibition/css/proposal-actions.css
@@ -1,0 +1,59 @@
+.proposal-bulk-bar {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-bottom: 12px;
+}
+
+.proposal-bulk-buttons {
+    display: inline-flex;
+    gap: 6px;
+    margin-left: auto;
+}
+
+.proposal-bulk-count {
+    min-width: 70px;
+}
+
+.proposal-select-col {
+    width: 32px;
+}
+
+.proposal-select-col .batch-select-label {
+    margin-bottom: 0;
+}
+
+.proposal-row-actions .btn + .btn {
+    margin-left: 4px;
+}
+
+.proposal-action-btn {
+    background: #fff;
+    border: 1px solid transparent;
+}
+
+.proposal-action-approve {
+    color: #21ba45;
+    border-color: #21ba45;
+}
+
+.proposal-action-reject {
+    color: #db2828;
+    border-color: #db2828;
+}
+
+.proposal-action-withdraw {
+    color: #767676;
+    border-color: #767676;
+}
+
+.proposal-action-withdraw:hover,
+.proposal-action-withdraw:focus {
+    background: #767676;
+    color: #fff;
+}
+
+.proposal-action-feedback:not(:empty) {
+    margin-bottom: 12px;
+}

--- a/exhibition/static/exhibition/js/proposal-actions.js
+++ b/exhibition/static/exhibition/js/proposal-actions.js
@@ -163,6 +163,27 @@
             return null
         }
 
+        function confirmClassFor(action) {
+            return action === 'approve' ? 'btn-success' : 'btn-danger'
+        }
+
+        function requestConfirmation(action, message) {
+            if (!message) {
+                return Promise.resolve(true)
+            }
+            var options = {
+                message: message,
+                title: i18n.confirmTitle,
+                confirmLabel: i18n.confirmLabel,
+                cancelLabel: i18n.cancelLabel,
+                confirmClass: confirmClassFor(action),
+            }
+            if (typeof window.showConfirmDialog === 'function') {
+                return window.showConfirmDialog(options)
+            }
+            return Promise.resolve(window.confirm(message))
+        }
+
         container.addEventListener('click', function (event) {
             var button = event.target.closest('[data-proposal-action]')
             if (!button) {
@@ -170,11 +191,11 @@
             }
             var action = button.dataset.proposalAction
             var code = button.dataset.proposalCode
-            var message = confirmFor(action, false)
-            if (message && !window.confirm(message)) {
-                return
-            }
-            submitAction(action, [code])
+            requestConfirmation(action, confirmFor(action, false)).then(function (confirmed) {
+                if (confirmed) {
+                    submitAction(action, [code])
+                }
+            })
         })
 
         bulkButtons.forEach(function (button) {
@@ -184,11 +205,11 @@
                 if (!codes.length) {
                     return
                 }
-                var message = confirmFor(action, true)
-                if (message && !window.confirm(message)) {
-                    return
-                }
-                submitAction(action, codes)
+                requestConfirmation(action, confirmFor(action, true)).then(function (confirmed) {
+                    if (confirmed) {
+                        submitAction(action, codes)
+                    }
+                })
             })
         })
 

--- a/exhibition/static/exhibition/js/proposal-actions.js
+++ b/exhibition/static/exhibition/js/proposal-actions.js
@@ -1,0 +1,212 @@
+(function () {
+    function getCookie(name) {
+        var cookieValue = null
+        if (document.cookie && document.cookie !== '') {
+            var cookies = document.cookie.split(';')
+            for (var index = 0; index < cookies.length; index++) {
+                var cookie = cookies[index].trim()
+                if (cookie.substring(0, name.length + 1) === name + '=') {
+                    cookieValue = decodeURIComponent(cookie.substring(name.length + 1))
+                    break
+                }
+            }
+        }
+        return cookieValue
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        var container = document.querySelector('[data-proposal-list]')
+        if (!container) {
+            return
+        }
+
+        var actionUrl = container.dataset.proposalActionsUrl
+        var csrfToken = getCookie('eventyay_csrftoken') || getCookie('csrftoken')
+        var feedback = document.querySelector('[data-proposal-feedback]')
+        var i18nEl = document.querySelector('[data-proposal-i18n]')
+        var i18n = i18nEl ? i18nEl.dataset : {}
+
+        var selectAll = container.querySelector('[data-proposal-select-all]')
+        var bulkButtons = container.querySelectorAll('[data-proposal-bulk]')
+        var countLabel = container.querySelector('[data-proposal-selected-count]')
+
+        function checkboxes() {
+            return Array.prototype.slice.call(container.querySelectorAll('[data-proposal-checkbox]'))
+        }
+
+        function selectedCodes() {
+            return checkboxes()
+                .filter(function (box) {
+                    return box.checked
+                })
+                .map(function (box) {
+                    return box.value
+                })
+        }
+
+        function refreshSelection() {
+            var boxes = checkboxes()
+            var selected = boxes.filter(function (box) {
+                return box.checked
+            })
+            var count = selected.length
+            bulkButtons.forEach(function (button) {
+                button.disabled = count === 0
+            })
+            if (countLabel) {
+                countLabel.textContent = count ? count + ' ' + (i18n.selected || '') : ''
+            }
+            if (selectAll) {
+                selectAll.checked = boxes.length > 0 && count === boxes.length
+                selectAll.indeterminate = count > 0 && count < boxes.length
+            }
+        }
+
+        function showFeedback(ok, message) {
+            if (!feedback) {
+                return
+            }
+            feedback.innerHTML = ''
+            var alert = document.createElement('div')
+            alert.className = 'alert ' + (ok ? 'alert-success' : 'alert-danger')
+            alert.textContent = message
+            feedback.appendChild(alert)
+        }
+
+        function updateRow(result) {
+            var row = container.querySelector('[data-proposal-row="' + result.code + '"]')
+            if (!row) {
+                return
+            }
+            var stateCell = row.querySelector('[data-proposal-state]')
+            if (stateCell) {
+                stateCell.textContent = result.state_display
+            }
+            var actionsCell = row.querySelector('[data-proposal-actions-cell]')
+            if (actionsCell) {
+                actionsCell.querySelectorAll('[data-proposal-action]').forEach(function (button) {
+                    button.remove()
+                })
+            }
+            var checkbox = row.querySelector('[data-proposal-checkbox]')
+            if (checkbox) {
+                checkbox.remove()
+            }
+        }
+
+        function setBusy(busy) {
+            bulkButtons.forEach(function (button) {
+                button.disabled = busy || selectedCodes().length === 0
+            })
+            container.querySelectorAll('[data-proposal-action]').forEach(function (button) {
+                button.disabled = busy
+            })
+        }
+
+        function submitAction(action, codes) {
+            if (!codes.length) {
+                return
+            }
+            setBusy(true)
+            var body = new URLSearchParams()
+            body.append('action', action)
+            codes.forEach(function (code) {
+                body.append('proposal', code)
+            })
+            fetch(actionUrl, {
+                method: 'POST',
+                headers: {
+                    'X-CSRFToken': csrfToken,
+                    'X-Requested-With': 'XMLHttpRequest',
+                },
+                credentials: 'include',
+                body: body,
+            })
+                .then(function (response) {
+                    return response.json().then(function (data) {
+                        return { ok: response.ok, data: data }
+                    })
+                })
+                .then(function (payload) {
+                    if (payload.ok && payload.data.ok) {
+                        payload.data.results.forEach(updateRow)
+                        showFeedback(true, payload.data.message)
+                    } else {
+                        showFeedback(false, payload.data.message || i18n.error)
+                    }
+                })
+                .catch(function () {
+                    showFeedback(false, i18n.error)
+                })
+                .finally(function () {
+                    setBusy(false)
+                    refreshSelection()
+                })
+        }
+
+        function confirmFor(action, isBulk) {
+            if (isBulk) {
+                if (action === 'approve') {
+                    return i18n.confirmApprove
+                }
+                if (action === 'reject') {
+                    return i18n.confirmReject
+                }
+                return null
+            }
+            if (action === 'reject') {
+                return i18n.confirmRejectOne
+            }
+            if (action === 'withdraw') {
+                return i18n.confirmWithdrawOne
+            }
+            return null
+        }
+
+        container.addEventListener('click', function (event) {
+            var button = event.target.closest('[data-proposal-action]')
+            if (!button) {
+                return
+            }
+            var action = button.dataset.proposalAction
+            var code = button.dataset.proposalCode
+            var message = confirmFor(action, false)
+            if (message && !window.confirm(message)) {
+                return
+            }
+            submitAction(action, [code])
+        })
+
+        bulkButtons.forEach(function (button) {
+            button.addEventListener('click', function () {
+                var action = button.dataset.proposalBulk
+                var codes = selectedCodes()
+                if (!codes.length) {
+                    return
+                }
+                var message = confirmFor(action, true)
+                if (message && !window.confirm(message)) {
+                    return
+                }
+                submitAction(action, codes)
+            })
+        })
+
+        if (selectAll) {
+            selectAll.addEventListener('change', function () {
+                checkboxes().forEach(function (box) {
+                    box.checked = selectAll.checked
+                })
+                refreshSelection()
+            })
+        }
+
+        container.addEventListener('change', function (event) {
+            if (event.target.matches('[data-proposal-checkbox]')) {
+                refreshSelection()
+            }
+        })
+
+        refreshSelection()
+    })
+})()

--- a/exhibition/templates/exhibitors/proposal_detail.html
+++ b/exhibition/templates/exhibitors/proposal_detail.html
@@ -119,7 +119,7 @@
         {% bootstrap_form_errors form %}
         <fieldset>
             <legend>{% trans "Review" %}</legend>
-            {% if can_manage %}
+            {% if can_review %}
                 {% bootstrap_field form.is_exhibitor layout="control" %}
                 {% bootstrap_field form.is_sponsor layout="control" %}
                 {% bootstrap_field form.sponsor_group layout="control" %}
@@ -132,7 +132,7 @@
             <button type="submit" class="btn btn-default" name="action" value="save">
                 {% trans "Save review notes" %}
             </button>
-            {% if can_manage and not proposal.approved_exhibitor_id and proposal.state != "rejected" %}
+            {% if can_review %}
                 <button type="submit" class="btn btn-primary" name="action" value="approve">
                     {% trans "Approve and create partner" %}
                 </button>

--- a/exhibition/templates/exhibitors/proposal_list.html
+++ b/exhibition/templates/exhibitors/proposal_list.html
@@ -116,7 +116,10 @@
                  data-confirm-reject-one="{% trans 'Reject this proposal?' %}"
                  data-confirm-withdraw-one="{% trans 'Withdraw this proposal?' %}"
                  data-error="{% trans 'The action could not be completed. Please try again.' %}"
-                 data-selected="{% trans 'selected' %}"></div>
+                 data-selected="{% trans 'selected' %}"
+                 data-confirm-title="{% trans 'Please confirm' %}"
+                 data-confirm-label="{% trans 'Confirm' %}"
+                 data-cancel-label="{% trans 'Cancel' %}"></div>
             <script defer src="{% static 'exhibition/js/proposal-actions.js' %}"></script>
         {% endif %}
     {% else %}

--- a/exhibition/templates/exhibitors/proposal_list.html
+++ b/exhibition/templates/exhibitors/proposal_list.html
@@ -1,7 +1,13 @@
 {% extends "exhibitors/base.html" %}
 {% load i18n %}
+{% load static %}
 
 {% block title %}{{ request.event.name }} - {% trans "Exhibition requests" %}{% endblock %}
+
+{% block custom_header %}
+    {{ block.super }}
+    <link rel="stylesheet" href="{% static 'exhibition/css/proposal-actions.css' %}">
+{% endblock %}
 
 {% block exhibitors_header %}
     <h1>{% trans "Exhibition requests" %}</h1>
@@ -9,21 +15,52 @@
 
 {% block exhibitors_content %}
     {% if proposals %}
-        <div class="table-responsive">
+        <div class="proposal-action-feedback" data-proposal-feedback></div>
+        <div class="table-responsive"
+             data-proposal-actions-url="{% url 'plugins:exhibition:proposal.actions' organizer=request.event.organizer.slug event=request.event.slug %}"
+             data-proposal-list>
+            {% if can_manage %}
+                <div class="proposal-bulk-bar">
+                    <span class="proposal-bulk-count text-muted" data-proposal-selected-count></span>
+                    <span class="proposal-bulk-buttons">
+                        <button type="button" class="btn btn-success btn-sm proposal-action-btn proposal-action-approve" data-proposal-bulk="approve" disabled>
+                            <i class="fa fa-check"></i> {% trans "Approve selected" %}
+                        </button>
+                        <button type="button" class="btn btn-danger btn-sm proposal-action-btn proposal-action-reject" data-proposal-bulk="reject" disabled>
+                            <i class="fa fa-times"></i> {% trans "Reject selected" %}
+                        </button>
+                    </span>
+                </div>
+            {% endif %}
             <table class="table table-hover">
                 <thead>
                 <tr>
+                    {% if can_manage %}
+                        <th class="proposal-select-col">
+                            <label class="batch-select-label" aria-label="{% trans 'Select all proposals' %}">
+                                <input type="checkbox" data-proposal-select-all>
+                            </label>
+                        </th>
+                    {% endif %}
                     <th>{% trans "Name" %}</th>
                     <th>{% trans "Submitter" %}</th>
                     <th>{% trans "Type" %}</th>
                     <th>{% trans "State" %}</th>
                     <th>{% trans "Updated" %}</th>
-                    <th class="action-col-1"></th>
+                    <th class="text-right">{% trans "Actions" %}</th>
                 </tr>
                 </thead>
                 <tbody>
                 {% for proposal in proposals %}
-                    <tr>
+                    <tr data-proposal-row="{{ proposal.code }}">
+                        {% if can_manage %}
+                            <td class="proposal-select-col text-center">
+                                {% if proposal.state == actionable_state %}
+                                    <input type="checkbox" class="proposal-select" value="{{ proposal.code }}"
+                                           data-proposal-checkbox aria-label="{% trans 'Select proposal' %}">
+                                {% endif %}
+                            </td>
+                        {% endif %}
                         <td>
                             <strong>
                                 <a href="{% url 'plugins:exhibition:proposal.detail' organizer=request.event.organizer.slug event=request.event.slug code=proposal.code %}">
@@ -49,10 +86,21 @@
                                 {% endif %}
                             {% endwith %}
                         </td>
-                        <td>{{ proposal.get_state_display }}</td>
+                        <td data-proposal-state>{{ proposal.get_state_display }}</td>
                         <td>{{ proposal.updated|date:"SHORT_DATETIME_FORMAT" }}</td>
-                        <td class="text-right">
-                            <a class="btn btn-default btn-sm" href="{% url 'plugins:exhibition:proposal.detail' organizer=request.event.organizer.slug event=request.event.slug code=proposal.code %}">
+                        <td class="text-right proposal-row-actions" data-proposal-actions-cell>
+                            {% if can_manage and proposal.state == actionable_state %}
+                                <button type="button" class="btn btn-success btn-sm proposal-action-btn proposal-action-approve" data-proposal-action="approve" data-proposal-code="{{ proposal.code }}" title="{% trans 'Approve' %}">
+                                    <i class="fa fa-check"></i>
+                                </button>
+                                <button type="button" class="btn btn-danger btn-sm proposal-action-btn proposal-action-reject" data-proposal-action="reject" data-proposal-code="{{ proposal.code }}" title="{% trans 'Reject' %}">
+                                    <i class="fa fa-times"></i>
+                                </button>
+                                <button type="button" class="btn btn-sm proposal-action-btn proposal-action-withdraw" data-proposal-action="withdraw" data-proposal-code="{{ proposal.code }}" title="{% trans 'Withdraw' %}">
+                                    <i class="fa fa-undo"></i>
+                                </button>
+                            {% endif %}
+                            <a class="btn btn-default btn-sm" href="{% url 'plugins:exhibition:proposal.detail' organizer=request.event.organizer.slug event=request.event.slug code=proposal.code %}" title="{% trans 'View' %}">
                                 <i class="fa fa-eye"></i>
                             </a>
                         </td>
@@ -61,6 +109,16 @@
                 </tbody>
             </table>
         </div>
+        {% if can_manage %}
+            <div data-proposal-i18n
+                 data-confirm-approve="{% trans 'Approve the selected proposals and create their partner profiles?' %}"
+                 data-confirm-reject="{% trans 'Reject the selected proposals?' %}"
+                 data-confirm-reject-one="{% trans 'Reject this proposal?' %}"
+                 data-confirm-withdraw-one="{% trans 'Withdraw this proposal?' %}"
+                 data-error="{% trans 'The action could not be completed. Please try again.' %}"
+                 data-selected="{% trans 'selected' %}"></div>
+            <script defer src="{% static 'exhibition/js/proposal-actions.js' %}"></script>
+        {% endif %}
     {% else %}
         <div class="empty-collection">
             <p>{% trans "No exhibition requests have been submitted yet." %}</p>

--- a/exhibition/urls.py
+++ b/exhibition/urls.py
@@ -28,6 +28,7 @@ from .views import (
     ExhibitorDeleteView,
     ExhibitorEditView,
     ExhibitorListView,
+    ProposalActionView,
     ProposalDetailView,
     ProposalListView,
     PublicCallView,
@@ -136,6 +137,11 @@ urlpatterns = [
         "exhibitors/event/<orgslug:organizer>/<slug:event>/call",
         ProposalListView.as_view(),
         name="proposal.list",
+    ),
+    path(
+        "exhibitors/event/<orgslug:organizer>/<slug:event>/call/actions",
+        ProposalActionView.as_view(),
+        name="proposal.actions",
     ),
     path(
         "exhibitors/event/<orgslug:organizer>/<slug:event>/call/proposals/<str:code>",

--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -52,7 +52,6 @@ from .social_links import serialize_social_link
 from .utils import (
     add_external_image_csp_sources,
     build_exhibitor_video_embed,
-    create_exhibitor_from_proposal,
     public_exhibitors_queryset,
     should_hide_applicant_emails,
 )
@@ -814,13 +813,7 @@ class ProposalDetailView(EventPermissionRequiredMixin, UpdateView):
                 messages.error(self.request, _("This proposal can no longer be changed."))
                 return redirect(self.get_success_url())
         if action == "approve":
-            exhibitor = create_exhibitor_from_proposal(self.object)
-            mail_helpers.queue_proposal_email(
-                self.request.event,
-                self.object,
-                mail_helpers.PROPOSAL_ACCEPTED,
-                requestor=self.request.user,
-            )
+            exhibitor = self.object.approve(requestor=self.request.user)
             messages.success(
                 self.request,
                 _("Request approved and partner profile created. An acceptance email was placed in the outbox."),
@@ -839,14 +832,7 @@ class ProposalDetailView(EventPermissionRequiredMixin, UpdateView):
                     _("This request has already been approved and cannot be rejected."),
                 )
             else:
-                self.object.state = ExhibitionProposalState.REJECTED
-                self.object.save(update_fields=["state", "updated"])
-                mail_helpers.queue_proposal_email(
-                    self.request.event,
-                    self.object,
-                    mail_helpers.PROPOSAL_REJECTED,
-                    requestor=self.request.user,
-                )
+                self.object.reject(requestor=self.request.user)
                 messages.success(
                     self.request,
                     _("Request rejected. A rejection email was placed in the outbox."),
@@ -895,10 +881,9 @@ class ProposalActionView(EventPermissionRequiredMixin, View):
 
     def apply_action(self, proposal, action):
         if action == "approve":
-            create_exhibitor_from_proposal(proposal)
+            proposal.approve(requestor=self.request.user)
         elif action == "reject":
-            proposal.state = ExhibitionProposalState.REJECTED
-            proposal.save(update_fields=["state", "updated"])
+            proposal.reject(requestor=self.request.user)
         elif action == "withdraw":
             proposal.state = ExhibitionProposalState.WITHDRAWN
             proposal.save(update_fields=["state", "updated"])

--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -10,7 +10,7 @@ from django.http import Http404, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
 from django.utils import timezone
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _, ngettext
 from django.views import View
 from django.views.generic import DeleteView, DetailView, ListView, TemplateView
 from eventyay.base.templatetags.rich_text import rich_text
@@ -724,11 +724,21 @@ class ProposalListView(EventPermissionRequiredMixin, ListView):
             .order_by("-updated", "-created")
         )
 
+    def can_manage(self):
+        return self.request.user.has_event_permission(
+            self.request.event.organizer,
+            self.request.event,
+            ("can_change_event_settings", "can_change_exhibition_proposals"),
+            request=self.request,
+        )
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["hide_applicant_emails"] = should_hide_applicant_emails(
             self.request.user, self.request.event, request=self.request
         )
+        context["can_manage"] = self.can_manage()
+        context["actionable_state"] = ExhibitionProposalState.SUBMITTED
         return context
 
 
@@ -756,8 +766,11 @@ class ProposalDetailView(EventPermissionRequiredMixin, UpdateView):
             request=self.request,
         )
 
+    def can_review(self):
+        return self.can_manage() and self.object.state == ExhibitionProposalState.SUBMITTED
+
     def get_form_class(self):
-        if self.can_manage():
+        if self.can_review():
             return ExhibitionProposalReviewForm
         return ExhibitionProposalReviewNotesForm
 
@@ -783,6 +796,7 @@ class ProposalDetailView(EventPermissionRequiredMixin, UpdateView):
         context = super().get_context_data(**kwargs)
         context["answers"] = self.object.answers.select_related("question").prefetch_related("options")
         context["can_manage"] = self.can_manage()
+        context["can_review"] = self.can_review()
         context["can_edit_exhibitor"] = self.can_edit_exhibitor()
         context["hide_applicant_emails"] = should_hide_applicant_emails(
             self.request.user, self.request.event, request=self.request
@@ -793,8 +807,12 @@ class ProposalDetailView(EventPermissionRequiredMixin, UpdateView):
     def form_valid(self, form):
         self.object = form.save()
         action = self.request.POST.get("action", "save")
-        if action in ("approve", "reject") and not self.can_manage():
-            raise PermissionDenied()
+        if action in ("approve", "reject"):
+            if not self.can_manage():
+                raise PermissionDenied()
+            if self.object.state != ExhibitionProposalState.SUBMITTED:
+                messages.error(self.request, _("This proposal can no longer be changed."))
+                return redirect(self.get_success_url())
         if action == "approve":
             exhibitor = create_exhibitor_from_proposal(self.object)
             mail_helpers.queue_proposal_email(
@@ -843,6 +861,78 @@ class ProposalDetailView(EventPermissionRequiredMixin, UpdateView):
             "plugins:exhibition:proposal.detail",
             kwargs={**event_kwargs(self.request.event), "code": self.object.code},
         )
+
+
+class ProposalActionView(EventPermissionRequiredMixin, View):
+    permission = ("can_change_event_settings", "can_change_exhibition_proposals")
+    valid_actions = {"approve", "reject", "withdraw"}
+
+    def post(self, request, *args, **kwargs):
+        action = request.POST.get("action")
+        codes = request.POST.getlist("proposal")
+        if action not in self.valid_actions or not codes:
+            return self.respond(request, False, _("No valid action was selected."), [], 0)
+
+        proposals = ExhibitionProposal.objects.filter(event=request.event, code__in=codes).select_related(
+            "approved_exhibitor"
+        )
+        results = []
+        skipped = 0
+        with transaction.atomic():
+            for proposal in proposals:
+                if proposal.state != ExhibitionProposalState.SUBMITTED:
+                    skipped += 1
+                    continue
+                self.apply_action(proposal, action)
+                results.append(
+                    {
+                        "code": proposal.code,
+                        "state": proposal.state,
+                        "state_display": proposal.get_state_display(),
+                    }
+                )
+        return self.respond(request, True, self.build_message(action, len(results), skipped), results, skipped)
+
+    def apply_action(self, proposal, action):
+        if action == "approve":
+            create_exhibitor_from_proposal(proposal)
+        elif action == "reject":
+            proposal.state = ExhibitionProposalState.REJECTED
+            proposal.save(update_fields=["state", "updated"])
+        elif action == "withdraw":
+            proposal.state = ExhibitionProposalState.WITHDRAWN
+            proposal.save(update_fields=["state", "updated"])
+
+    def build_message(self, action, count, skipped):
+        if count:
+            templates = {
+                "approve": ngettext("%(count)d proposal was approved.", "%(count)d proposals were approved.", count),
+                "reject": ngettext("%(count)d proposal was rejected.", "%(count)d proposals were rejected.", count),
+                "withdraw": ngettext("%(count)d proposal was withdrawn.", "%(count)d proposals were withdrawn.", count),
+            }
+            message = templates[action] % {"count": count}
+        else:
+            message = _("No proposals were updated.")
+        if skipped:
+            skipped_message = ngettext(
+                "%(skipped)d was skipped because it was already processed.",
+                "%(skipped)d were skipped because they were already processed.",
+                skipped,
+            ) % {"skipped": skipped}
+            message = f"{message} {skipped_message}"
+        return message
+
+    def respond(self, request, ok, message, results, skipped):
+        if request.headers.get("x-requested-with") == "XMLHttpRequest":
+            return JsonResponse(
+                {"ok": ok, "message": str(message), "results": results, "skipped": skipped},
+                status=200 if ok else 400,
+            )
+        if ok:
+            messages.success(request, message)
+        else:
+            messages.error(request, message)
+        return redirect("plugins:exhibition:proposal.list", **event_kwargs(request.event))
 
 
 class ExhibitionQuestionListView(EventPermissionRequiredMixin, ListView):

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,0 +1,71 @@
+import pytest
+from django_scopes import scopes_disabled
+from eventyay.base.models.auth import User
+
+from exhibition.models import ExhibitionProposal, ExhibitionProposalState, ExhibitorInfo
+from exhibition.views import ProposalActionView
+
+
+def _proposal(event, email, state=ExhibitionProposalState.SUBMITTED, **kwargs):
+    user = User.objects.create_user(email=email, password="pw")
+    return ExhibitionProposal.objects.create(
+        event=event,
+        user=user,
+        name=kwargs.pop("name", "Org"),
+        state=state,
+        **kwargs,
+    )
+
+
+@pytest.mark.django_db
+def test_apply_action_approve_creates_exhibitor(event):
+    with scopes_disabled():
+        proposal = _proposal(event, "approve@e.com")
+        ProposalActionView().apply_action(proposal, "approve")
+        proposal.refresh_from_db()
+        assert proposal.state == ExhibitionProposalState.ACCEPTED
+        assert proposal.approved_exhibitor_id is not None
+        assert ExhibitorInfo.objects.filter(event=event, pk=proposal.approved_exhibitor_id).exists()
+
+
+@pytest.mark.django_db
+def test_apply_action_approve_sponsor_creates_sponsor(event):
+    with scopes_disabled():
+        proposal = _proposal(event, "sponsor@e.com", is_sponsor=True, is_exhibitor=False)
+        ProposalActionView().apply_action(proposal, "approve")
+        proposal.refresh_from_db()
+        exhibitor = ExhibitorInfo.objects.get(pk=proposal.approved_exhibitor_id)
+        assert exhibitor.is_sponsor is True
+        assert exhibitor.is_exhibitor is False
+
+
+@pytest.mark.django_db
+def test_apply_action_reject_sets_state_without_partner(event):
+    with scopes_disabled():
+        proposal = _proposal(event, "reject@e.com")
+        ProposalActionView().apply_action(proposal, "reject")
+        proposal.refresh_from_db()
+        assert proposal.state == ExhibitionProposalState.REJECTED
+        assert proposal.approved_exhibitor_id is None
+        assert not ExhibitorInfo.objects.filter(event=event).exists()
+
+
+@pytest.mark.django_db
+def test_apply_action_withdraw_sets_state(event):
+    with scopes_disabled():
+        proposal = _proposal(event, "withdraw@e.com")
+        ProposalActionView().apply_action(proposal, "withdraw")
+        proposal.refresh_from_db()
+        assert proposal.state == ExhibitionProposalState.WITHDRAWN
+
+
+def test_build_message_reports_count_and_skips():
+    view = ProposalActionView()
+    message = view.build_message("approve", 2, 1)
+    assert "2 proposals were approved." in message
+    assert "1 was skipped" in message
+
+
+def test_build_message_no_updates():
+    view = ProposalActionView()
+    assert str(view.build_message("reject", 0, 0)) == "No proposals were updated."

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,8 +1,14 @@
 import pytest
+from django.test import RequestFactory
 from django_scopes import scopes_disabled
 from eventyay.base.models.auth import User
 
-from exhibition.models import ExhibitionProposal, ExhibitionProposalState, ExhibitorInfo
+from exhibition.models import (
+    ExhibitionEmailQueue,
+    ExhibitionProposal,
+    ExhibitionProposalState,
+    ExhibitorInfo,
+)
 from exhibition.views import ProposalActionView
 
 
@@ -17,11 +23,20 @@ def _proposal(event, email, state=ExhibitionProposalState.SUBMITTED, **kwargs):
     )
 
 
+def _action_view(event, email="organizer@e.com"):
+    request = RequestFactory().post("/")
+    request.user = User.objects.create_user(email=email, password="pw")
+    request.event = event
+    view = ProposalActionView()
+    view.request = request
+    return view
+
+
 @pytest.mark.django_db
 def test_apply_action_approve_creates_exhibitor(event):
     with scopes_disabled():
         proposal = _proposal(event, "approve@e.com")
-        ProposalActionView().apply_action(proposal, "approve")
+        _action_view(event, "org-approve@e.com").apply_action(proposal, "approve")
         proposal.refresh_from_db()
         assert proposal.state == ExhibitionProposalState.ACCEPTED
         assert proposal.approved_exhibitor_id is not None
@@ -29,10 +44,20 @@ def test_apply_action_approve_creates_exhibitor(event):
 
 
 @pytest.mark.django_db
+def test_apply_action_approve_queues_acceptance_email(event):
+    with scopes_disabled():
+        proposal = _proposal(event, "approve-mail@e.com")
+        _action_view(event, "org-approve-mail@e.com").apply_action(proposal, "approve")
+        queued = ExhibitionEmailQueue.objects.filter(event=event, proposal=proposal)
+        assert queued.count() == 1
+        assert queued.first().to_email == "approve-mail@e.com"
+
+
+@pytest.mark.django_db
 def test_apply_action_approve_sponsor_creates_sponsor(event):
     with scopes_disabled():
         proposal = _proposal(event, "sponsor@e.com", is_sponsor=True, is_exhibitor=False)
-        ProposalActionView().apply_action(proposal, "approve")
+        _action_view(event, "org-sponsor@e.com").apply_action(proposal, "approve")
         proposal.refresh_from_db()
         exhibitor = ExhibitorInfo.objects.get(pk=proposal.approved_exhibitor_id)
         assert exhibitor.is_sponsor is True
@@ -43,7 +68,7 @@ def test_apply_action_approve_sponsor_creates_sponsor(event):
 def test_apply_action_reject_sets_state_without_partner(event):
     with scopes_disabled():
         proposal = _proposal(event, "reject@e.com")
-        ProposalActionView().apply_action(proposal, "reject")
+        _action_view(event, "org-reject@e.com").apply_action(proposal, "reject")
         proposal.refresh_from_db()
         assert proposal.state == ExhibitionProposalState.REJECTED
         assert proposal.approved_exhibitor_id is None
@@ -51,12 +76,23 @@ def test_apply_action_reject_sets_state_without_partner(event):
 
 
 @pytest.mark.django_db
-def test_apply_action_withdraw_sets_state(event):
+def test_apply_action_reject_queues_rejection_email(event):
+    with scopes_disabled():
+        proposal = _proposal(event, "reject-mail@e.com")
+        _action_view(event, "org-reject-mail@e.com").apply_action(proposal, "reject")
+        queued = ExhibitionEmailQueue.objects.filter(event=event, proposal=proposal)
+        assert queued.count() == 1
+        assert queued.first().to_email == "reject-mail@e.com"
+
+
+@pytest.mark.django_db
+def test_apply_action_withdraw_sets_state_without_email(event):
     with scopes_disabled():
         proposal = _proposal(event, "withdraw@e.com")
-        ProposalActionView().apply_action(proposal, "withdraw")
+        _action_view(event, "org-withdraw@e.com").apply_action(proposal, "withdraw")
         proposal.refresh_from_db()
         assert proposal.state == ExhibitionProposalState.WITHDRAWN
+        assert not ExhibitionEmailQueue.objects.filter(event=event, proposal=proposal).exists()
 
 
 def test_build_message_reports_count_and_skips():

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -6,8 +6,14 @@ from django_scopes import scopes_disabled
 from eventyay.base.models.auth import User
 
 from exhibition.forms import ExhibitionProposalReviewForm, ExhibitionProposalReviewNotesForm
+from exhibition.models import ExhibitionProposal, ExhibitionProposalState
 from exhibition.utils import should_hide_applicant_emails
 from exhibition.views import ProposalDetailView
+
+
+def _proposal(event, email, state=ExhibitionProposalState.SUBMITTED):
+    submitter = User.objects.create_user(email=email, password="pw")
+    return ExhibitionProposal.objects.create(event=event, user=submitter, name="Org", state=state)
 
 
 def _member(event, email, **flags):
@@ -74,6 +80,21 @@ def test_reviewer_gets_notes_only_form(event):
 def test_manager_gets_full_review_form(event):
     with scopes_disabled():
         user = _member(event, "mg-form@e.com", can_change_exhibition_proposals=True)
+        proposal = _proposal(event, "sub-form@e.com", state=ExhibitionProposalState.SUBMITTED)
         view = _detail_view(event, user)
+        view.object = proposal
         assert view.can_manage() is True
+        assert view.can_review() is True
         assert view.get_form_class() is ExhibitionProposalReviewForm
+
+
+@pytest.mark.django_db
+def test_manager_gets_notes_form_for_non_submitted_proposal(event):
+    with scopes_disabled():
+        user = _member(event, "mg-terminal@e.com", can_change_exhibition_proposals=True)
+        proposal = _proposal(event, "sub-terminal@e.com", state=ExhibitionProposalState.REJECTED)
+        view = _detail_view(event, user)
+        view.object = proposal
+        assert view.can_manage() is True
+        assert view.can_review() is False
+        assert view.get_form_class() is ExhibitionProposalReviewNotesForm


### PR DESCRIPTION
fixes #45 

includes:

- approve/reject/withdraw actions per row
- Detailed view still remains
- Detailed view don't show approve checkboxes
- bulk actions accept/reject can be applied to selected items in list
- bulk actions queue emails (only accept/reject)


https://github.com/user-attachments/assets/e65ea8b6-26a8-4a03-b5eb-f9755a4d671d


