### PR TITLE
feat: show change history for accepted requests

### DIFF
--- a/exhibition/migrations/0015_exhibitionproposal_accepted_profile_snapshot.py
+++ b/exhibition/migrations/0015_exhibitionproposal_accepted_profile_snapshot.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("exhibition", "0014_exhibitionproposal_profile_edited_at"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="exhibitionproposal",
+            name="accepted_profile_snapshot",
+            field=models.JSONField(blank=True, null=True),
+        ),
+    ]

--- a/exhibition/migrations/0016_exhibitionproposal_accepted_profile_snapshot.py
+++ b/exhibition/migrations/0016_exhibitionproposal_accepted_profile_snapshot.py
@@ -3,7 +3,7 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("exhibition", "0014_exhibitionproposal_profile_edited_at"),
+        ("exhibition", "0015_backfill_lead_access_flags"),
     ]
 
     operations = [

--- a/exhibition/models.py
+++ b/exhibition/models.py
@@ -452,6 +452,21 @@ PROPOSAL_REVIEW_ACTIONS = {
     "reopen": ExhibitionProposalState.SUBMITTED,
 }
 
+SUBMITTER_PROFILE_FIELD_LABELS = {
+    "description": _("Organization Description"),
+    "email": _("Contact email"),
+    "url": _("Organization Website"),
+    "contact_url": _("Contact Page URL"),
+    "video_url": _("Promotional Video URL"),
+    "slides": _("Promotional Slides"),
+    "logo": _("Logo"),
+    "header_image": _("Header Image"),
+    "booth_name": _("Preferred booth name"),
+    "notes": _("Message to the organizers"),
+    "social_links": _("Social Media"),
+    "extra_links": _("Extra Links"),
+}
+
 
 class ExhibitionProposal(models.Model):
     code = models.CharField(
@@ -530,6 +545,7 @@ class ExhibitionProposal(models.Model):
     )
     submitted = models.DateTimeField(null=True, blank=True)
     profile_edited_at = models.DateTimeField(null=True, blank=True)
+    accepted_profile_snapshot = models.JSONField(null=True, blank=True)
     created = models.DateTimeField(auto_now_add=True)
     updated = models.DateTimeField(auto_now=True)
 
@@ -603,6 +619,65 @@ class ExhibitionProposal(models.Model):
     @property
     def edited_after_acceptance(self):
         return self.state == ExhibitionProposalState.ACCEPTED and self.profile_edited_at is not None
+
+    def submitter_profile_values(self):
+        """Serialise the submitter-owned profile fields into a comparable {key: text} mapping."""
+        values = {
+            "description": localize_event_text(self.description) or "",
+            "email": self.email or "",
+            "url": self.url or "",
+            "contact_url": self.contact_url or "",
+            "video_url": self.video_url or "",
+            "slides": self.visible_slides_url,
+            "logo": self.visible_logo_url,
+            "header_image": self.visible_header_image_url,
+            "booth_name": self.localized_booth_name,
+            "notes": self.notes or "",
+            "social_links": "\n".join(
+                f"{link.get_network_display()}: {link.url}" for link in self.social_links.all()
+            ),
+            "extra_links": "\n".join(f"{link.label}: {link.url}" for link in self.extra_links.all()),
+        }
+        for answer in self.answers.all():
+            values[f"answer_{answer.question_id}"] = str(answer.answer_string)
+        return {key: str(value) for key, value in values.items()}
+
+    def capture_profile_snapshot(self):
+        self.accepted_profile_snapshot = self.submitter_profile_values()
+
+    def profile_field_changes(self):
+        """Return the field-level diff between the acceptance snapshot and the current profile."""
+        if not self.accepted_profile_snapshot:
+            return []
+        old_values = self.accepted_profile_snapshot
+        new_values = self.submitter_profile_values()
+        answer_labels = self._answer_field_labels(list(old_values) + list(new_values))
+        ordered_keys = list(SUBMITTER_PROFILE_FIELD_LABELS) + list(answer_labels)
+        changes = []
+        for key in ordered_keys:
+            old = old_values.get(key, "")
+            new = new_values.get(key, "")
+            if old == new:
+                continue
+            changes.append(
+                {
+                    "label": SUBMITTER_PROFILE_FIELD_LABELS.get(key) or answer_labels.get(key) or key,
+                    "old": old,
+                    "new": new,
+                }
+            )
+        return changes
+
+    def _answer_field_labels(self, keys):
+        answer_ids = {
+            key.removeprefix("answer_")
+            for key in keys
+            if key.startswith("answer_") and key.removeprefix("answer_").isdigit()
+        }
+        if not answer_ids:
+            return {}
+        questions = ExhibitionQuestion.objects.filter(id__in=answer_ids)
+        return {f"answer_{question.id}": question.localized_question for question in questions}
 
     @property
     def localized_booth_name(self):

--- a/exhibition/models.py
+++ b/exhibition/models.py
@@ -649,8 +649,15 @@ class ExhibitionProposal(models.Model):
             return []
         old_values = self.accepted_profile_snapshot
         new_values = self.submitter_profile_values()
-        answer_labels = self._answer_field_labels(list(old_values) + list(new_values))
-        ordered_keys = list(SUBMITTER_PROFILE_FIELD_LABELS) + list(answer_labels)
+        all_keys = set(old_values) | set(new_values)
+        answer_labels = self._answer_field_labels(all_keys)
+        base_keys = list(SUBMITTER_PROFILE_FIELD_LABELS)
+        answer_keys = sorted(
+            (key for key in all_keys if key.startswith("answer_")),
+            key=lambda key: int(key.removeprefix("answer_")),
+        )
+        other_keys = sorted(all_keys - set(base_keys) - set(answer_keys))
+        ordered_keys = base_keys + answer_keys + other_keys
         changes = []
         for key in ordered_keys:
             old = old_values.get(key, "")

--- a/exhibition/models.py
+++ b/exhibition/models.py
@@ -633,9 +633,7 @@ class ExhibitionProposal(models.Model):
             "header_image": self.visible_header_image_url,
             "booth_name": self.localized_booth_name,
             "notes": self.notes or "",
-            "social_links": "\n".join(
-                f"{link.get_network_display()}: {link.url}" for link in self.social_links.all()
-            ),
+            "social_links": "\n".join(f"{link.get_network_display()}: {link.url}" for link in self.social_links.all()),
             "extra_links": "\n".join(f"{link.label}: {link.url}" for link in self.extra_links.all()),
         }
         for answer in self.answers.all():

