### PR TITLE
feat: implement email outbox bulk actions, filtering, sorting

### DIFF
--- a/exhibition/static/exhibition/css/message-center.css
+++ b/exhibition/static/exhibition/css/message-center.css
@@ -27,13 +27,17 @@
     display: flex;
     align-items: center;
     flex-wrap: wrap;
-    gap: 8px;
+    gap: 6px;
     margin-bottom: 15px;
 }
 
 .email-search .filter-actions {
     display: flex;
     gap: 6px;
+}
+
+.email-search .form-control {
+    border-radius: 4px;
 }
 
 .email-bulk-toolbar {

--- a/exhibition/static/exhibition/css/message-center.css
+++ b/exhibition/static/exhibition/css/message-center.css
@@ -17,3 +17,33 @@
     display: flex;
     gap: 4px;
 }
+
+.email-select {
+    width: 2em;
+    text-align: center;
+}
+
+.email-search {
+    margin-bottom: 15px;
+}
+
+.email-bulk-toolbar {
+    margin-bottom: 10px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.email-sort {
+    white-space: nowrap;
+    margin-left: 4px;
+}
+
+.email-sort a {
+    text-decoration: none;
+}
+
+.email-list-loading {
+    opacity: 0.5;
+    pointer-events: none;
+}

--- a/exhibition/static/exhibition/css/message-center.css
+++ b/exhibition/static/exhibition/css/message-center.css
@@ -24,7 +24,16 @@
 }
 
 .email-search {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px;
     margin-bottom: 15px;
+}
+
+.email-search .filter-actions {
+    display: flex;
+    gap: 6px;
 }
 
 .email-bulk-toolbar {

--- a/exhibition/static/exhibition/js/message-center.js
+++ b/exhibition/static/exhibition/js/message-center.js
@@ -1,0 +1,77 @@
+(function () {
+    "use strict";
+
+    function container() {
+        return document.getElementById("email-list");
+    }
+
+    function load(url, push) {
+        var target = container();
+        if (!target) {
+            return;
+        }
+        target.classList.add("email-list-loading");
+        fetch(url, { headers: { "X-Requested-With": "XMLHttpRequest" }, credentials: "same-origin" })
+            .then(function (response) {
+                return response.text();
+            })
+            .then(function (html) {
+                target.innerHTML = html;
+                target.classList.remove("email-list-loading");
+                if (push) {
+                    window.history.pushState({ emailList: true }, "", url);
+                }
+            })
+            .catch(function () {
+                target.classList.remove("email-list-loading");
+                window.location.href = url;
+            });
+    }
+
+    function onSubmit(event) {
+        var form = event.target;
+        if (!form.matches || !form.matches("form.email-search")) {
+            return;
+        }
+        event.preventDefault();
+        var params = new URLSearchParams(new FormData(form)).toString();
+        load(window.location.pathname + "?" + params, true);
+    }
+
+    function onClick(event) {
+        var link = event.target.closest("#email-list a[data-ajax], #email-list .btn-clear-filter");
+        if (!link) {
+            return;
+        }
+        event.preventDefault();
+        load(link.href, true);
+    }
+
+    function onChange(event) {
+        var element = event.target;
+        if (element.matches("[data-select-all]")) {
+            var rows = element.closest("table").querySelectorAll("[data-select-row]");
+            rows.forEach(function (row) {
+                row.checked = element.checked;
+            });
+        } else if (element.matches("[data-select-row]")) {
+            var table = element.closest("table");
+            var all = table.querySelector("[data-select-all]");
+            if (all) {
+                var boxes = Array.prototype.slice.call(table.querySelectorAll("[data-select-row]"));
+                all.checked = boxes.length > 0 && boxes.every(function (box) {
+                    return box.checked;
+                });
+            }
+        }
+    }
+
+    document.addEventListener("submit", onSubmit);
+    document.addEventListener("click", onClick);
+    document.addEventListener("change", onChange);
+    window.addEventListener("popstate", function () {
+        if (container()) {
+            load(window.location.href, false);
+        }
+    });
+})();

--- a/exhibition/templates/exhibitors/_email_outbox_body.html
+++ b/exhibition/templates/exhibitors/_email_outbox_body.html
@@ -2,10 +2,21 @@
 
 <form method="get" class="form-inline email-search" data-ajax>
     <div class="input-group">
-        <input type="text" name="q" class="form-control" placeholder="{% trans 'Search recipient or subject' %}" value="{{ query }}">
+        <input type="text" name="q" class="form-control" placeholder="{% trans 'Search' %}"
+               value="{{ query }}" aria-label="{% trans 'Search emails' %}">
     </div>
     <input type="hidden" name="ordering" value="{{ current_ordering }}">
-    {% include "eventyay_common/filter_actions.html" %}
+    <div class="filter-actions">
+        <button class="btn btn-primary" type="submit">
+            <span class="fa fa-search" aria-hidden="true"></span>
+            {% trans "Search" %}
+        </button>
+        <a href="{{ request.path }}" class="btn btn-default btn-clear-filter"
+           aria-label="{% trans 'Clear search' %}" title="{% trans 'Clear search' %}">
+            <span class="fa fa-eraser" aria-hidden="true"></span>
+            <span class="sr-only">{% trans "Clear search" %}</span>
+        </a>
+    </div>
 </form>
 
 {% trans "Recipient" as label_recipient %}

--- a/exhibition/templates/exhibitors/_email_outbox_body.html
+++ b/exhibition/templates/exhibitors/_email_outbox_body.html
@@ -1,0 +1,108 @@
+{% load i18n %}
+
+<form method="get" class="form-inline email-search" data-ajax>
+    <div class="input-group">
+        <input type="text" name="q" class="form-control" placeholder="{% trans 'Search recipient or subject' %}" value="{{ query }}">
+    </div>
+    <input type="hidden" name="ordering" value="{{ current_ordering }}">
+    {% include "eventyay_common/filter_actions.html" %}
+</form>
+
+{% trans "Recipient" as label_recipient %}
+{% trans "Subject" as label_subject %}
+{% trans "Created" as label_created %}
+
+<form method="post" action="{% url 'plugins:exhibition:email.bulk' organizer=request.event.organizer.slug event=request.event.slug %}">
+    {% csrf_token %}
+    {% if entries %}
+        <div class="email-bulk-toolbar">
+            <button type="submit" class="btn btn-default btn-sm" name="op" value="send">
+                <i class="fa fa-mail-forward"></i> {% trans "Send selected" %}
+            </button>
+            <button type="submit" class="btn btn-default btn-sm" name="op" value="discard">
+                <i class="fa fa-trash"></i> {% trans "Discard selected" %}
+            </button>
+            <button type="submit" class="btn btn-primary btn-sm" name="op" value="send_all">
+                {% trans "Send all" %}
+            </button>
+            <button type="submit" class="btn btn-danger btn-sm" name="op" value="discard_all">
+                {% trans "Discard all" %}
+            </button>
+        </div>
+    {% endif %}
+    <div class="table-responsive">
+        <table class="table table-hover">
+            <thead>
+            <tr>
+                <th class="email-select"><input type="checkbox" data-select-all></th>
+                <th>{% include "exhibitors/_email_sort_header.html" with field="to_email" label=label_recipient %}</th>
+                <th>{% include "exhibitors/_email_sort_header.html" with field="subject" label=label_subject %}</th>
+                <th>{% include "exhibitors/_email_sort_header.html" with field="created" label=label_created %}</th>
+                <th>{% trans "Scheduled" %}</th>
+                <th>{% trans "Actions" %}</th>
+            </tr>
+            </thead>
+            <tbody>
+            {% for entry in entries %}
+                <tr>
+                    <td class="email-select">
+                        <input type="checkbox" name="selected" value="{{ entry.pk }}" data-select-row>
+                    </td>
+                    <td>
+                        <span class="email-recipients" title="{{ entry.recipients|join:', ' }}">{{ entry.recipients|join:", " }}</span>
+                        {% if entry.is_batch %}
+                            <span class="label label-default">{{ entry.recipients|length }}</span>
+                        {% endif %}
+                    </td>
+                    <td>
+                        <a href="{% url 'plugins:exhibition:email.edit' organizer=request.event.organizer.slug event=request.event.slug pk=entry.pk %}">
+                            {{ entry.subject }}
+                        </a>
+                    </td>
+                    <td class="email-created">{{ entry.created }}</td>
+                    <td class="email-scheduled">
+                        {% if entry.scheduled_at %}
+                            <span class="label label-info">{{ entry.scheduled_at }}</span>
+                        {% else %}
+                            <span class="text-muted">—</span>
+                        {% endif %}
+                    </td>
+                    <td class="email-actions">
+                        <div class="btn-toolbar" role="toolbar">
+                            <div class="btn-group" role="group">
+                                <button type="submit" class="btn btn-sm btn-primary" title="{% trans 'Send this email' %}"
+                                        formaction="{% url 'plugins:exhibition:email.send' organizer=request.event.organizer.slug event=request.event.slug pk=entry.pk %}">
+                                    <i class="fa fa-mail-forward"></i>
+                                </button>
+                            </div>
+                            <div class="btn-group" role="group">
+                                <a class="btn btn-sm btn-info" title="{% trans 'Edit this email' %}"
+                                   href="{% url 'plugins:exhibition:email.edit' organizer=request.event.organizer.slug event=request.event.slug pk=entry.pk %}">
+                                    <i class="fa fa-edit"></i>
+                                </a>
+                            </div>
+                            <div class="btn-group" role="group">
+                                <a class="btn btn-sm btn-danger" title="{% trans 'Discard this email' %}"
+                                   href="{% url 'plugins:exhibition:email.delete' organizer=request.event.organizer.slug event=request.event.slug pk=entry.pk %}">
+                                    <i class="fa fa-trash"></i>
+                                </a>
+                            </div>
+                        </div>
+                    </td>
+                </tr>
+            {% empty %}
+                <tr>
+                    <td colspan="6">
+                        {% if query %}
+                            {% trans "No emails match your search." %}
+                        {% else %}
+                            {% trans "The outbox is empty." %}
+                        {% endif %}
+                    </td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    {% include "pretixcontrol/pagination.html" %}
+</form>

--- a/exhibition/templates/exhibitors/_email_sent_body.html
+++ b/exhibition/templates/exhibitors/_email_sent_body.html
@@ -1,0 +1,50 @@
+{% load i18n %}
+
+<form method="get" class="form-inline email-search" data-ajax>
+    <div class="input-group">
+        <input type="text" name="q" class="form-control" placeholder="{% trans 'Search recipient or subject' %}" value="{{ query }}">
+    </div>
+    <input type="hidden" name="ordering" value="{{ current_ordering }}">
+    {% include "eventyay_common/filter_actions.html" %}
+</form>
+
+{% trans "Recipient" as label_recipient %}
+{% trans "Subject" as label_subject %}
+{% trans "Sent" as label_sent %}
+
+<div class="table-responsive">
+    <table class="table table-hover">
+        <thead>
+        <tr>
+            <th>{% include "exhibitors/_email_sort_header.html" with field="to_email" label=label_recipient %}</th>
+            <th>{% include "exhibitors/_email_sort_header.html" with field="subject" label=label_subject %}</th>
+            <th>{% include "exhibitors/_email_sort_header.html" with field="sent_at" label=label_sent %}</th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for entry in entries %}
+            <tr>
+                <td>
+                    <span class="email-recipients" title="{{ entry.recipients|join:', ' }}">{{ entry.recipients|join:", " }}</span>
+                    {% if entry.is_batch %}
+                        <span class="label label-default">{{ entry.recipients|length }}</span>
+                    {% endif %}
+                </td>
+                <td>{{ entry.subject }}</td>
+                <td class="email-created">{{ entry.sent_at }}</td>
+            </tr>
+        {% empty %}
+            <tr>
+                <td colspan="3">
+                    {% if query %}
+                        {% trans "No emails match your search." %}
+                    {% else %}
+                        {% trans "No emails have been sent yet." %}
+                    {% endif %}
+                </td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% include "pretixcontrol/pagination.html" %}

