### PR TITLE
Reflect tickets required fileds in exhibitor data access settings

### DIFF
--- a/exhibition/api.py
+++ b/exhibition/api.py
@@ -300,20 +300,43 @@ class ExhibitorInfoViewSet(viewsets.ModelViewSet):
 
 class LeadCreateView(views.APIView):
     def get_allowed_attendee_data(self, order_position, settings, exhibitor):
-        """Helper method to get allowed attendee data based on settings"""
-        # Get all allowed fields including defaults
-        allowed_fields = settings.all_allowed_fields
-        attendee_data = {
-            "name": order_position.attendee_name,  # Always included
-            "email": order_position.attendee_email,  # Always included
-            "company": order_position.company,  # Always included
-            "city": order_position.city if "attendee_city" in allowed_fields else None,
-            "country": str(order_position.country) if "attendee_country" in allowed_fields else None,
-            "note": "",
-            "tags": [],
-        }
+        attendee_data = {"note": "", "tags": []}
+        if settings.is_field_allowed("attendee_name"):
+            attendee_data["name"] = order_position.attendee_name
+        if settings.is_field_allowed("attendee_email"):
+            attendee_data["email"] = order_position.attendee_email
+        if settings.is_field_allowed("system_company"):
+            attendee_data["company"] = order_position.company
+        if settings.is_field_allowed("system_job_title"):
+            attendee_data["job_title"] = order_position.job_title
+        if settings.is_field_allowed("system_street"):
+            address_parts = [
+                order_position.street,
+                order_position.zipcode,
+                order_position.city,
+                str(order_position.country) if order_position.country else "",
+            ]
+            attendee_data["address"] = ", ".join(part for part in address_parts if part)
 
-        return {k: v for k, v in attendee_data.items() if v is not None}
+        answers = {answer.question_id: answer for answer in order_position.answers.all()}
+        required_questions = order_position.order.event.questions.filter(required=True, active=True).order_by(
+            "position", "id"
+        )
+        question_data = []
+        for question in required_questions:
+            if not settings.is_field_allowed(f"question_{question.pk}"):
+                continue
+            answer = answers.get(question.pk)
+            question_data.append(
+                {
+                    "question": str(question.question),
+                    "answer": str(answer.answer) if answer else "",
+                }
+            )
+        if question_data:
+            attendee_data["questions"] = question_data
+
+        return attendee_data
 
     def post(self, request, *args, **kwargs):
         # Extract parameters from the request

