### PR TITLE
fix: enforce allow_lead_access / allow_voucher_access and clarify lead scanning flags (#73)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -168,6 +168,23 @@ The plugin exposes API endpoints for:
 These endpoints are intended for integration with exhibitor-facing tools such
 as lead scanning applications.
 
+Each ``ExhibitorInfo`` carries three independent access flags, all returned
+by the exhibitor-authentication endpoint so that any client can inspect
+them, and enforced server-side where noted:
+
+- ``lead_scanning_enabled``: the exhibitor's devices may scan badges and
+  create new leads at all. Enforced by the lead-creation endpoint, which
+  returns 403 when this is off.
+- ``allow_lead_access``: the exhibitor may read, export, or annotate leads
+  that were already scanned for them. This is separate from
+  ``lead_scanning_enabled`` and is enforced by this plugin's lead
+  retrieval, lead update, and lead-tag endpoints.
+- ``allow_voucher_access``: whether personal attendee data (name, email,
+  company, address, question answers) is attached to a scan at all. When
+  off, scanning still records a lead so duplicate-scan detection keeps
+  working, but only an empty note/tags shell is stored — no personal
+  data. Enforced by the lead-creation endpoint.
+
 Contributing
 ------------
 

--- a/exhibition/api.py
+++ b/exhibition/api.py
@@ -52,6 +52,28 @@ class SponsorGroupLevelField(serializers.IntegerField):
 
 
 class ExhibitorAuthView(views.APIView):
+    """Authenticate an exhibitor key.
+
+    This is the single entry point any client (this plugin's own frontend,
+    the check-in app, or an external voucher-issuing service) uses to
+    resolve an exhibitor key. Besides identifying the exhibitor, the
+    response also exposes the three access-control flags stored on
+    ``ExhibitorInfo`` so that whichever system is enforcing access to a
+    given resource can make that decision:
+
+    - ``lead_scanning_enabled``: this exhibitor's devices may scan badges
+      and create new Lead records at all (enforced by ``LeadCreateView``).
+    - ``allow_lead_access``: this exhibitor may read/export/annotate the
+      leads that were already scanned for them (enforced in this plugin
+      by ``LeadRetrieveView``, ``LeadUpdateView`` and ``TagListView``).
+    - ``allow_voucher_access``: whether personal attendee data (name,
+      email, company, address, question answers) is attached to a scan
+      at all. When off, scanning still records a lead (so duplicate-scan
+      detection keeps working), but only an empty note/tags shell is
+      stored, with no personal data. Enforced by
+      ``LeadCreateView.get_allowed_attendee_data``.
+    """
+
     def post(self, request, *args, **kwargs):
         key = request.data.get("key")
 
@@ -68,6 +90,9 @@ class ExhibitorAuthView(views.APIView):
                     "exhibitor_name": _localize_i18n_value(exhibitor.name, locale),
                     "booth_id": exhibitor.booth_id,
                     "booth_name": _localize_i18n_value(exhibitor.booth_name, locale),
+                    "lead_scanning_enabled": exhibitor.lead_scanning_enabled,
+                    "allow_lead_access": exhibitor.allow_lead_access,
+                    "allow_voucher_access": exhibitor.allow_voucher_access,
                 },
                 status=status.HTTP_200_OK,
             )
@@ -301,6 +326,18 @@ class ExhibitorInfoViewSet(viewsets.ModelViewSet):
 class LeadCreateView(views.APIView):
     def get_allowed_attendee_data(self, order_position, settings, exhibitor):
         attendee_data = {"note": "", "tags": []}
+
+        # allow_voucher_access gates whether *personal* attendee data is
+        # attached to a scan at all. When it's off, the exhibitor still
+        # gets a lead record (so duplicate-scan detection keeps working),
+        # but no name/email/company/address/answers are attached to it.
+        # `exhibitor` is only ever None from unit tests exercising this
+        # method in isolation; real calls always pass the authenticated
+        # exhibitor, so that case is treated as ungated for backward
+        # compatibility with those tests.
+        if exhibitor is not None and not exhibitor.allow_voucher_access:
+            return attendee_data
+
         if settings.is_field_allowed("attendee_name"):
             attendee_data["name"] = order_position.attendee_name
         if settings.is_field_allowed("attendee_email"):
@@ -358,6 +395,13 @@ class LeadCreateView(views.APIView):
                 {"success": False, "error": "Invalid exhibitor key"},
                 status=status.HTTP_401_UNAUTHORIZED,
             )
+
+        if not exhibitor.lead_scanning_enabled:
+            return Response(
+                {"success": False, "error": "Lead scanning is not enabled for this exhibitor"},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
         settings = ExhibitorSettings.objects.get_or_create(event=exhibitor.event)[0]
 
         # Get attendee details
@@ -406,6 +450,23 @@ class LeadCreateView(views.APIView):
         )
 
 