--- a/exhibition/templates/exhibitors/_email_sent_body.html
+++ b/exhibition/templates/exhibitors/_email_sent_body.html
@@ -2,10 +2,21 @@
 
 <form method="get" class="form-inline email-search" data-ajax>
     <div class="input-group">
-        <input type="text" name="q" class="form-control" placeholder="{% trans 'Search recipient or subject' %}" value="{{ query }}">
+        <input type="text" name="q" class="form-control" placeholder="{% trans 'Search' %}"
+               value="{{ query }}" aria-label="{% trans 'Search emails' %}">
     </div>
     <input type="hidden" name="ordering" value="{{ current_ordering }}">
-    {% include "eventyay_common/filter_actions.html" %}
+    <div class="filter-actions">
+        <button class="btn btn-primary" type="submit">
+            <span class="fa fa-search" aria-hidden="true"></span>
+            {% trans "Search" %}
+        </button>
+        <a href="{{ request.path }}" class="btn btn-default btn-clear-filter"
+           aria-label="{% trans 'Clear search' %}" title="{% trans 'Clear search' %}">
+            <span class="fa fa-eraser" aria-hidden="true"></span>
+            <span class="sr-only">{% trans "Clear search" %}</span>
+        </a>
+    </div>
 </form>
 
 {% trans "Recipient" as label_recipient %}

