### PR TITLE
Bulk keys export, and queue the access-code email with vouchers

### DIFF
--- a/exhibition/static/exhibition/css/dragsort-table.css
+++ b/exhibition/static/exhibition/css/dragsort-table.css
@@ -36,8 +36,10 @@ body.dragging .dragsort-button {
     margin-bottom: 0;
 }
 
+
 [data-partner-download-link].disabled {
-    opacity: 0.5;
+    box-shadow: 0px 0px 0px 1px #cccccc inset;
+    opacity: 0.65;
     pointer-events: none;
     cursor: not-allowed;
 }

--- a/exhibition/static/exhibition/css/dragsort-table.css
+++ b/exhibition/static/exhibition/css/dragsort-table.css
@@ -27,3 +27,11 @@
 body.dragging .dragsort-button {
     transform: translate(-9999px);
 }
+
+.partner-select-col {
+    width: 32px;
+}
+
+.partner-select-col .batch-select-label {
+    margin-bottom: 0;
+}

--- a/exhibition/static/exhibition/css/dragsort-table.css
+++ b/exhibition/static/exhibition/css/dragsort-table.css
@@ -35,3 +35,9 @@ body.dragging .dragsort-button {
 .partner-select-col .batch-select-label {
     margin-bottom: 0;
 }
+
+[data-partner-download-link].disabled {
+    opacity: 0.5;
+    pointer-events: none;
+    cursor: not-allowed;
+}

--- a/exhibition/static/exhibition/js/partner-select.js
+++ b/exhibition/static/exhibition/js/partner-select.js
@@ -35,6 +35,10 @@
                 selectAll.checked = boxes.length > 0 && selected.length === boxes.length
                 selectAll.indeterminate = selected.length > 0 && selected.length < boxes.length
             }