--- a/exhibition/static/exhibition/css/proposal-actions.css
+++ b/exhibition/static/exhibition/css/proposal-actions.css
@@ -71,3 +71,22 @@
 .proposal-action-feedback:not(:empty) {
     margin-bottom: 12px;
 }
+
+.proposal-state-cell {
+    white-space: nowrap;
+}
+
+.proposal-edited-dot {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    margin-left: 6px;
+    vertical-align: super;
+    border-radius: 50%;
+    background: #f0ad4e;
+}
+
+.proposal-edited-dot:hover,
+.proposal-edited-dot:focus {
+    background: #df8a13;
+}

--- a/exhibition/static/exhibition/css/proposal-actions.css
+++ b/exhibition/static/exhibition/css/proposal-actions.css
@@ -81,7 +81,7 @@
     width: 8px;
     height: 8px;
     margin-left: 6px;
-    vertical-align: super;
+    vertical-align: middle;
     border-radius: 50%;
     background: #f0ad4e;
 }

--- a/exhibition/templates/exhibitors/proposal_detail.html
+++ b/exhibition/templates/exhibitors/proposal_detail.html
@@ -16,6 +16,42 @@
         </a>
     </p>
 
+    {% if proposal.edited_after_acceptance %}
+        <div class="panel panel-warning" id="post-acceptance-changes">
+            <div class="panel-heading">
+                <h3 class="panel-title">
+                    {% blocktrans with when=proposal.profile_edited_at|date:"SHORT_DATETIME_FORMAT" %}Changes made by the applicant after acceptance ({{ when }}){% endblocktrans %}
+                </h3>
+            </div>
+            <div class="panel-body">
+                {% if profile_changes %}
+                    <div class="table-responsive">
+                        <table class="table table-bordered">
+                            <thead>
+                                <tr>
+                                    <th>{% trans "Field" %}</th>
+                                    <th>{% trans "Before acceptance" %}</th>
+                                    <th>{% trans "After edit" %}</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for change in profile_changes %}
+                                    <tr>
+                                        <th scope="row">{{ change.label }}</th>
+                                        <td><del>{{ change.old|linebreaksbr|default:"—" }}</del></td>
+                                        <td><ins>{{ change.new|linebreaksbr|default:"—" }}</ins></td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                {% else %}
+                    <p class="text-muted">{% trans "The applicant edited the profile, but the tracked fields are unchanged." %}</p>
+                {% endif %}
+            </div>
+        </div>
+    {% endif %}
+
     <div class="panel panel-default">
         <div class="panel-heading">
             <h3 class="panel-title">{{ proposal.name|event_localize }}</h3>