--- a/exhibition/templates/exhibitors/_email_sort_header.html
+++ b/exhibition/templates/exhibitors/_email_sort_header.html
@@ -1,0 +1,10 @@
+{% load i18n %}
+{{ label }}
+<span class="email-sort">
+    <a data-ajax href="?q={{ query|urlencode }}&ordering={{ field }}"
+       class="{% if current_ordering == field %}text-primary{% else %}text-muted{% endif %}"
+       aria-label="{% trans 'Sort ascending' %}"><i class="fa fa-caret-up"></i></a>
+    <a data-ajax href="?q={{ query|urlencode }}&ordering=-{{ field }}"
+       class="{% if current_ordering == '-'|add:field %}text-primary{% else %}text-muted{% endif %}"
+       aria-label="{% trans 'Sort descending' %}"><i class="fa fa-caret-down"></i></a>
+</span>

--- a/exhibition/templates/exhibitors/base.html
+++ b/exhibition/templates/exhibitors/base.html
@@ -1,5 +1,6 @@
 {% extends 'pretixcontrol/base.html' %}
 {% load i18n %}
+{% load exhibition_email %}
 
 {% block title %}{{ request.event.name }} - {% trans "Exhibitors & Sponsors" %}{% endblock %}
 
@@ -72,9 +73,11 @@
   {% endif %}
   {% if 'can_change_event_settings' in request.eventpermset or 'can_change_exhibition_proposals' in request.eventpermset or 'is_exhibition_reviewer' in request.eventpermset %}
     <li>