+            if (downloadLink) {
+                downloadLink.classList.toggle('disabled', selected.length === 0)
+                downloadLink.setAttribute('aria-disabled', selected.length === 0 ? 'true' : 'false')
+            }
         }
 
         if (selectAll) {
@@ -54,11 +58,11 @@
 
         if (downloadLink && baseHref) {
             downloadLink.addEventListener('click', function (event) {
+                event.preventDefault()
                 var selected = selectedValues()
                 if (!selected.length) {
                     return
                 }
-                event.preventDefault()
                 var params = selected
                     .map(function (value) {
                         return 'pk=' + encodeURIComponent(value)

--- a/exhibition/static/exhibition/js/partner-select.js
+++ b/exhibition/static/exhibition/js/partner-select.js
@@ -1,0 +1,73 @@
+(function () {
+    document.addEventListener('DOMContentLoaded', function () {
+        var scope = document.querySelector('[data-partner-select-scope]')
+        if (!scope) {
+            return
+        }
+
+        var selectAll = scope.querySelector('[data-partner-select-all]')
+        var countLabel = scope.querySelector('[data-partner-selected-count]')
+        var downloadLink = scope.querySelector('[data-partner-download-link]')
+        var selectedLabel = scope.dataset.selectedLabel || 'selected'
+        var baseHref = downloadLink ? downloadLink.getAttribute('href') : null
+
+        function checkboxes() {
+            return Array.prototype.slice.call(scope.querySelectorAll('[data-partner-checkbox]'))
+        }
+
+        function selectedValues() {
+            return checkboxes()
+                .filter(function (box) {
+                    return box.checked
+                })
+                .map(function (box) {
+                    return box.value
+                })
+        }
+
+        function refreshSelection() {
+            var boxes = checkboxes()
+            var selected = selectedValues()
+            if (countLabel) {
+                countLabel.textContent = selected.length ? selected.length + ' ' + selectedLabel : ''
+            }
+            if (selectAll) {
+                selectAll.checked = boxes.length > 0 && selected.length === boxes.length
+                selectAll.indeterminate = selected.length > 0 && selected.length < boxes.length
+            }
+        }
+
+        if (selectAll) {
+            selectAll.addEventListener('change', function () {
+                checkboxes().forEach(function (box) {
+                    box.checked = selectAll.checked
+                })
+                refreshSelection()
+            })
+        }
+
+        scope.addEventListener('change', function (event) {
+            if (event.target.hasAttribute('data-partner-checkbox')) {
+                refreshSelection()
+            }
+        })
+
+        if (downloadLink && baseHref) {
+            downloadLink.addEventListener('click', function (event) {
+                var selected = selectedValues()
+                if (!selected.length) {
+                    return
+                }
+                event.preventDefault()
+                var params = selected
+                    .map(function (value) {
+                        return 'pk=' + encodeURIComponent(value)
+                    })
+                    .join('&')
+                window.location.href = baseHref + '&' + params
+            })
+        }
+
+        refreshSelection()
+    })
+})()

--- a/exhibition/static/exhibition/js/partner-select.js
+++ b/exhibition/static/exhibition/js/partner-select.js
@@ -1,5 +1,5 @@
 (function () {
-    document.addEventListener('DOMContentLoaded', function () {
+    function init() {
         var scope = document.querySelector('[data-partner-select-scope]')
         if (!scope) {
             return
@@ -73,5 +73,12 @@
         }
 
         refreshSelection()
-    })
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init)
+    } else {
+        init()
+    }
+    document.addEventListener('eventyay:ajax-results-replaced', init)
 })()

--- a/exhibition/templates/exhibitors/_partner_row.html
+++ b/exhibition/templates/exhibitors/_partner_row.html
@@ -1,5 +1,10 @@
 {% load i18n %}
 <tr {% if reorder_enabled and "can_change_event_settings" in request.eventpermset %}dragsort-id="{{ e.id }}"{% endif %}>
+    {% if "can_change_event_settings" in request.eventpermset %}
+        <td class="partner-select-col">
+            <input type="checkbox" value="{{ e.id }}" data-partner-checkbox aria-label="{% blocktrans trimmed with name=e.name %}Select {{ name }}{% endblocktrans %}">
+        </td>
+    {% endif %}
     <td>
         {% if "can_change_event_settings" in request.eventpermset %}
             <strong><a href="{% url "plugins:exhibition:edit" organizer=request.event.organizer.slug event=request.event.slug pk=e.id %}?type={{ partner_type }}">

--- a/exhibition/templates/exhibitors/exhibitor_info.html
+++ b/exhibition/templates/exhibitors/exhibitor_info.html
@@ -50,7 +50,8 @@
                     {% if partner_type == 'sponsor' %}{% trans "Add a Sponsor" %}{% elif partner_type == 'exhibitor' %}{% trans "Add an Exhibitor" %}{% else %}{% trans "Add an Exhibitor or Sponsor" %}{% endif %}
                 </a>
                 <a href="?download=yes" class="btn btn-default" title="{% trans "Download access keys as CSV" %}">
-                    <i class="fa fa-download"></i> {% trans "Download access keys" %}
+                    <i class="fa fa-download"></i>
+                    {% if partner_type == 'sponsor' %}{% trans "Download sponsor keys" %}{% elif partner_type == 'exhibitor' %}{% trans "Download exhibitor keys" %}{% else %}{% trans "Download access keys" %}{% endif %}
                 </a>
             {% endif %}
         </p>

--- a/exhibition/templates/exhibitors/exhibitor_info.html
+++ b/exhibition/templates/exhibitors/exhibitor_info.html
@@ -9,6 +9,7 @@
     <script defer src="{% static 'exhibition/js/list-filters.js' %}"></script>
     <script defer src="{% static 'orga/js/dragsort.js' %}"></script>
     <script defer src="{% static 'exhibition/js/copy-key.js' %}"></script>
+    <script defer src="{% static 'exhibition/js/partner-select.js' %}"></script>
 {% endblock %}
 {% block exhibitors_header %}
     <h1>{% if partner_type == 'sponsor' %}{% trans "Sponsors" %}{% elif partner_type == 'exhibitor' %}{% trans "Exhibitors" %}{% else %}{% trans "Exhibitors & Sponsors" %}{% endif %}</h1>
@@ -44,15 +45,17 @@
             {% endif %}
         </div>
     {% else %}
+        <div data-partner-select-scope data-selected-label="{% trans "selected" %}">
         <p>
             {% if "can_change_event_settings" in request.eventpermset %}
                 <a href="{{ add_url }}" class="btn btn-default"><i class="fa fa-plus"></i>
                     {% if partner_type == 'sponsor' %}{% trans "Add a Sponsor" %}{% elif partner_type == 'exhibitor' %}{% trans "Add an Exhibitor" %}{% else %}{% trans "Add an Exhibitor or Sponsor" %}{% endif %}
                 </a>
-                <a href="?download=yes" class="btn btn-default" title="{% trans "Download access keys as CSV" %}">
+                <a href="?download=yes" class="btn btn-default" title="{% trans "Download access keys as CSV" %}" data-partner-download-link>
                     <i class="fa fa-download"></i>
                     {% if partner_type == 'sponsor' %}{% trans "Download sponsor keys" %}{% elif partner_type == 'exhibitor' %}{% trans "Download exhibitor keys" %}{% else %}{% trans "Download access keys" %}{% endif %}
                 </a>
+                <span class="text-muted" data-partner-selected-count></span>
             {% endif %}
         </p>
 
@@ -70,6 +73,13 @@
                 <table class="table table-hover dragsort-table">
                     <thead>
                     <tr>
+                        {% if "can_change_event_settings" in request.eventpermset %}
+                            <th class="partner-select-col">
+                                <label class="batch-select-label" aria-label="{% trans 'Select all partners' %}">
+                                    <input type="checkbox" data-partner-select-all>
+                                </label>
+                            </th>
+                        {% endif %}
                         <th>{% include "exhibitors/_sort_header.html" with field="name" label=label_name %}</th>
                         <th>{% trans "Group" %}</th>
                         <th class="action-col-2"></th>
@@ -91,6 +101,13 @@
                 <table class="table table-hover dragsort-table">
                     <thead>
                     <tr>
+                        {% if "can_change_event_settings" in request.eventpermset %}
+                            <th class="partner-select-col">
+                                <label class="batch-select-label" aria-label="{% trans 'Select all partners' %}">
+                                    <input type="checkbox" data-partner-select-all>
+                                </label>
+                            </th>
+                        {% endif %}
                         <th>{% include "exhibitors/_sort_header.html" with field="name" label=label_name %}</th>
                         {% if not partner_type %}<th>{% trans "Group" %}</th>{% endif %}
                         <th>{% include "exhibitors/_sort_header.html" with field="booth" label=label_booth %}</th>
@@ -106,6 +123,7 @@
             </div>
         {% endif %}
         {% include "pretixcontrol/pagination.html" %}
+        </div>
     {% endif %}
     </div>
 {% endblock %}

--- a/exhibition/templates/exhibitors/exhibitor_info.html
+++ b/exhibition/templates/exhibitors/exhibitor_info.html
@@ -49,6 +49,9 @@
                 <a href="{{ add_url }}" class="btn btn-default"><i class="fa fa-plus"></i>
                     {% if partner_type == 'sponsor' %}{% trans "Add a Sponsor" %}{% elif partner_type == 'exhibitor' %}{% trans "Add an Exhibitor" %}{% else %}{% trans "Add an Exhibitor or Sponsor" %}{% endif %}
                 </a>
+                <a href="?download=yes" class="btn btn-default" title="{% trans "Download access keys as CSV" %}">
+                    <i class="fa fa-download"></i> {% trans "Download access keys" %}
+                </a>
             {% endif %}
         </p>
 

--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -419,10 +419,15 @@ class ExhibitorListView(EventPermissionRequiredMixin, FilteredListMixin, ListVie
         return super().get(request, *args, **kwargs)
 
     def download_keys_csv(self):
+        queryset = self.get_queryset()
+        selected_pks = self.request.GET.getlist("pk")
+        if selected_pks:
+            queryset = queryset.filter(pk__in=selected_pks)
+
         output = io.StringIO()
         writer = csv.writer(output, quoting=csv.QUOTE_NONNUMERIC, delimiter=",")
         writer.writerow([_("Name"), _("Booth ID"), _("Booth name"), _("Email"), _("Access key")])
-        for exhibitor in self.get_queryset():
+        for exhibitor in queryset:
             writer.writerow(
                 [
                     localize_event_text(exhibitor.name) or str(exhibitor.name),

--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -21,6 +21,7 @@ from eventyay.base.services.system_questions import (
     get_system_question_base_state,
 )
 from eventyay.base.templatetags.rich_text import rich_text
+from eventyay.common.utils.language import localize_event_text
 from eventyay.control.forms.filter import advanced_filter_count, advanced_filters_open_from_get
 from eventyay.control.permissions import EventPermissionRequiredMixin
 from eventyay.control.views import CreateView, PaginationMixin, UpdateView
@@ -399,6 +400,34 @@ class ExhibitorListView(EventPermissionRequiredMixin, FilteredListMixin, ListVie
         else:
             queryset = queryset.order_by("name", "pk")
         return self.apply_filters(queryset)
+
+    def get(self, request, *args, **kwargs):
+        if request.GET.get("download") == "yes":
+            if not request.user.has_event_permission(
+                request.event.organizer, request.event, "can_change_event_settings", request=request
+            ):
+                raise PermissionDenied()
+            return self.download_keys_csv()
+        return super().get(request, *args, **kwargs)
+
+    def download_keys_csv(self):
+        output = io.StringIO()
+        writer = csv.writer(output, quoting=csv.QUOTE_NONNUMERIC, delimiter=",")
+        writer.writerow([_("Name"), _("Booth ID"), _("Booth name"), _("Email"), _("Access key")])
+        for exhibitor in self.get_queryset():
+            writer.writerow(
+                [
+                    localize_event_text(exhibitor.name) or str(exhibitor.name),
+                    exhibitor.booth_id or "",
+                    exhibitor.localized_booth_name,
+                    exhibitor.email or "",
+                    exhibitor.key,
+                ]
+            )
+        response = HttpResponse(output.getvalue().encode("utf-8"), content_type="text/csv")
+        response["Content-Disposition"] = 'attachment; filename="exhibitor-keys.csv"'
+        response["Cache-Control"] = "no-store"
+        return response
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -1632,9 +1661,8 @@ class ExhibitorCreateView(ExhibitorLinkFormsetMixin, EventPermissionRequiredMixi
 
         response = super().form_valid(form)
         self.save_link_formsets()
-        if form.instance.lead_scanning_enabled and queue_exhibitor_access_mail(
-            self.request.event, self.object, self.request.user
-        ):
+        needs_key = form.instance.lead_scanning_enabled or form.instance.allow_voucher_access
+        if needs_key and queue_exhibitor_access_mail(self.request.event, self.object, self.request.user):
             messages.info(self.request, _("An access-credentials email was placed in the outbox."))
         return response
 
@@ -1673,9 +1701,11 @@ class ExhibitorEditView(ExhibitorLinkFormsetMixin, EventPermissionRequiredMixin,
 
     @transaction.atomic
     def form_valid(self, form):
-        was_lead_scanning_enabled = (
-            ExhibitorInfo.objects.filter(pk=self.object.pk).values_list("lead_scanning_enabled", flat=True).first()
-        )
+        previous = (
+            ExhibitorInfo.objects.filter(pk=self.object.pk)
+            .values("lead_scanning_enabled", "allow_voucher_access")
+            .first()
+        ) or {}
 
         # Generate booth_id only for exhibitors if none exists.
         if (
@@ -1687,11 +1717,10 @@ class ExhibitorEditView(ExhibitorLinkFormsetMixin, EventPermissionRequiredMixin,
 
         response = super().form_valid(form)
         self.save_link_formsets()
-        if (
-            form.instance.lead_scanning_enabled
-            and not was_lead_scanning_enabled
-            and queue_exhibitor_access_mail(self.request.event, self.object, self.request.user)
-        ):
+        newly_granted = (form.instance.lead_scanning_enabled and not previous.get("lead_scanning_enabled")) or (
+            form.instance.allow_voucher_access and not previous.get("allow_voucher_access")
+        )
+        if newly_granted and queue_exhibitor_access_mail(self.request.event, self.object, self.request.user):
             messages.info(self.request, _("An access-credentials email was placed in the outbox."))
         return response
 

--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -117,6 +117,14 @@ def queue_exhibitor_access_mail(event, exhibitor, requestor):
     return mail_helpers.queue_exhibitor_access_email(event, exhibitor, requestor=requestor)
 
 
+def access_newly_granted(exhibitor, previous=None):
+    """True when lead scanning or voucher access is enabled and was not before."""
+    previous = previous or {}
+    return (exhibitor.lead_scanning_enabled and not previous.get("lead_scanning_enabled")) or (
+        exhibitor.allow_voucher_access and not previous.get("allow_voucher_access")
+    )
+
+
 def partner_type_of(exhibitor):
     if exhibitor.is_sponsor and exhibitor.is_exhibitor:
         return "both"
@@ -424,8 +432,12 @@ class ExhibitorListView(EventPermissionRequiredMixin, FilteredListMixin, ListVie
                     exhibitor.key,
                 ]
             )
-        response = HttpResponse(output.getvalue().encode("utf-8"), content_type="text/csv")
-        response["Content-Disposition"] = 'attachment; filename="exhibitor-keys.csv"'
+        filename = {
+            "sponsor": "sponsor-keys.csv",
+            "exhibitor": "exhibitor-keys.csv",
+        }.get(self.partner_type, "partner-keys.csv")
+        response = HttpResponse(output.getvalue().encode("utf-8"), content_type="text/csv; charset=utf-8")
+        response["Content-Disposition"] = f'attachment; filename="{filename}"'
         response["Cache-Control"] = "no-store"
         return response
 
@@ -1661,8 +1673,9 @@ class ExhibitorCreateView(ExhibitorLinkFormsetMixin, EventPermissionRequiredMixi
 
         response = super().form_valid(form)
         self.save_link_formsets()
-        needs_key = form.instance.lead_scanning_enabled or form.instance.allow_voucher_access
-        if needs_key and queue_exhibitor_access_mail(self.request.event, self.object, self.request.user):
+        if access_newly_granted(form.instance) and queue_exhibitor_access_mail(
+            self.request.event, self.object, self.request.user
+        ):
             messages.info(self.request, _("An access-credentials email was placed in the outbox."))
         return response
 
@@ -1717,10 +1730,9 @@ class ExhibitorEditView(ExhibitorLinkFormsetMixin, EventPermissionRequiredMixin,
 
         response = super().form_valid(form)
         self.save_link_formsets()
-        newly_granted = (form.instance.lead_scanning_enabled and not previous.get("lead_scanning_enabled")) or (
-            form.instance.allow_voucher_access and not previous.get("allow_voucher_access")
-        )
-        if newly_granted and queue_exhibitor_access_mail(self.request.event, self.object, self.request.user):
+        if access_newly_granted(form.instance, previous) and queue_exhibitor_access_mail(
+            self.request.event, self.object, self.request.user
+        ):
             messages.info(self.request, _("An access-credentials email was placed in the outbox."))
         return response
 

--- a/tests/test_access_keys.py
+++ b/tests/test_access_keys.py
@@ -1,0 +1,118 @@
+import pytest
+from django.core.exceptions import PermissionDenied
+from django.test import RequestFactory
+from django_scopes import scopes_disabled
+
+from exhibition.models import ExhibitorInfo
+from exhibition.views import ExhibitorListView, access_newly_granted
+
+
+class _User:
+    def __init__(self, allowed=True):
+        self.allowed = allowed
+        self.is_authenticated = True
+
+    def has_event_permission(self, organizer, event, permission, request=None):
+        return self.allowed
+
+
+def _download(event, partner_type=None, allowed=True):
+    request = RequestFactory().get("/", {"download": "yes"})
+    request.event = event
+    request.user = _User(allowed=allowed)
+    view = ExhibitorListView(partner_type=partner_type)
+    view.request = request
+    return view.get(request)
+
+
+@pytest.mark.django_db
+def test_download_requires_change_settings_permission(event):
+    with scopes_disabled():
+        ExhibitorInfo.objects.create(event=event, name="Acme", is_exhibitor=True)
+        with pytest.raises(PermissionDenied):
+            _download(event, partner_type="exhibitor", allowed=False)
+
+
+@pytest.mark.django_db
+def test_download_returns_csv_with_keys(event):
+    with scopes_disabled():
+        exhibitor = ExhibitorInfo.objects.create(
+            event=event, name="Acme", email="a@example.com", booth_id="B-9", is_exhibitor=True
+        )
+        response = _download(event, partner_type="exhibitor")
+        body = response.content.decode("utf-8")
+
+    assert response.status_code == 200
+    assert response["Content-Type"] == "text/csv; charset=utf-8"
+    assert response["Cache-Control"] == "no-store"
+    assert "exhibitor-keys.csv" in response["Content-Disposition"]
+    assert "Acme" in body
+    assert "B-9" in body
+    assert exhibitor.key in body
+
+
+@pytest.mark.django_db
+def test_download_respects_partner_type_filter(event):
+    with scopes_disabled():
+        sponsor = ExhibitorInfo.objects.create(event=event, name="SponsorCo", is_sponsor=True, is_exhibitor=False)
+        exhibitor = ExhibitorInfo.objects.create(event=event, name="ExhibitorCo", is_sponsor=False, is_exhibitor=True)
+
+        sponsor_body = _download(event, partner_type="sponsor").content.decode("utf-8")
+        exhibitor_body = _download(event, partner_type="exhibitor").content.decode("utf-8")
+
+    assert sponsor.key in sponsor_body
+    assert exhibitor.key not in sponsor_body
+    assert exhibitor.key in exhibitor_body
+    assert sponsor.key not in exhibitor_body
+
+
+@pytest.mark.django_db
+def test_download_filename_matches_partner_type(event):
+    with scopes_disabled():
+        ExhibitorInfo.objects.create(event=event, name="Acme", is_sponsor=True, is_exhibitor=True)
+        sponsor = _download(event, partner_type="sponsor")
+        combined = _download(event)
+
+    assert "sponsor-keys.csv" in sponsor["Content-Disposition"]
+    assert "partner-keys.csv" in combined["Content-Disposition"]
+
+
+def _flags(lead=False, voucher=False):
+    return ExhibitorInfo(lead_scanning_enabled=lead, allow_voucher_access=voucher)
+
+
+def test_access_granted_on_create_for_either_flag():
+    assert access_newly_granted(_flags(lead=True))
+    assert access_newly_granted(_flags(voucher=True))
+    assert not access_newly_granted(_flags())
+
+
+def test_access_granted_when_voucher_access_newly_enabled():
+    previous = {"lead_scanning_enabled": False, "allow_voucher_access": False}
+    assert access_newly_granted(_flags(voucher=True), previous)
+
+
+def test_access_granted_when_lead_scanning_newly_enabled():
+    previous = {"lead_scanning_enabled": False, "allow_voucher_access": False}
+    assert access_newly_granted(_flags(lead=True), previous)
+
+
+def test_access_not_granted_when_flag_was_already_enabled():
+    previous = {"lead_scanning_enabled": True, "allow_voucher_access": False}
+    assert not access_newly_granted(_flags(lead=True), previous)
+
+
+def test_access_granted_when_second_flag_added_to_existing_one():
+    previous = {"lead_scanning_enabled": True, "allow_voucher_access": False}
+    assert access_newly_granted(_flags(lead=True, voucher=True), previous)
+
+
+@pytest.mark.django_db
+def test_list_view_renders_normally_without_download_param(event):
+    request = RequestFactory().get("/")
+    request.event = event
+    request.user = _User()
+    view = ExhibitorListView(partner_type="exhibitor")
+    view.request = request
+    with scopes_disabled():
+        assert view.get_queryset().count() == 0


### PR DESCRIPTION
fixes #123 

https://github.com/user-attachments/assets/8c0c8ee6-630b-42e6-a1bd-5edb721842fe

## Summary by Sourcery

Add CSV export of exhibitor access keys and extend access-code email queuing to voucher-based access.

New Features:
- Allow organizers to download exhibitor access keys as a CSV from the exhibitors listing page.

Enhancements:
- Localize exhibitor names in the exported CSV using event-specific translations.
- Trigger access-credentials emails when voucher access is enabled or newly granted, not just when lead scanning is enabled.