--- a/exhibition/templates/exhibitors/proposal_detail.html
+++ b/exhibition/templates/exhibitors/proposal_detail.html
@@ -45,8 +45,10 @@
                             </tbody>
                         </table>
                     </div>
-                {% else %}
+                {% elif proposal.accepted_profile_snapshot %}
                     <p class="text-muted">{% trans "The applicant edited the profile, but the tracked fields are unchanged." %}</p>
+                {% else %}
+                    <p class="text-muted">{% trans "This profile was edited before change tracking was available, so the original values are not recorded." %}</p>
                 {% endif %}
             </div>
         </div>

--- a/exhibition/templates/exhibitors/proposal_list.html
+++ b/exhibition/templates/exhibitors/proposal_list.html
@@ -86,12 +86,14 @@
                                 {% endif %}
                             {% endwith %}
                         </td>
-                        <td data-proposal-state>
-                            {{ proposal.get_state_display }}
+                        <td class="proposal-state-cell">
+                            <span data-proposal-state>{{ proposal.get_state_display }}</span>
                             {% if proposal.edited_after_acceptance %}
-                                <a class="label label-warning" href="{% url 'plugins:exhibition:proposal.detail' organizer=request.event.organizer.slug event=request.event.slug code=proposal.code %}#post-acceptance-changes" title="{% blocktrans with when=proposal.profile_edited_at|date:'SHORT_DATETIME_FORMAT' %}Profile edited by the applicant on {{ when }}, after acceptance. View changes.{% endblocktrans %}">
-                                    {% trans "Edited after acceptance" %}
-                                </a>
+                                {% trans "Edited after acceptance, see detail view for changes." as edited_hint %}
+                                <a class="proposal-edited-dot"
+                                   href="{% url 'plugins:exhibition:proposal.detail' organizer=request.event.organizer.slug event=request.event.slug code=proposal.code %}#post-acceptance-changes"
+                                   title="{{ edited_hint }}"
+                                   aria-label="{{ edited_hint }}"></a>
                             {% endif %}
                         </td>
                         <td>{{ proposal.updated|date:"SHORT_DATETIME_FORMAT" }}</td>

--- a/exhibition/templates/exhibitors/proposal_list.html
+++ b/exhibition/templates/exhibitors/proposal_list.html
@@ -89,9 +89,9 @@
                         <td data-proposal-state>
                             {{ proposal.get_state_display }}
                             {% if proposal.edited_after_acceptance %}
-                                <span class="label label-warning" title="{% blocktrans with when=proposal.profile_edited_at|date:'SHORT_DATETIME_FORMAT' %}Profile edited by the applicant on {{ when }}, after acceptance.{% endblocktrans %}">
+                                <a class="label label-warning" href="{% url 'plugins:exhibition:proposal.detail' organizer=request.event.organizer.slug event=request.event.slug code=proposal.code %}#post-acceptance-changes" title="{% blocktrans with when=proposal.profile_edited_at|date:'SHORT_DATETIME_FORMAT' %}Profile edited by the applicant on {{ when }}, after acceptance. View changes.{% endblocktrans %}">
                                     {% trans "Edited after acceptance" %}