+      {% pending_email_count request.event as pending_emails %}
       <a href="{% url 'plugins:exhibition:email.outbox' organizer=request.event.organizer.slug event=request.event.slug %}" class="has-children">
         <span class="fa fa-fw fa-envelope"></span>
         <span class="sidebar-text">{% trans "Message center" %}</span>
+        {% if pending_emails %}<span class="badge">{{ pending_emails }}</span>{% endif %}
       </a>
       <a href="#" class="arrow">
         <span class="fa arrow"></span>
@@ -88,6 +91,7 @@
         <li>
           <a href="{% url 'plugins:exhibition:email.outbox' organizer=request.event.organizer.slug event=request.event.slug %}" {% if url_name == 'email.outbox' or url_name == 'email.edit' or url_name == 'email.delete' %}class="active"{% endif %}>
             <span class="sidebar-text">{% trans "Outbox" %}</span>
+            {% if pending_emails %}<span class="badge">{{ pending_emails }}</span>{% endif %}
           </a>
         </li>
         <li>

--- a/exhibition/templates/exhibitors/email_bulk_discard.html
+++ b/exhibition/templates/exhibitors/email_bulk_discard.html
@@ -1,0 +1,34 @@
+{% extends "exhibitors/base.html" %}
+{% load i18n %}
+
+{% block title %}{{ request.event.name }} - {% trans "Discard emails" %}{% endblock %}
+
+{% block exhibitors_header %}
+    <h1>{% trans "Discard emails" %}</h1>
+{% endblock %}
+
+{% block exhibitors_content %}
+    <form action="{% url 'plugins:exhibition:email.bulk' organizer=request.event.organizer.slug event=request.event.slug %}" method="post">
+        {% csrf_token %}
+        <input type="hidden" name="op" value="{% if scope == 'all' %}discard_all{% else %}discard{% endif %}">
+        <input type="hidden" name="confirmed" value="1">
+        {% for pk in selected %}
+            <input type="hidden" name="selected" value="{{ pk }}">
+        {% endfor %}
+        <p>
+            {% blocktrans trimmed count counter=count %}
+                Are you sure you want to discard {{ counter }} queued email? This cannot be undone.
+            {% plural %}
+                Are you sure you want to discard {{ counter }} queued emails? This cannot be undone.
+            {% endblocktrans %}
+        </p>
+        <div class="form-group submit-group">
+            <a class="btn btn-default" href="{% url 'plugins:exhibition:email.outbox' organizer=request.event.organizer.slug event=request.event.slug %}">
+                {% trans "Cancel" %}
+            </a>
+            <button type="submit" class="btn btn-danger">
+                <i class="fa fa-trash"></i> {% trans "Discard" %}
+            </button>
+        </div>
+    </form>
+{% endblock %}