+def _require_lead_access(exhibitor):
+    """Return a 403 Response if this exhibitor may not access already-scanned
+    lead data, or None if access is allowed.
+
+    ``lead_scanning_enabled`` only controls whether new leads can be
+    *created* (see ``LeadCreateView``). ``allow_lead_access`` is the
+    separate flag that controls whether the exhibitor can *read, export or
+    annotate* leads that were already collected, which is what this guards.
+    """
+    if not exhibitor.allow_lead_access:
+        return Response(
+            {"success": False, "error": "This exhibitor is not allowed to access lead data"},
+            status=status.HTTP_403_FORBIDDEN,
+        )
+    return None
+
+
 class LeadRetrieveView(views.APIView):
     def get(self, request, *args, **kwargs):
         # Authenticate the exhibitor using the key
@@ -417,6 +478,10 @@ class LeadRetrieveView(views.APIView):
                 {"success": False, "error": "Invalid exhibitor key"},
                 status=status.HTTP_401_UNAUTHORIZED,
             )
+
+        denied = _require_lead_access(exhibitor)
+        if denied is not None:
+            return denied
 
         # Fetch all leads associated with the exhibitor
         leads = Lead.objects.filter(exhibitor=exhibitor).values(
@@ -439,13 +504,18 @@ class TagListView(views.APIView):
         key = request.headers.get("Exhibitor")
         try:
             exhibitor = ExhibitorInfo.objects.get(key=key)
-            tags = ExhibitorTag.objects.filter(exhibitor=exhibitor)
-            return Response({"success": True, "tags": [tag.name for tag in tags]})
         except ExhibitorInfo.DoesNotExist:
             return Response(
                 {"success": False, "error": "Invalid exhibitor key"},
                 status=status.HTTP_401_UNAUTHORIZED,
             )
+
+        denied = _require_lead_access(exhibitor)
+        if denied is not None:
+            return denied
+
+        tags = ExhibitorTag.objects.filter(exhibitor=exhibitor)
+        return Response({"success": True, "tags": [tag.name for tag in tags]})
 
 
 class LeadUpdateView(views.APIView):
@@ -461,6 +531,10 @@ class LeadUpdateView(views.APIView):
                 {"success": False, "error": "Invalid exhibitor key"},
                 status=status.HTTP_401_UNAUTHORIZED,
             )
+
+        denied = _require_lead_access(exhibitor)
+        if denied is not None:
+            return denied
 
         try:
             lead = Lead.objects.get(pseudonymization_id=lead_id, exhibitor=exhibitor)

