### PR TITLE
chore: Access-code email template should live with the other templates

### DIFF
--- a/exhibition/forms.py
+++ b/exhibition/forms.py
@@ -1380,7 +1380,7 @@ class ExhibitionMailTemplatesForm(SettingsForm):
         mail_helpers.PROPOSAL_NEW: _("Request received (confirmation)"),
         mail_helpers.PROPOSAL_ACCEPTED: _("Request accepted"),
         mail_helpers.PROPOSAL_REJECTED: _("Request rejected"),
-        mail_helpers.EXHIBITOR_ACCESS: _("Exhibitor access code"),
+        mail_helpers.EXHIBITOR_ACCESS: _("Exhibitor lead scanning key"),
     }
 
     def __init__(self, *args, **kwargs):

--- a/exhibition/forms.py
+++ b/exhibition/forms.py
@@ -1380,6 +1380,7 @@ class ExhibitionMailTemplatesForm(SettingsForm):
         mail_helpers.PROPOSAL_NEW: _("Request received (confirmation)"),
         mail_helpers.PROPOSAL_ACCEPTED: _("Request accepted"),
         mail_helpers.PROPOSAL_REJECTED: _("Request rejected"),
+        mail_helpers.EXHIBITOR_ACCESS: _("Exhibitor access code"),
     }
 
     def __init__(self, *args, **kwargs):

--- a/exhibition/mail.py
+++ b/exhibition/mail.py
@@ -16,8 +16,9 @@ logger = logging.getLogger(__name__)
 PROPOSAL_NEW = "proposal_new"
 PROPOSAL_ACCEPTED = "proposal_accepted"
 PROPOSAL_REJECTED = "proposal_rejected"
+EXHIBITOR_ACCESS = "exhibitor_access"
 