--- a/exhibition/templates/exhibitors/email_outbox.html
+++ b/exhibition/templates/exhibitors/email_outbox.html
@@ -5,6 +5,7 @@
 {% block custom_header %}
     {{ block.super }}
     <link rel="stylesheet" href="{% static 'exhibition/css/message-center.css' %}">
+    <script defer src="{% static 'exhibition/js/message-center.js' %}"></script>
 {% endblock %}
 
 {% block title %}{{ request.event.name }} - {% trans "Email outbox" %}{% endblock %}
@@ -17,71 +18,7 @@
     <p class="text-muted">
         {% trans "Emails waiting to be sent. Review, edit, or discard them before sending." %}
     </p>
-    <div class="table-responsive">
-        <table class="table table-hover">
-            <thead>
-            <tr>
-                <th>{% trans "Recipient" %}</th>
-                <th>{% trans "Subject" %}</th>
-                <th>{% trans "Created" %}</th>
-                <th>{% trans "Scheduled" %}</th>
-                <th>{% trans "Actions" %}</th>
-            </tr>
-            </thead>
-            <tbody>
-            {% for entry in entries %}
-                <tr>
-                    <td>
-                        <span class="email-recipients" title="{{ entry.recipients|join:', ' }}">{{ entry.recipients|join:", " }}</span>
-                        {% if entry.is_batch %}
-                            <span class="label label-default">{{ entry.recipients|length }}</span>
-                        {% endif %}
-                    </td>
-                    <td>
-                        <a href="{% url 'plugins:exhibition:email.edit' organizer=request.event.organizer.slug event=request.event.slug pk=entry.pk %}">
-                            {{ entry.subject }}
-                        </a>
-                    </td>
-                    <td class="email-created">{{ entry.created }}</td>
-                    <td class="email-scheduled">
-                        {% if entry.scheduled_at %}
-                            <span class="label label-info">{{ entry.scheduled_at }}</span>
-                        {% else %}
-                            <span class="text-muted">—</span>
-                        {% endif %}
-                    </td>
-                    <td class="email-actions">
-                        <div class="btn-toolbar" role="toolbar">
-                            <div class="btn-group" role="group">
-                                <form method="post" action="{% url 'plugins:exhibition:email.send' organizer=request.event.organizer.slug event=request.event.slug pk=entry.pk %}">
-                                    {% csrf_token %}
-                                    <button type="submit" class="btn btn-sm btn-primary" title="{% trans 'Send this email' %}">
-                                        <i class="fa fa-mail-forward"></i>
-                                    </button>
-                                </form>
-                            </div>
-                            <div class="btn-group" role="group">
-                                <a class="btn btn-sm btn-info" title="{% trans 'Edit this email' %}"
-                                   href="{% url 'plugins:exhibition:email.edit' organizer=request.event.organizer.slug event=request.event.slug pk=entry.pk %}">
-                                    <i class="fa fa-edit"></i>
-                                </a>
-                            </div>
-                            <div class="btn-group" role="group">
-                                <a class="btn btn-sm btn-danger" title="{% trans 'Delete this email' %}"
-                                   href="{% url 'plugins:exhibition:email.delete' organizer=request.event.organizer.slug event=request.event.slug pk=entry.pk %}">
-                                    <i class="fa fa-trash"></i>
-                                </a>
-                            </div>
-                        </div>
-                    </td>
-                </tr>
-            {% empty %}
-                <tr>
-                    <td colspan="5">{% trans "The outbox is empty." %}</td>
-                </tr>
-            {% endfor %}
-            </tbody>
-        </table>
+    <div id="email-list">
+        {% include "exhibitors/_email_outbox_body.html" %}
     </div>