--- a/exhibition/forms.py
+++ b/exhibition/forms.py
@@ -67,11 +67,21 @@ class ExhibitorInfoForm(I18nModelForm):
     )
     allow_voucher_access = forms.BooleanField(
         required=False,
-        label=_("Allowed to access voucher data"),
+        label=_("Include personal attendee data on scanned leads"),
+        help_text=_(
+            "When off, badge scans still create a lead (so re-scanning the same attendee is "
+            "still detected), but no attendee name, email, company, address, or question "
+            "answers are attached to it \u2014 only your own notes and tags."
+        ),
     )
     allow_lead_access = forms.BooleanField(
         required=False,
-        label=_("Allowed to access scanned lead data"),
+        label=_("Can view and export scanned leads"),
+        help_text=_(
+            "Grants this exhibitor access to the attendee details already collected through "
+            "badge scanning. This is different from \u201cAllow lead scanning\u201d below, which only "
+            "controls whether the exhibitor can scan badges to create new leads in the first place."
+        ),
     )
     lead_scanning_scope_by_device = forms.TypedChoiceField(
         label=_("Lead scanning behavior"),
@@ -155,6 +165,13 @@ class ExhibitorInfoForm(I18nModelForm):
             "is_sponsor": _("Mark this partner as an event sponsor"),
             "booth_name": _("Preferred booth name"),
             "lead_scanning_enabled": _("Allow lead scanning"),
+        }
+        help_texts = {
+            "lead_scanning_enabled": _(
+                "Lets this exhibitor's devices scan attendee badges to create new leads. "
+                "Does not by itself grant access to view the leads collected \u2014 see "
+                "\u201cCan view and export scanned leads\u201d above."
+            ),
         }
 
     PROFILE_SETTING_FIELD_MAP = {

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -420,3 +420,56 @@ def test_lead_data_only_includes_allowed_fields(event):
     assert "email" not in data
     assert "job_title" not in data
     assert "address" not in data
+
+
+@pytest.mark.django_db
+def test_lead_data_strips_personal_fields_without_voucher_access(event):
+    settings = make_exhibitor_settings(event)
+    settings.allowed_fields = ["attendee_name", "attendee_email", "system_company"]
+    settings.save()
+
+    order_position = SimpleNamespace(
+        attendee_name="Alice",
+        attendee_email="alice@example.com",
+        company="Acme",
+        job_title="Engineer",
+        street="Main St",
+        zipcode="12345",
+        city="Springfield",
+        country="US",
+        answers=SimpleNamespace(all=lambda: []),
+        order=SimpleNamespace(event=event),
+    )
+
+    with scopes_disabled():
+        exhibitor = ExhibitorInfo.objects.create(event=event, name="Acme", allow_voucher_access=False)
+        data = LeadCreateView().get_allowed_attendee_data(order_position, settings, exhibitor)
+
+    assert data == {"note": "", "tags": []}
+
+
+@pytest.mark.django_db
+def test_lead_data_includes_personal_fields_with_voucher_access(event):
+    settings = make_exhibitor_settings(event)
+    settings.allowed_fields = ["attendee_name", "attendee_email"]
+    settings.save()
+
+    order_position = SimpleNamespace(
+        attendee_name="Alice",
+        attendee_email="alice@example.com",
+        company="Acme",
+        job_title="Engineer",
+        street="Main St",
+        zipcode="12345",
+        city="Springfield",
+        country="US",
+        answers=SimpleNamespace(all=lambda: []),
+        order=SimpleNamespace(event=event),
+    )
+
+    with scopes_disabled():
+        exhibitor = ExhibitorInfo.objects.create(event=event, name="Acme", allow_voucher_access=True)
+        data = LeadCreateView().get_allowed_attendee_data(order_position, settings, exhibitor)
+
+    assert data["name"] == "Alice"
+    assert data["email"] == "alice@example.com"

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -2,11 +2,20 @@ from types import SimpleNamespace
 
 import pytest
 from django.test import RequestFactory
+from django.utils import timezone
 from django_scopes import scopes_disabled
 from eventyay.base.models.auth import User
+from rest_framework import status
 
+from exhibition.api import ExhibitorAuthView, LeadCreateView, LeadRetrieveView, LeadUpdateView, TagListView
 from exhibition.forms import ExhibitionProposalReviewForm, ExhibitionProposalReviewNotesForm
-from exhibition.models import ExhibitionProposal, ExhibitionProposalState
+from exhibition.models import (
+    ExhibitionProposal,
+    ExhibitionProposalState,
+    ExhibitorInfo,
+    ExhibitorSettings,
+    Lead,
+)
 from exhibition.utils import should_hide_applicant_emails
 from exhibition.views import ProposalDetailView
 
@@ -98,3 +107,165 @@ def test_manager_gets_notes_form_for_non_submitted_proposal(event):
         assert view.can_manage() is True
         assert view.can_review() is False
         assert view.get_form_class() is ExhibitionProposalReviewNotesForm
+
+
+def _exhibitor(event, **kwargs):
+    return ExhibitorInfo.objects.create(event=event, name="Acme", **kwargs)
+
+
+def _request_with_key(path, key):
+    request = RequestFactory().get(path, **{"HTTP_EXHIBITOR": key})
+    return request
+
+
+@pytest.mark.django_db
+def test_lead_retrieve_denied_without_allow_lead_access(event):
+    with scopes_disabled():
+        exhibitor = _exhibitor(event, allow_lead_access=False)
+        request = _request_with_key("/", exhibitor.key)
+        response = LeadRetrieveView.as_view()(request)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.data["success"] is False
+
+
+@pytest.mark.django_db
+def test_lead_retrieve_allowed_with_allow_lead_access(event):
+    with scopes_disabled():
+        exhibitor = _exhibitor(event, allow_lead_access=True)
+        Lead.objects.create(
+            exhibitor=exhibitor,
+            exhibitor_name="Acme",
+            pseudonymization_id="abc123",
+            scanned=timezone.now(),
+            scan_type="qr",
+            device_name="scanner-1",
+            booth_id=exhibitor.booth_id or "",
+            booth_name="",
+            attendee={"name": "Alice"},
+        )
+        request = _request_with_key("/", exhibitor.key)
+        response = LeadRetrieveView.as_view()(request)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["success"] is True
+        assert len(response.data["leads"]) == 1
+
+
+@pytest.mark.django_db
+def test_lead_update_denied_without_allow_lead_access(event):
+    with scopes_disabled():
+        exhibitor = _exhibitor(event, allow_lead_access=False)
+        lead = Lead.objects.create(
+            exhibitor=exhibitor,
+            exhibitor_name="Acme",
+            pseudonymization_id="abc123",
+            scanned=timezone.now(),
+            scan_type="qr",
+            device_name="scanner-1",
+            booth_id=exhibitor.booth_id or "",
+            booth_name="",
+            attendee={},
+        )
+        request = RequestFactory().post(
+            "/",
+            data={"note": "hi", "tags": []},
+            content_type="application/json",
+            **{"HTTP_EXHIBITOR": exhibitor.key},
+        )
+        response = LeadUpdateView.as_view()(
+            request, organizer="o", event="e", lead_id=lead.pseudonymization_id
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test_tag_list_denied_without_allow_lead_access(event):
+    with scopes_disabled():
+        exhibitor = _exhibitor(event, allow_lead_access=False)
+        request = _request_with_key("/", exhibitor.key)
+        response = TagListView.as_view()(request, organizer="o", event="e")
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test_tag_list_allowed_with_allow_lead_access(event):
+    with scopes_disabled():
+        exhibitor = _exhibitor(event, allow_lead_access=True)
+        request = _request_with_key("/", exhibitor.key)
+        response = TagListView.as_view()(request, organizer="o", event="e")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["success"] is True
+
+
+@pytest.mark.django_db
+def test_exhibitor_auth_exposes_access_flags(event):
+    with scopes_disabled():
+        exhibitor = _exhibitor(
+            event,
+            lead_scanning_enabled=True,
+            allow_lead_access=True,
+            allow_voucher_access=False,
+        )
+        request = RequestFactory().post("/", data={"key": exhibitor.key})
+        response = ExhibitorAuthView.as_view()(request)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["lead_scanning_enabled"] is True
+        assert response.data["allow_lead_access"] is True
+        assert response.data["allow_voucher_access"] is False
+
+
+def _lead_create_request(key, **overrides):
+    data = {
+        "lead": "abc123",
+        "scanned": "2026-01-01T00:00:00Z",
+        "scan_type": "qr",
+        "device_name": "scanner-1",
+    }
+    data.update(overrides)
+    return RequestFactory().post(
+        "/",
+        data=data,
+        content_type="application/json",
+        **{"HTTP_EXHIBITOR": key},
+    )
+
+
+@pytest.mark.django_db
+def test_lead_create_denied_without_lead_scanning_enabled(event):
+    with scopes_disabled():
+        exhibitor = _exhibitor(event, lead_scanning_enabled=False)
+        request = _lead_create_request(exhibitor.key)
+        response = LeadCreateView.as_view()(request)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.data["success"] is False
+
+
+@pytest.mark.django_db
+def test_lead_create_allowed_with_lead_scanning_enabled(event, monkeypatch):
+    with scopes_disabled():
+        exhibitor = _exhibitor(event, lead_scanning_enabled=True, allow_voucher_access=True)
+        settings = ExhibitorSettings.objects.create(event=event)
+        settings.allowed_fields = ["attendee_name"]
+        settings.save()
+
+        order_position = SimpleNamespace(
+            attendee_name="Alice",
+            attendee_email="alice@example.com",
+            company="Acme",
+            job_title="Engineer",
+            street="Main St",
+            zipcode="12345",
+            city="Springfield",
+            country="US",
+            answers=SimpleNamespace(all=lambda: []),
+            order=SimpleNamespace(event=event),
+        )
+        import exhibition.api as api_module
+
+        monkeypatch.setattr(api_module.OrderPosition.objects, "get", lambda **kwargs: order_position)
+
+        request = _lead_create_request(exhibitor.key)
+        response = LeadCreateView.as_view()(request)
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.data["success"] is True
+        assert response.data["attendee"]["name"] == "Alice"
+        assert Lead.objects.filter(exhibitor=exhibitor, pseudonymization_id="abc123").exists()


### PR DESCRIPTION
## Summary by Sourcery

Tighten and clarify exhibitor lead access controls and data exposure while expanding test coverage and admin-facing descriptions.

New Features:
- Expose exhibitor lead and voucher access flags in the exhibitor authentication API response so clients can enforce permissions.
- Enforce per-exhibitor lead scanning enablement before allowing new leads to be created via the lead creation API.

Bug Fixes:
- Prevent exhibitors without lead access from retrieving, updating, or listing tags for scanned leads.
- Ensure personal attendee data is omitted from leads when voucher access is disabled, while still recording the lead shell.

Enhancements:
- Add centralized helper for enforcing exhibitor lead-access checks across retrieve, update, and tag list endpoints.
- Improve admin form labels and help texts for exhibitor lead scanning and data access options for clearer configuration.
- Document the exhibitor authentication endpoint behavior and its access-control flags via an API view docstring.

Tests:
- Add API tests covering lead creation, retrieval, updating, tag listing, and exhibitor authentication under different access-flag combinations.
- Extend tests to verify behavior of personal attendee data inclusion or omission based on voucher access settings.