--- a/exhibition/migrations/0008_default_share_attendee_name_email.py
+++ b/exhibition/migrations/0008_default_share_attendee_name_email.py
@@ -1,0 +1,33 @@
+from django.db import migrations, models
+
+import exhibition.models
+
+
+def add_name_email_to_existing(apps, schema_editor):
+    ExhibitorSettings = apps.get_model("exhibition", "ExhibitorSettings")
+    for settings in ExhibitorSettings.objects.all():
+        allowed = list(settings.allowed_fields or [])
+        changed = False
+        for field in ("attendee_name", "attendee_email"):
+            if field not in allowed:
+                allowed.append(field)
+                changed = True
+        if changed:
+            settings.allowed_fields = allowed
+            settings.save(update_fields=["allowed_fields"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('exhibition', '0007_offset_exhibition_question_positions'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='exhibitorsettings',
+            name='allowed_fields',
+            field=models.JSONField(default=exhibition.models.default_allowed_fields),
+        ),
+        migrations.RunPython(add_name_email_to_existing, migrations.RunPython.noop),
+    ]

--- a/exhibition/models.py
+++ b/exhibition/models.py
@@ -153,11 +153,15 @@ def get_default_proposal_field_definition(key):
     return next(field for field in PROPOSAL_DEFAULT_FIELDS if field["key"] == key)
 
 
+def default_allowed_fields():
+    return ["attendee_name", "attendee_email"]
+
+
 class ExhibitorSettings(models.Model):
     event = models.ForeignKey("base.Event", on_delete=models.CASCADE)
     exhibitors_access_mail_subject = models.CharField(max_length=255)
     exhibitors_access_mail_body = models.TextField()
-    allowed_fields = models.JSONField(default=list)
+    allowed_fields = models.JSONField(default=default_allowed_fields)
     call_enabled = models.BooleanField(default=False)
     call_headline = I18nCharField(
         max_length=200,
@@ -176,11 +180,8 @@ class ExhibitorSettings(models.Model):
     call_hide_after_deadline = models.BooleanField(default=False)
     proposal_field_settings = models.JSONField(default=default_proposal_field_settings)
 
-    @property
-    def all_allowed_fields(self):
-        """Return all allowed fields, including required default fields"""
-        default_fields = ["attendee_name", "attendee_email"]
-        return list(set(default_fields + self.allowed_fields))
+    def is_field_allowed(self, identifier):
+        return identifier in (self.allowed_fields or [])
 
     @property
     def call_is_open(self):

--- a/exhibition/templates/exhibitors/settings.html
+++ b/exhibition/templates/exhibitors/settings.html
@@ -108,39 +108,15 @@ Best regards, Your {event} team{% endblocktrans %}
                     <div class="form-group">
                         <label class="col-md-3 control-label">{% trans "Exhibitor vouchers" %}</label>
                         <div class="col-md-9">
-                            <div class="checkbox">
-                                <label>
-                                    <input type="checkbox" checked disabled>
-                                    {% trans "Attendee Name" %} ({% trans "Required" %})
-                                </label>
-                            </div>
-                            <div class="checkbox">
-                                <label>
-                                    <input type="checkbox" checked disabled>
-                                    {% trans "Attendee Email" %} ({% trans "Required" %})
-                                </label>
-                            </div>
-                            <div class="checkbox">
-                                <label>
-                                    <input type="checkbox" name="exhibitors_access_voucher" value="attendee_company"
-                                           {% if 'attendee_company' in settings.allowed_fields %}checked{% endif %}>
-                                    {% trans "Attendee Company" %}
-                                </label>
-                            </div>
-                            <div class="checkbox">
-                                <label>
-                                    <input type="checkbox" name="exhibitors_access_voucher" value="attendee_city"
-                                           {% if 'attendee_city' in settings.allowed_fields %}checked{% endif %}>
-                                    {% trans "Attendee City" %}
-                                </label>
-                            </div>
-                            <div class="checkbox">
-                                <label>
-                                    <input type="checkbox" name="exhibitors_access_voucher" value="attendee_country"
-                                           {% if 'attendee_country' in settings.allowed_fields %}checked{% endif %}>
-                                    {% trans "Attendee Country" %}
-                                </label>
-                            </div>
+                            {% for field in data_access_fields %}
+                                <div class="checkbox">
+                                    <label>
+                                        <input type="checkbox" name="exhibitors_access_voucher" value="{{ field.value }}"
+                                               {% if field.checked %}checked{% endif %}>
+                                        {{ field.label }}
+                                    </label>
+                                </div>
+                            {% endfor %}
                         </div>
                     </div>
                 </fieldset>

--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -13,6 +13,10 @@ from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from django.views import View
 from django.views.generic import DeleteView, DetailView, ListView, TemplateView
+from eventyay.base.services.system_questions import (
+    STATE_REQUIRED,
+    get_system_question_base_state,
+)
 from eventyay.base.templatetags.rich_text import rich_text
 from eventyay.control.permissions import EventPermissionRequiredMixin
 from eventyay.control.views import CreateView, UpdateView
@@ -121,7 +125,7 @@ class SettingsView(EventPermissionRequiredMixin, ListView):
         ctx = super().get_context_data(**kwargs)
         settings = ExhibitorSettings.objects.get_or_create(event=self.request.event)[0]
         ctx["settings"] = settings
-        ctx["default_fields"] = ["attendee_name", "attendee_email"]
+        ctx["data_access_fields"] = self.get_data_access_fields(settings)
         ctx["active_tab"] = self.get_active_tab()
 
         edit_group_forms = kwargs.get("edit_group_forms", {})
@@ -160,6 +164,44 @@ class SettingsView(EventPermissionRequiredMixin, ListView):
         ctx["expanded_group_pk"] = kwargs.get("expanded_group_pk")
         return ctx
 
+    SYSTEM_QUESTION_FIELD_LABELS = {
+        "company": _("Company name"),
+        "job_title": _("Job title"),
+        "street": _("Address"),
+    }
+
+    def get_data_access_fields(self, settings):
+        fields = [
+            {
+                "value": "attendee_name",
+                "label": _("Attendee Name"),
+                "checked": settings.is_field_allowed("attendee_name"),
+            },
+            {
+                "value": "attendee_email",
+                "label": _("Attendee Email"),
+                "checked": settings.is_field_allowed("attendee_email"),
+            },
+        ]
+        event = self.request.event
+        for field_id, label in self.SYSTEM_QUESTION_FIELD_LABELS.items():
+            if get_system_question_base_state(event, field_id) != STATE_REQUIRED:
+                continue
+            value = f"system_{field_id}"
+            fields.append({"value": value, "label": label, "checked": settings.is_field_allowed(value)})
+
+        required_questions = self.request.event.questions.filter(required=True, active=True).order_by("position", "id")
+        for question in required_questions:
+            value = f"question_{question.pk}"
+            fields.append(
+                {
+                    "value": value,
+                    "label": str(question.question),
+                    "checked": settings.is_field_allowed(value),
+                }
+            )
+        return fields
+
     def get_next_sponsor_group_level(self):
         return get_next_sponsor_group_level(self.request.event)
 
@@ -169,8 +211,7 @@ class SettingsView(EventPermissionRequiredMixin, ListView):
         active_tab = self.get_active_tab()
 
         if action == "save_exhibitor_settings":
-            allowed_fields = request.POST.getlist("exhibitors_access_voucher")
-            settings.allowed_fields = allowed_fields
+            settings.allowed_fields = request.POST.getlist("exhibitors_access_voucher")
             settings.exhibitors_access_mail_subject = request.POST.get("exhibitors_access_mail_subject", "")
             settings.exhibitors_access_mail_body = request.POST.get("exhibitors_access_mail_body", "")
             settings.save()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,13 +1,16 @@
 import json
 import re
+from types import SimpleNamespace
 
 import pytest
 from django.conf import settings as django_settings
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import RequestFactory
+from django_scopes import scopes_disabled
+from eventyay.base.models import Question
 from rest_framework import serializers
 
-from exhibition.api import ExhibitorInfoSerializer
+from exhibition.api import ExhibitorInfoSerializer, LeadCreateView
 from exhibition.forms import ExhibitionProposalForm, ExhibitorInfoForm, SponsorGroupForm
 from exhibition.models import (
     PROPOSAL_DEFAULT_FIELD_KEYS,
@@ -20,6 +23,7 @@ from exhibition.views import (
     CallTextPreviewView,
     ExhibitionQuestionListView,
     ExhibitorListView,
+    SettingsView,
     SponsorGroupReorderView,
 )
 
@@ -348,3 +352,69 @@ def test_partner_lists_filter_by_type_and_show_both(event):
 
     assert ids_for("sponsor") == {sponsor.id, both.id}
     assert ids_for("exhibitor") == {exhibitor.id, both.id}
+
+
+@pytest.mark.django_db
+def test_new_settings_share_attendee_name_and_email_by_default(event):
+    settings = make_exhibitor_settings(event)
+
+    assert settings.is_field_allowed("attendee_name")
+    assert settings.is_field_allowed("attendee_email")
+    assert not settings.is_field_allowed("system_company")
+
+
+@pytest.mark.django_db
+def test_data_access_fields_reflect_required_ticket_configuration(event):
+    settings = make_exhibitor_settings(event)
+    event.settings.set("attendee_company_asked", True)
+    event.settings.set("attendee_company_required", True)
+    event.settings.set("attendee_job_title_asked", True)
+    event.settings.set("attendee_job_title_required", False)
+
+    with scopes_disabled():
+        required_question = Question.objects.create(
+            event=event, question="Job role", type="S", required=True, active=True, position=0
+        )
+        Question.objects.create(
+            event=event, question="Dietary needs", type="S", required=False, active=True, position=1
+        )
+
+        view = SettingsView()
+        view.request = RequestFactory().get("/")
+        view.request.event = event
+        values = [field["value"] for field in view.get_data_access_fields(settings)]
+
+    assert values[:2] == ["attendee_name", "attendee_email"]
+    assert "system_company" in values
+    assert "system_job_title" not in values
+    assert f"question_{required_question.pk}" in values
+    assert len(values) == 4
+
+
+@pytest.mark.django_db
+def test_lead_data_only_includes_allowed_fields(event):
+    settings = make_exhibitor_settings(event)
+    settings.allowed_fields = ["attendee_name", "system_company"]
+    settings.save()
+
+    order_position = SimpleNamespace(
+        attendee_name="Alice",
+        attendee_email="alice@example.com",
+        company="Acme",
+        job_title="Engineer",
+        street="Main St",
+        zipcode="12345",
+        city="Springfield",
+        country="US",
+        answers=SimpleNamespace(all=lambda: []),
+        order=SimpleNamespace(event=event),
+    )
+
+    with scopes_disabled():
+        data = LeadCreateView().get_allowed_attendee_data(order_position, settings, None)
+
+    assert data["name"] == "Alice"
+    assert data["company"] == "Acme"
+    assert "email" not in data
+    assert "job_title" not in data
+    assert "address" not in data


### PR DESCRIPTION
fixes #72 

Name and email show by default and enabled but still  can be disabled. Other fields appear only when they are set required in tickets' forms.


https://github.com/user-attachments/assets/f62f2de3-55d0-4987-b228-97f1024aefab