-                                </span>
+                                </a>
                             {% endif %}
                         </td>
                         <td>{{ proposal.updated|date:"SHORT_DATETIME_FORMAT" }}</td>

--- a/exhibition/utils.py
+++ b/exhibition/utils.py
@@ -143,9 +143,7 @@ def create_exhibitor_from_proposal(proposal):
         proposal.submitted = proposal.submitted or timezone.now()
         proposal.profile_edited_at = None
         proposal.capture_profile_snapshot()
-        proposal.save(
-            update_fields=["state", "submitted", "profile_edited_at", "accepted_profile_snapshot", "updated"]
-        )
+        proposal.save(update_fields=["state", "submitted", "profile_edited_at", "accepted_profile_snapshot", "updated"])
         return exhibitor
 
     exhibitor = ExhibitorInfo.objects.create(

--- a/exhibition/utils.py
+++ b/exhibition/utils.py
@@ -141,7 +141,11 @@ def create_exhibitor_from_proposal(proposal):
         )
         proposal.state = ExhibitionProposalState.ACCEPTED
         proposal.submitted = proposal.submitted or timezone.now()
-        proposal.save(update_fields=["state", "submitted", "updated"])
+        proposal.profile_edited_at = None
+        proposal.capture_profile_snapshot()
+        proposal.save(
+            update_fields=["state", "submitted", "profile_edited_at", "accepted_profile_snapshot", "updated"]
+        )
         return exhibitor
 
     exhibitor = ExhibitorInfo.objects.create(
@@ -187,7 +191,18 @@ def create_exhibitor_from_proposal(proposal):
     proposal.approved_exhibitor = exhibitor
     proposal.state = ExhibitionProposalState.ACCEPTED
     proposal.submitted = proposal.submitted or timezone.now()
-    proposal.save(update_fields=["approved_exhibitor", "state", "submitted", "updated"])
+    proposal.profile_edited_at = None
+    proposal.capture_profile_snapshot()
+    proposal.save(
+        update_fields=[
+            "approved_exhibitor",
+            "state",
+            "submitted",
+            "profile_edited_at",
+            "accepted_profile_snapshot",
+            "updated",
+        ]
+    )
     return exhibitor
 
 

--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -1077,9 +1077,7 @@ class ProposalDetailView(EventPermissionRequiredMixin, UpdateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["answers"] = self.object.answers.select_related("question").prefetch_related("options")
-        context["profile_changes"] = (
-            self.object.profile_field_changes() if self.object.edited_after_acceptance else []
-        )
+        context["profile_changes"] = self.object.profile_field_changes() if self.object.edited_after_acceptance else []
         context["can_manage"] = self.can_manage()
         context["can_review"] = self.can_review()
         context["can_edit_exhibitor"] = self.can_edit_exhibitor()

--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -690,6 +690,9 @@ class UserProposalEditView(
                 form.instance.submitted = form.instance.submitted or timezone.now()
         else:
             form.instance.profile_edited_at = timezone.now()
+            if not form.instance.accepted_profile_snapshot:
+                baseline = ExhibitionProposal.objects.get(pk=form.instance.pk)
+                form.instance.accepted_profile_snapshot = baseline.submitter_profile_values()
         response = super().form_valid(form)
         self.save_link_formsets()
         if (

--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -702,7 +702,7 @@ class UserProposalEditView(
             send_proposal_confirmation(self.request.event, self.object, self.request.user)
         if self.object.approved_exhibitor_id:
             sync_exhibitor_from_proposal(self.object)
-        messages.success(self.request, _("Your request has been saved."))
+        messages.success(self.request, _("Your changes have been saved."))
         return response
 
     def get_context_data(self, **kwargs):

--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -1074,6 +1074,9 @@ class ProposalDetailView(EventPermissionRequiredMixin, UpdateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["answers"] = self.object.answers.select_related("question").prefetch_related("options")
+        context["profile_changes"] = (
+            self.object.profile_field_changes() if self.object.edited_after_acceptance else []
+        )
         context["can_manage"] = self.can_manage()
         context["can_review"] = self.can_review()
         context["can_edit_exhibitor"] = self.can_edit_exhibitor()

--- a/tests/test_accepted_proposal_edit.py
+++ b/tests/test_accepted_proposal_edit.py
@@ -81,6 +81,7 @@ def test_form_valid_syncs_accepted_proposal_and_marks_edited(event):
         _settings_with_required_email(event)
         proposal, exhibitor = _accepted_proposal(event)
         assert proposal.profile_edited_at is None
+        assert proposal.accepted_profile_snapshot is None
 
         request = RequestFactory().post(
             "/",
@@ -104,3 +105,8 @@ def test_form_valid_syncs_accepted_proposal_and_marks_edited(event):
         assert proposal.state == ExhibitionProposalState.ACCEPTED
         assert proposal.profile_edited_at is not None
         assert exhibitor.email == "new@example.com"
+
+        assert proposal.accepted_profile_snapshot["email"] == "old@example.com"
+        changes = {change["label"]: change for change in proposal.profile_field_changes()}
+        assert changes["Contact email"]["old"] == "old@example.com"
+        assert changes["Contact email"]["new"] == "new@example.com"

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -61,6 +61,41 @@ def test_available_review_actions_for_accepted_has_no_approve(event):
 
 
 @pytest.mark.django_db
+def test_create_exhibitor_from_proposal_captures_profile_snapshot(event):
+    with scopes_disabled():
+        proposal = _proposal(event, "snap@e.com", description="Original description")
+        create_exhibitor_from_proposal(proposal)
+        proposal.refresh_from_db()
+
+        assert proposal.state == ExhibitionProposalState.ACCEPTED
+        assert proposal.profile_edited_at is None
+        assert proposal.accepted_profile_snapshot == proposal.submitter_profile_values()
+        assert proposal.accepted_profile_snapshot["description"] == "Original description"
+
+
+@pytest.mark.django_db
+def test_reapprove_after_reject_refreshes_profile_snapshot_and_clears_edited_flag(event):
+    with scopes_disabled():
+        proposal = _proposal(event, "refresh@e.com", description="Original description")
+        create_exhibitor_from_proposal(proposal)
+        proposal.refresh_from_db()
+
+        proposal.description = "Edited after acceptance"
+        proposal.profile_edited_at = proposal.updated
+        proposal.save(update_fields=["description", "profile_edited_at"])
+
+        proposal.reject()
+        proposal.refresh_from_db()
+        proposal.approve()
+        proposal.refresh_from_db()
+
+        assert proposal.state == ExhibitionProposalState.ACCEPTED
+        assert proposal.profile_edited_at is None
+        assert proposal.accepted_profile_snapshot["description"] == "Edited after acceptance"
+        assert proposal.profile_field_changes() == []
+
+
+@pytest.mark.django_db
 def test_reject_after_accept_deactivates_partner(event):
     with scopes_disabled():
         proposal = _proposal(event, "flip@e.com")


### PR DESCRIPTION
fixes #104 

Includes:

- Capture a snapshot of submitter-owned profile fields at acceptance 
- Render a diff on the organizer proposal detail view
- Indicator to show which request changed
- Covers the same fields the submitter can edit

https://github.com/user-attachments/assets/1cbfe48b-c6e7-4ad8-bb3b-b9fb60bf754f

## Summary by Sourcery

Track and display applicant profile changes made after an exhibition request is accepted.

New Features:
- Capture a JSON snapshot of submitter-owned profile fields at the moment an exhibition proposal is accepted.
- Show a field-level before/after diff of applicant profile changes on the organizer proposal detail view.
- Indicate in the proposal list when an accepted request has been edited after acceptance, with a link to the detailed changes section.

Enhancements:
- Extend proposal editing logic to record the time of post-acceptance edits and ensure a baseline snapshot exists for change tracking.
- Label tracked profile fields and dynamic question answers for clearer presentation in the change history table.