-LIFECYCLE_ROLES = (PROPOSAL_NEW, PROPOSAL_ACCEPTED, PROPOSAL_REJECTED)
+LIFECYCLE_ROLES = (PROPOSAL_NEW, PROPOSAL_ACCEPTED, PROPOSAL_REJECTED, EXHIBITOR_ACCESS)
 
 PLACEHOLDER_DOCS = (
     ("{event_name}", _lazy("The event's name")),
@@ -25,6 +26,9 @@ PLACEHOLDER_DOCS = (
     ("{request_code}", _lazy("The request's unique code")),
     ("{request_url}", _lazy("Link for the applicant to view or edit the request")),
     ("{name}", _lazy("The applicant's name")),
+    ("{exhibitor_name}", _lazy("The exhibitor / sponsor name (access email only)")),
+    ("{booth_id}", _lazy("The exhibitor's booth ID (access email only)")),
+    ("{exhibitor_access_code}", _lazy("The exhibitor's secret access code (access email only)")),
 )
 
 _SETTINGS_PREFIX = "exhibition_mail_"
@@ -74,6 +78,18 @@ DEFAULT_TEMPLATES = {
                 "thank you for your interest in {event_name}. Unfortunately we are unable "
                 "to accept your request “{request_name}” this time.\n\n"
                 "We hope to see you at a future event.\n\n"
+                "Best regards,\n"
+                "The {event_name} team"
+            )
+        ),
+    ),
+    EXHIBITOR_ACCESS: (
+        LazyI18nString.from_gettext(gettext_noop("Your exhibitor access code for {event_name}")),
+        LazyI18nString.from_gettext(
+            gettext_noop(
+                "Hello,\n\n"
+                "your exhibitor account for {event_name} has been created.\n\n"
+                "You can sign in using the following access code: {exhibitor_access_code}\n\n"
                 "Best regards,\n"
                 "The {event_name} team"
             )
@@ -238,18 +254,13 @@ def queue_compose_emails(event, proposals, subject, body, *, scheduled_at=None, 
 
 def queue_exhibitor_access_email(event, exhibitor, *, requestor=None):
     """Queue the access-credentials email; ``None`` if no recipient or template."""
-    from .models import ExhibitionEmailQueue, ExhibitorSettings
+    from .models import ExhibitionEmailQueue
 
     to_email = (exhibitor.email or "").strip()
     if not to_email:
         return None
 
-    exhibitor_settings = ExhibitorSettings.objects.filter(event=event).first()
-    subject_tpl = (exhibitor_settings.exhibitors_access_mail_subject if exhibitor_settings else "") or ""
-    body_tpl = (exhibitor_settings.exhibitors_access_mail_body if exhibitor_settings else "") or ""
-    if not subject_tpl and not body_tpl:
-        return None
-
+    subject_tpl, body_tpl = get_email_template(event, EXHIBITOR_ACCESS)
     locale = recipient_locale(event)
     context = build_exhibitor_context(event, exhibitor)
 

--- a/exhibition/mail.py
+++ b/exhibition/mail.py
@@ -84,12 +84,13 @@ DEFAULT_TEMPLATES = {
         ),
     ),
     EXHIBITOR_ACCESS: (
-        LazyI18nString.from_gettext(gettext_noop("Your exhibitor access code for {event_name}")),
+        LazyI18nString.from_gettext(gettext_noop("Your exhibitor access code")),
         LazyI18nString.from_gettext(
             gettext_noop(
-                "Hello,\n\n"
-                "your exhibitor account for {event_name} has been created.\n\n"
-                "You can sign in using the following access code: {exhibitor_access_code}\n\n"
+                "Hello {exhibitor_name},\n\n"
+                "Your exhibitor account for {event_name} has been created.\n\n"
+                "Booth: {booth_id}\n"
+                "Access code: {exhibitor_access_code}\n\n"
                 "Best regards,\n"
                 "The {event_name} team"
             )
@@ -253,7 +254,7 @@ def queue_compose_emails(event, proposals, subject, body, *, scheduled_at=None, 
 
 
 def queue_exhibitor_access_email(event, exhibitor, *, requestor=None):
-    """Queue the access-credentials email; ``None`` if no recipient or template."""
+    """Queue the access-credentials email; ``None`` if the exhibitor has no email address."""
     from .models import ExhibitionEmailQueue
 
     to_email = (exhibitor.email or "").strip()

--- a/exhibition/mail.py
+++ b/exhibition/mail.py
@@ -84,15 +84,21 @@ DEFAULT_TEMPLATES = {
         ),
     ),
     EXHIBITOR_ACCESS: (
-        LazyI18nString.from_gettext(gettext_noop("Your exhibitor access code")),
+        LazyI18nString.from_gettext(gettext_noop("Lead Scanning Access for {event_name}")),
         LazyI18nString.from_gettext(
             gettext_noop(
                 "Hello {exhibitor_name},\n\n"
-                "Your exhibitor account for {event_name} has been created.\n\n"
-                "Booth: {booth_id}\n"
-                "Access code: {exhibitor_access_code}\n\n"
+                "Please use the information below to activate the **Lead Scanning app**:\n\n"
+                "1. Open the **Web App**: access.eventyay.com\n"
+                "2. Enter the **Device Token(s)**:\n"
+                "    - Device 1: {device_1_token}\n"
+                "    - Device 2: {device_2_token}\n\n"
+                "    *Please enter each Device Token manually. Each token is unique to one device. "
+                "If you set up additional devices, each device will require its own Device Token.*\n\n"
+                "3. Enter the **Exhibitor Key**: {exhibitor_access_code}\n\n"
+                "Please share these details with the team members who will be scanning leads at the event.\n\n"
                 "Best regards,\n"
-                "The {event_name} team"
+                "The {event_name} Team"
             )
         ),
     ),

--- a/exhibition/templates/exhibitors/settings.html
+++ b/exhibition/templates/exhibitors/settings.html
@@ -30,17 +30,6 @@
 {% endblock %}
 
 {% block exhibitors_content %}
-    {% trans "Your exhibitor access code" as default_subject %}
-    {% blocktrans asvar default_body %}Hello {exhibitor_name},
-
-Your exhibitor account for {event_name} has been created.
-
-Booth: {booth_id}
-Access code: {exhibitor_access_code}
-
-Best regards,
-The {event_name} team{% endblocktrans %}
-
     {% if active_tab == "call" %}
             <form action="" method="post" class="form-horizontal">
                 {% csrf_token %}
@@ -165,20 +154,13 @@ The {event_name} team{% endblocktrans %}
 
                 <fieldset>
                     <legend>{% trans "Exhibitor login" %}</legend>
-
-                    <div class="form-group">
-                        <label class="col-md-3 control-label">{% trans "Access code email subject" %}</label>
-                        <div class="col-md-9">
-                            <input type="text" name="exhibitors_access_mail_subject" class="form-control" value="{{ settings.exhibitors_access_mail_subject|default:default_subject }}">
-                        </div>
-                    </div>
-
-                    <div class="form-group">
-                        <label class="col-md-3 control-label">{% trans "Access code email body" %}</label>
-                        <div class="col-md-9">
-                            <textarea name="exhibitors_access_mail_body" class="form-control" rows="5">{{ settings.exhibitors_access_mail_body|default:default_body }}</textarea>
-                        </div>
-                    </div>
+                    <p>
+                        {% url 'plugins:exhibition:email.templates' organizer=request.event.organizer.slug event=request.event.slug as templates_url %}
+                        {% blocktrans trimmed %}
+                            The access-code email is edited with the other email templates in the
+                            <a href="{{ templates_url }}">Message center</a>.
+                        {% endblocktrans %}
+                    </p>
                 </fieldset>
 
                 <div class="form-group submit-group">

--- a/exhibition/templates/exhibitors/settings.html
+++ b/exhibition/templates/exhibitors/settings.html
@@ -152,17 +152,6 @@
                 </fieldset>
 
 
-                <fieldset>
-                    <legend>{% trans "Exhibitor login" %}</legend>
-                    <p>
-                        {% url 'plugins:exhibition:email.templates' organizer=request.event.organizer.slug event=request.event.slug as templates_url %}
-                        {% blocktrans trimmed %}
-                            The access-code email is edited with the other email templates in the
-                            <a href="{{ templates_url }}">Message center</a>.
-                        {% endblocktrans %}
-                    </p>
-                </fieldset>
-
                 <div class="form-group submit-group">
                     <div class="col-md-9 col-md-offset-3">
                         <button type="submit" class="btn btn-primary btn-save">

--- a/exhibition/templates/exhibitors/settings.html
+++ b/exhibition/templates/exhibitors/settings.html
@@ -151,6 +151,15 @@
                     </div>
                 </fieldset>
 
+                <fieldset>
+                    <legend>{% trans "Exhibitor login" %}</legend>
+                    <p>
+                        {% trans "The access-code email sent to exhibitors is now edited together with the plugin's other email templates." %}
+                        <a href="{% url 'plugins:exhibition:email.templates' organizer=request.event.organizer.slug event=request.event.slug %}">
+                            {% trans "Edit email templates" %}
+                        </a>
+                    </p>
+                </fieldset>
 
                 <div class="form-group submit-group">
                     <div class="col-md-9 col-md-offset-3">

--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -257,8 +257,6 @@ class SettingsView(EventPermissionRequiredMixin, ListView):
 
         if action == "save_exhibitor_settings":
             settings.allowed_fields = request.POST.getlist("exhibitors_access_voucher")
-            settings.exhibitors_access_mail_subject = request.POST.get("exhibitors_access_mail_subject", "")
-            settings.exhibitors_access_mail_body = request.POST.get("exhibitors_access_mail_body", "")
             settings.save()
             messages.success(self.request, _("Settings have been saved."))
             return redirect(self.get_settings_url("exhibitors"))
@@ -1865,6 +1863,7 @@ class EmailTemplatesView(EventPermissionRequiredMixin, TemplateView):
                 (mail_helpers.PROPOSAL_NEW, _("Request received (confirmation)")),
                 (mail_helpers.PROPOSAL_ACCEPTED, _("Request accepted")),
                 (mail_helpers.PROPOSAL_REJECTED, _("Request rejected")),
+                (mail_helpers.EXHIBITOR_ACCESS, _("Exhibitor access code")),
             )
         ]
         context["email_placeholders"] = mail_helpers.PLACEHOLDER_DOCS

--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -1863,7 +1863,7 @@ class EmailTemplatesView(EventPermissionRequiredMixin, TemplateView):
                 (mail_helpers.PROPOSAL_NEW, _("Request received (confirmation)")),
                 (mail_helpers.PROPOSAL_ACCEPTED, _("Request accepted")),
                 (mail_helpers.PROPOSAL_REJECTED, _("Request rejected")),
-                (mail_helpers.EXHIBITOR_ACCESS, _("Exhibitor access code")),
+                (mail_helpers.EXHIBITOR_ACCESS, _("Exhibitor lead scanning key")),
             )
         ]
         context["email_placeholders"] = mail_helpers.PLACEHOLDER_DOCS

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -16,7 +16,6 @@ from exhibition.models import (
     ExhibitionProposal,
     ExhibitionProposalState,
     ExhibitorInfo,
-    ExhibitorSettings,
     SponsorGroup,
 )
 from exhibition.views import (
@@ -193,12 +192,14 @@ def test_outbox_and_sent_querysets_do_not_overlap(mail_event, proposal):
 
 @pytest.mark.django_db
 def test_access_email_resolves_placeholders_and_keeps_newlines(mail_event, exhibitor):
-    with scopes_disabled():
-        ExhibitorSettings.objects.create(
-            event=mail_event,
-            exhibitors_access_mail_subject="Access for {event_name}",
-            exhibitors_access_mail_body="Hello {exhibitor_name},\n\nBooth: {booth_id}\nCode: {exhibitor_access_code}",
-        )
+    mail_event.settings.set(
+        mail_helpers.subject_settings_key(mail_helpers.EXHIBITOR_ACCESS),
+        "Access for {event_name}",
+    )
+    mail_event.settings.set(
+        mail_helpers.body_settings_key(mail_helpers.EXHIBITOR_ACCESS),
+        "Hello {exhibitor_name},\n\nBooth: {booth_id}\nCode: {exhibitor_access_code}",
+    )
 
     queued = mail_helpers.queue_exhibitor_access_email(mail_event, exhibitor)
 
@@ -212,25 +213,17 @@ def test_access_email_resolves_placeholders_and_keeps_newlines(mail_event, exhib
 
 
 @pytest.mark.django_db
-def test_access_email_returns_none_without_template(mail_event, exhibitor):
-    with scopes_disabled():
-        ExhibitorSettings.objects.create(
-            event=mail_event,
-            exhibitors_access_mail_subject="",
-            exhibitors_access_mail_body="",
-        )
+def test_access_email_falls_back_to_default_template(mail_event, exhibitor):
+    queued = mail_helpers.queue_exhibitor_access_email(mail_event, exhibitor)
 
-    assert mail_helpers.queue_exhibitor_access_email(mail_event, exhibitor) is None
+    assert queued is not None
+    assert "Acme Corp" in queued.body
+    assert exhibitor.key in queued.body
 
 
 @pytest.mark.django_db
 def test_access_email_returns_none_without_exhibitor_email(mail_event):
     with scopes_disabled():
-        ExhibitorSettings.objects.create(
-            event=mail_event,
-            exhibitors_access_mail_subject="Access",
-            exhibitors_access_mail_body="Code: {exhibitor_access_code}",
-        )
         exhibitor = ExhibitorInfo.objects.create(event=mail_event, name="No Email Co", email="")
 
     assert mail_helpers.queue_exhibitor_access_email(mail_event, exhibitor) is None


### PR DESCRIPTION
fixes #124


https://github.com/user-attachments/assets/03f86443-1806-41ba-a319-17948ba2f1ad


## Summary by Sourcery

Move exhibitor access-code emails into the shared email template system and message center.

New Features:
- Add a dedicated 'exhibitor access code' email template type managed via the common mail template infrastructure.

Enhancements:
- Remove per-event inline configuration of exhibitor access email subject/body from exhibitor settings in favor of centralized templates.
- Document within exhibitor settings that access-code emails are now edited in the Message center alongside other templates.
- Extend email placeholder documentation to cover exhibitor-specific placeholders used by the new access email template.