-    {% include "pretixcontrol/pagination.html" %}
 {% endblock %}

--- a/exhibition/templates/exhibitors/email_sent.html
+++ b/exhibition/templates/exhibitors/email_sent.html
@@ -5,6 +5,7 @@
 {% block custom_header %}
     {{ block.super }}
     <link rel="stylesheet" href="{% static 'exhibition/css/message-center.css' %}">
+    <script defer src="{% static 'exhibition/js/message-center.js' %}"></script>
 {% endblock %}
 
 {% block title %}{{ request.event.name }} - {% trans "Sent emails" %}{% endblock %}
@@ -14,34 +15,7 @@
 {% endblock %}
 
 {% block exhibitors_content %}
-    <div class="table-responsive">
-        <table class="table table-hover">
-            <thead>
-            <tr>
-                <th>{% trans "Recipient" %}</th>
-                <th>{% trans "Subject" %}</th>
-                <th>{% trans "Sent" %}</th>
-            </tr>
-            </thead>
-            <tbody>
-            {% for entry in entries %}
-                <tr>
-                    <td>
-                        <span class="email-recipients" title="{{ entry.recipients|join:', ' }}">{{ entry.recipients|join:", " }}</span>
-                        {% if entry.is_batch %}
-                            <span class="label label-default">{{ entry.recipients|length }}</span>
-                        {% endif %}
-                    </td>
-                    <td>{{ entry.subject }}</td>
-                    <td class="email-created">{{ entry.sent_at }}</td>
-                </tr>
-            {% empty %}
-                <tr>
-                    <td colspan="3">{% trans "No emails have been sent yet." %}</td>
-                </tr>
-            {% endfor %}
-            </tbody>
-        </table>
+    <div id="email-list">
+        {% include "exhibitors/_email_sent_body.html" %}
     </div>
-    {% include "pretixcontrol/pagination.html" %}
 {% endblock %}

--- a/exhibition/templatetags/exhibition_email.py
+++ b/exhibition/templatetags/exhibition_email.py
@@ -1,0 +1,11 @@
+from django import template
+
+from ..models import ExhibitionEmailQueue
+
+register = template.Library()
+
+
+@register.simple_tag
+def pending_email_count(event):
+    """Number of unsent queued emails for the event, shown as a nav badge."""
+    return ExhibitionEmailQueue.objects.filter(event=event, sent_at__isnull=True).count()

