### PR TITLE
Fix sidebar's Exhibitors item points to the exhibitors route

### DIFF
--- a/exhibition/urls.py
+++ b/exhibition/urls.py
@@ -125,7 +125,7 @@ urlpatterns = [
     ),
     path(
         "exhibitors/event/<orgslug:organizer>/<slug:event>",
-        ExhibitorListView.as_view(),
+        ExhibitorListView.as_view(partner_type="exhibitor"),
         name="info",
     ),
     path(


### PR DESCRIPTION
fixes #112

https://github.com/user-attachments/assets/d187c586-9fc7-4379-845f-6d0b177bbe0b



## Summary by Sourcery

Bug Fixes:
- Route for exhibitors event now uses ExhibitorListView configured with the exhibitor partner type instead of the default configuration.