--- a/exhibition/urls.py
+++ b/exhibition/urls.py
@@ -12,6 +12,7 @@ from .api import (
 )
 from .views import (
     CallTextPreviewView,
+    EmailBulkActionView,
     EmailComposeView,
     EmailDeleteView,
     EmailEditView,
@@ -222,6 +223,11 @@ urlpatterns = [
         "exhibitors/event/<orgslug:organizer>/<slug:event>/emails/outbox",
         EmailOutboxListView.as_view(),
         name="email.outbox",
+    ),
+    path(
+        "exhibitors/event/<orgslug:organizer>/<slug:event>/emails/bulk",
+        EmailBulkActionView.as_view(),
+        name="email.bulk",
     ),
     path(
         "exhibitors/event/<orgslug:organizer>/<slug:event>/emails/sent",

--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -7,7 +7,7 @@ from django.core.exceptions import PermissionDenied
 from django.db import transaction
 from django.db.models import Count, Q
 from django.http import Http404, HttpResponse, JsonResponse
-from django.shortcuts import get_object_or_404, redirect
+from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _, ngettext
@@ -1580,38 +1580,70 @@ def group_email_entries(emails):
     return entries
 
 
-class EmailOutboxListView(EventPermissionRequiredMixin, ListView):
+class EmailListMixin:
+    """Shared search and ordering for the outbox and sent lists."""
+
+    context_object_name = "emails"
+    date_field = "created"
+
+    def base_queryset(self):
+        raise NotImplementedError
+
+    def allowed_orderings(self):
+        return {"to_email", "-to_email", "subject", "-subject", self.date_field, "-" + self.date_field}
+
+    def get_queryset(self):
+        queryset = self.base_queryset()
+        query = self.request.GET.get("q", "").strip()
+        if query:
+            queryset = queryset.filter(Q(to_email__icontains=query) | Q(subject__icontains=query))
+        default_ordering = "-" + self.date_field
+        ordering = self.request.GET.get("ordering", default_ordering)
+        if ordering not in self.allowed_orderings():
+            ordering = default_ordering
+        self.current_ordering = ordering
+        return queryset.order_by(ordering)
+
+    partial_template_name = None
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["entries"] = group_email_entries(context["emails"])
+        context["query"] = self.request.GET.get("q", "")
+        context["current_ordering"] = getattr(self, "current_ordering", "-" + self.date_field)
+        context["date_field"] = self.date_field
+        return context
+
+    def get_template_names(self):
+        if self.request.headers.get("x-requested-with") == "XMLHttpRequest":
+            return [self.partial_template_name]
+        return [self.template_name]
+
+
+class EmailOutboxListView(EmailListMixin, EventPermissionRequiredMixin, ListView):
     """Unsent queued emails awaiting organiser review."""
 
     model = ExhibitionEmailQueue
     permission = EMAIL_MANAGE_PERMISSION
     template_name = "exhibitors/email_outbox.html"
-    context_object_name = "emails"
+    partial_template_name = "exhibitors/_email_outbox_body.html"
+    date_field = "created"
 
-    def get_queryset(self):
-        return ExhibitionEmailQueue.objects.filter(event=self.request.event, sent_at__isnull=True).order_by("-created")
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context["entries"] = group_email_entries(context["emails"])
-        return context
+    def base_queryset(self):
+        return ExhibitionEmailQueue.objects.filter(event=self.request.event, sent_at__isnull=True)
 
 
-class EmailSentListView(EventPermissionRequiredMixin, ListView):
+class EmailSentListView(EmailListMixin, EventPermissionRequiredMixin, ListView):
     """Read-only list of already-sent emails."""
 
     model = ExhibitionEmailQueue
     permission = EMAIL_MANAGE_PERMISSION
     template_name = "exhibitors/email_sent.html"
-    context_object_name = "emails"
+    partial_template_name = "exhibitors/_email_sent_body.html"
+    date_field = "sent_at"
 
-    def get_queryset(self):
-        return ExhibitionEmailQueue.objects.filter(event=self.request.event, sent_at__isnull=False).order_by("-sent_at")
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context["entries"] = group_email_entries(context["emails"])
-        return context
+    def base_queryset(self):
+        return ExhibitionEmailQueue.objects.filter(event=self.request.event, sent_at__isnull=False)
 
 
 class EmailEditView(EventPermissionRequiredMixin, UpdateView):
@@ -1724,6 +1756,75 @@ class EmailDeleteView(EventPermissionRequiredMixin, DeleteView):
     def get_success_url(self):
         messages.success(self.request, _("The email has been discarded."))
         return reverse("plugins:exhibition:email.outbox", kwargs=event_kwargs(self.request.event))
+
+
+class EmailBulkActionView(EventPermissionRequiredMixin, View):
+    """Send or discard several queued emails at once (selected rows or all)."""
+
+    permission = EMAIL_MANAGE_PERMISSION
+
+    def target_rows(self, request, scope):
+        base = ExhibitionEmailQueue.objects.filter(event=request.event, sent_at__isnull=True)
+        if scope == "all":
+            return base
+        selected = request.POST.getlist("selected")
+        if not selected:
+            return base.none()
+        batches = [batch for batch in base.filter(pk__in=selected).values_list("batch", flat=True) if batch]
+        return base.filter(Q(pk__in=selected) | Q(batch__in=batches))
+
+    def post(self, request, *args, **kwargs):
+        op = request.POST.get("op", "")
+        action = "send" if op.startswith("send") else "discard" if op.startswith("discard") else None
+        scope = "all" if op.endswith("_all") else "selected"
+        outbox_url = redirect("plugins:exhibition:email.outbox", **event_kwargs(request.event))
+
+        if action is None:
+            return outbox_url
+
+        rows = self.target_rows(request, scope)
+
+        if action == "send":
+            count = 0
+            for row in rows:
+                row.send(requestor=request.user)
+                count += 1
+            if count:
+                messages.success(
+                    request,
+                    ngettext("%(count)d email has been sent.", "%(count)d emails have been sent.", count)
+                    % {"count": count},
+                )
+            else:
+                messages.info(request, _("No emails were selected."))
+            return outbox_url
+
+        if request.POST.get("confirmed"):
+            count = rows.count()
+            rows.delete()
+            if count:
+                messages.success(
+                    request,
+                    ngettext("%(count)d email has been discarded.", "%(count)d emails have been discarded.", count)
+                    % {"count": count},
+                )
+            else:
+                messages.info(request, _("No emails were selected."))
+            return outbox_url
+
+        count = rows.count()
+        if not count:
+            messages.info(request, _("No emails were selected."))
+            return outbox_url
+        return render(
+            request,
+            "exhibitors/email_bulk_discard.html",
+            {
+                "count": count,
+                "scope": scope,
+                "selected": request.POST.getlist("selected"),
+            },
+        )
 
 
 class EmailTemplatesView(EventPermissionRequiredMixin, TemplateView):


### PR DESCRIPTION
fixes #107


- Outbox bulk selection — row checkboxes + "select all", with Send selected and Discard selected actions.
- Bulk shortcuts — "Send all" and "Discard all" buttons.
- Search / filter — filter Outbox and Sent by recipient and subject.
- Sortable columns — sort Outbox/Sent by recipient, subject, and created/sent date.
- Pending count — show a badge/count of queued emails in the Message center nav.

<img width="1512" height="856" alt="image" src="https://github.com/user-attachments/assets/6366d8d8-6805-4ddc-afdd-fa1d8726ea27" />


## Summary by Sourcery

Add search, sorting, and bulk actions to the exhibitor email message center for both outbox and sent emails.

New Features:
- Introduce shared list mixin for email outbox and sent views supporting text search and configurable ordering.
- Add bulk send and discard operations for queued emails, including batch-aware selection and confirmation for destructive actions.
- Display a sidebar badge with the count of pending emails via a new template tag.
- Implement AJAX-powered email list updates with client-side search, sorting controls, and pagination for outbox and sent views.

Enhancements:
- Refactor email outbox and sent templates into reusable partials with a common table layout and filter UI.
- Improve message center styling with dedicated CSS for search bar, bulk toolbar, sorting controls, and loading state.