### PR TITLE
Match exhibitor form fields UI to ticket order form

### DIFF
--- a/exhibition/forms.py
+++ b/exhibition/forms.py
@@ -57,24 +57,24 @@ class ExhibitorInfoForm(I18nModelForm):
     )
     header_image_url = forms.URLField(
         required=False,
-        label=_("Header Image URL"),
+        label=_("Header image URL"),
         help_text=_("Use an external image URL instead of uploading a header image file."),
     )
     sponsor_group = forms.ModelChoiceField(
         queryset=SponsorGroup.objects.none(),
         required=False,
-        label=_("Sponsor Group"),
+        label=_("Sponsor group"),
     )
     allow_voucher_access = forms.BooleanField(
         required=False,
-        label=_("Allowed To Access Voucher Data"),
+        label=_("Allowed to access voucher data"),
     )
     allow_lead_access = forms.BooleanField(
         required=False,
-        label=_("Allowed To Access Scanned Lead Data"),
+        label=_("Allowed to access scanned lead data"),
     )
     lead_scanning_scope_by_device = forms.TypedChoiceField(
-        label=_("Lead Scanning Behavior"),
+        label=_("Lead scanning behavior"),
         choices=(
             (
                 False,
@@ -142,19 +142,19 @@ class ExhibitorInfoForm(I18nModelForm):
             "lead_scanning_scope_by_device",
         ]
         labels = {
-            "name": _("Organization Name"),
-            "description": _("Organization Description"),
-            "email": _("Contact Email"),
-            "contact_url": _("Contact Page URL"),
-            "video_url": _("Promotional Video URL"),
-            "slides": _("Promotional Slides"),
+            "name": _("Organization name"),
+            "description": _("Organization description"),
+            "email": _("Contact email"),
+            "contact_url": _("Contact page URL"),
+            "video_url": _("Promotional video URL"),
+            "slides": _("Promotional slides"),
             "logo": _("Logo"),
-            "header_image": _("Header Image"),
-            "url": _("Organization Website"),
-            "is_exhibitor": _("Mark This Partner As An Exhibitor"),
-            "is_sponsor": _("Mark This Partner As An Event Sponsor"),
-            "booth_name": _("Preferred Booth Name"),
-            "lead_scanning_enabled": _("Allow Lead Scanning"),
+            "header_image": _("Header image"),
+            "url": _("Organization website"),
+            "is_exhibitor": _("Mark this partner as an exhibitor"),
+            "is_sponsor": _("Mark this partner as an event sponsor"),
+            "booth_name": _("Preferred booth name"),
+            "lead_scanning_enabled": _("Allow lead scanning"),
         }
 
     PROFILE_SETTING_FIELD_MAP = {
@@ -447,7 +447,7 @@ class SponsorGroupForm(I18nModelForm):
         localized_fields = "__all__"
         fields = ["name", "level"]
         labels = {
-            "name": _("Group Name"),
+            "name": _("Group name"),
         }
 
     def __init__(self, *args, **kwargs):
@@ -652,7 +652,7 @@ class ExhibitionProposalForm(ExhibitionQuestionFieldsMixin, I18nModelForm):
     )
     header_image_url = forms.URLField(
         required=False,
-        label=_("Header Image URL"),
+        label=_("Header image URL"),
         help_text=_("Use an external image URL instead of uploading a header image file."),
     )
 
@@ -696,17 +696,17 @@ class ExhibitionProposalForm(ExhibitionQuestionFieldsMixin, I18nModelForm):
             "notes",
         ]
         labels = {
-            "name": _("Organization Name"),
-            "description": _("Organization Description"),
-            "email": _("Contact Email"),
-            "contact_url": _("Contact Page URL"),
-            "video_url": _("Promotional Video URL"),
-            "slides": _("Promotional Slides"),
+            "name": _("Organization name"),
+            "description": _("Organization description"),
+            "email": _("Contact email"),
+            "contact_url": _("Contact page URL"),
+            "video_url": _("Promotional video URL"),
+            "slides": _("Promotional slides"),
             "logo": _("Logo"),
-            "header_image": _("Header Image"),
-            "url": _("Organization Website"),
-            "booth_name": _("Preferred Booth Name"),
-            "notes": _("Message To The Organizers"),
+            "header_image": _("Header image"),
+            "url": _("Organization website"),
+            "booth_name": _("Preferred booth name"),
+            "notes": _("Message to the organizers"),
         }
         widgets = {
             "notes": forms.Textarea(attrs={"rows": 4}),
@@ -980,7 +980,7 @@ class ExhibitionProposalReviewForm(I18nModelForm):
     sponsor_group = forms.ModelChoiceField(
         queryset=SponsorGroup.objects.none(),
         required=False,
-        label=_("Sponsor Group"),
+        label=_("Sponsor group"),
     )
 
     class Meta:
@@ -995,11 +995,11 @@ class ExhibitionProposalReviewForm(I18nModelForm):
             "review_notes",
         ]
         labels = {
-            "is_exhibitor": _("Approve As Exhibitor"),
-            "is_sponsor": _("Approve As Sponsor"),
+            "is_exhibitor": _("Approve as exhibitor"),
+            "is_sponsor": _("Approve as sponsor"),
             "booth_id": _("Booth ID"),
-            "booth_name": _("Booth Name"),
-            "review_notes": _("Internal Review Notes"),
+            "booth_name": _("Booth name"),
+            "review_notes": _("Internal review notes"),
         }
         widgets = {
             "review_notes": forms.Textarea(attrs={"rows": 4}),
@@ -1029,7 +1029,7 @@ class ExhibitionProposalReviewNotesForm(I18nModelForm):
         localized_fields = "__all__"
         fields = ["review_notes"]
         labels = {
-            "review_notes": _("Internal Review Notes"),
+            "review_notes": _("Internal review notes"),
         }
         widgets = {
             "review_notes": forms.Textarea(attrs={"rows": 4}),
@@ -1055,9 +1055,9 @@ class ExhibitionQuestionForm(I18nModelForm):
             "active",
         ]
         labels = {
-            "variant": _("Field Type"),
-            "question": _("Custom Question"),
-            "help_text": _("Help Text"),
+            "variant": _("Field type"),
+            "question": _("Custom question"),
+            "help_text": _("Help text"),
             "required": _("Required"),
             "active": _("Active"),
         }

--- a/exhibition/forms.py
+++ b/exhibition/forms.py
@@ -726,9 +726,7 @@ class ExhibitionProposalForm(ExhibitionQuestionFieldsMixin, I18nModelForm):
         if self.event:
             self.exhibition_settings = ExhibitorSettings.objects.get_or_create(event=self.event)[0]
             self.proposal_field_settings = self.exhibition_settings.normalized_proposal_field_settings
-            self.active_proposal_fields = {
-                key: value["active"] for key, value in self.proposal_field_settings.items()
-            }
+            self.active_proposal_fields = {key: value["active"] for key, value in self.proposal_field_settings.items()}
             self.required_proposal_fields = {
                 key: value["required"] for key, value in self.proposal_field_settings.items()
             }
@@ -791,9 +789,7 @@ class ExhibitionProposalForm(ExhibitionQuestionFieldsMixin, I18nModelForm):
             return []
         entries = []
         for key in PROPOSAL_DEFAULT_FIELD_KEYS:
-            entries.append(
-                (self.proposal_field_settings[key]["position"], 0, key, self.setting_field_map.get(key, ()))
-            )
+            entries.append((self.proposal_field_settings[key]["position"], 0, key, self.setting_field_map.get(key, ())))
         for field_name, field in self.fields.items():
             question = getattr(field, "question", None)
             if question is not None:

--- a/exhibition/forms.py
+++ b/exhibition/forms.py
@@ -67,14 +67,14 @@ class ExhibitorInfoForm(I18nModelForm):
     )
     allow_voucher_access = forms.BooleanField(
         required=False,
-        label=_("Allowed to access voucher data"),
+        label=_("Allowed To Access Voucher Data"),
     )
     allow_lead_access = forms.BooleanField(
         required=False,
-        label=_("Allowed to access scanned lead data"),
+        label=_("Allowed To Access Scanned Lead Data"),
     )
     lead_scanning_scope_by_device = forms.TypedChoiceField(
-        label=_("Lead scanning behavior"),
+        label=_("Lead Scanning Behavior"),
         choices=(
             (
                 False,
@@ -144,17 +144,17 @@ class ExhibitorInfoForm(I18nModelForm):
         labels = {
             "name": _("Organization Name"),
             "description": _("Organization Description"),
-            "email": _("Contact email"),
+            "email": _("Contact Email"),
             "contact_url": _("Contact Page URL"),
             "video_url": _("Promotional Video URL"),
             "slides": _("Promotional Slides"),
             "logo": _("Logo"),
             "header_image": _("Header Image"),
             "url": _("Organization Website"),
-            "is_exhibitor": _("Mark this partner as an exhibitor"),
-            "is_sponsor": _("Mark this partner as an event sponsor"),
-            "booth_name": _("Preferred booth name"),
-            "lead_scanning_enabled": _("Allow lead scanning"),
+            "is_exhibitor": _("Mark This Partner As An Exhibitor"),
+            "is_sponsor": _("Mark This Partner As An Event Sponsor"),
+            "booth_name": _("Preferred Booth Name"),
+            "lead_scanning_enabled": _("Allow Lead Scanning"),
         }
 
     PROFILE_SETTING_FIELD_MAP = {
@@ -698,15 +698,15 @@ class ExhibitionProposalForm(ExhibitionQuestionFieldsMixin, I18nModelForm):
         labels = {
             "name": _("Organization Name"),
             "description": _("Organization Description"),
-            "email": _("Contact email"),
+            "email": _("Contact Email"),
             "contact_url": _("Contact Page URL"),
             "video_url": _("Promotional Video URL"),
             "slides": _("Promotional Slides"),
             "logo": _("Logo"),
             "header_image": _("Header Image"),
             "url": _("Organization Website"),
-            "booth_name": _("Preferred booth name"),
-            "notes": _("Message to the organizers"),
+            "booth_name": _("Preferred Booth Name"),
+            "notes": _("Message To The Organizers"),
         }
         widgets = {
             "notes": forms.Textarea(attrs={"rows": 4}),
@@ -720,13 +720,18 @@ class ExhibitionProposalForm(ExhibitionQuestionFieldsMixin, I18nModelForm):
         super().__init__(*args, **kwargs)
         self.event = event or getattr(instance, "event", None)
         self.exhibition_settings = None
+        self.proposal_field_settings = {}
         self.active_proposal_fields = {}
         self.required_proposal_fields = {}
         if self.event:
             self.exhibition_settings = ExhibitorSettings.objects.get_or_create(event=self.event)[0]
-            proposal_field_settings = self.exhibition_settings.normalized_proposal_field_settings
-            self.active_proposal_fields = {key: value["active"] for key, value in proposal_field_settings.items()}
-            self.required_proposal_fields = {key: value["required"] for key, value in proposal_field_settings.items()}
+            self.proposal_field_settings = self.exhibition_settings.normalized_proposal_field_settings
+            self.active_proposal_fields = {
+                key: value["active"] for key, value in self.proposal_field_settings.items()
+            }
+            self.required_proposal_fields = {
+                key: value["required"] for key, value in self.proposal_field_settings.items()
+            }
         for field_name in ("logo", "header_image"):
             if field_name in self.fields:
                 self.fields[field_name].widget.attrs.setdefault("accept", "image/*")
@@ -781,27 +786,52 @@ class ExhibitionProposalForm(ExhibitionQuestionFieldsMixin, I18nModelForm):
                 else:
                     field.required = is_required
 
-    def apply_proposal_field_order(self):
+    def _ordered_proposal_entries(self):
         if not self.exhibition_settings:
-            return
-        field_settings = self.exhibition_settings.normalized_proposal_field_settings
-        formset_keys = set(PROPOSAL_FORMSET_FIELD_KEYS)
+            return []
         entries = []
         for key in PROPOSAL_DEFAULT_FIELD_KEYS:
-            if key in formset_keys:
-                continue
-            entries.append((field_settings[key]["position"], 0, self.setting_field_map.get(key, ())))
+            entries.append(
+                (self.proposal_field_settings[key]["position"], 0, key, self.setting_field_map.get(key, ()))
+            )
         for field_name, field in self.fields.items():
             question = getattr(field, "question", None)
             if question is not None:
-                entries.append((question.position, 1, (field_name,)))
+                entries.append((question.position, 1, f"question_{question.pk}", (field_name,)))
         entries.sort(key=lambda entry: (entry[0], entry[1]))
-        ordered_field_names = []
-        for _position, _kind, field_names in entries:
-            for field_name in field_names:
-                if field_name in self.fields:
-                    ordered_field_names.append(field_name)
+        return entries
+
+    def apply_proposal_field_order(self):
+        if not self.exhibition_settings:
+            return
+        ordered_field_names = [
+            field_name
+            for _position, _kind, _key, field_names in self._ordered_proposal_entries()
+            for field_name in field_names
+            if field_name in self.fields
+        ]
         self.order_fields(ordered_field_names)
+
+    @property
+    def proposal_items(self):
+        if not self.exhibition_settings:
+            return [{"kind": "field", "key": field_name, "field": self[field_name]} for field_name in self.fields]
+        formset_keys = set(PROPOSAL_FORMSET_FIELD_KEYS)
+        composite_keys = {"slides", "logo", "header_image"}
+        items = []
+        for _position, _kind, key, field_names in self._ordered_proposal_entries():
+            if key in formset_keys:
+                if self.field_setting_is_active(key):
+                    items.append({"kind": key, "key": key})
+                continue
+            visible_field_names = [name for name in field_names if name in self.fields]
+            if not visible_field_names:
+                continue
+            if key in composite_keys:
+                items.append({"kind": key, "key": key})
+            else:
+                items.append({"kind": "field", "key": key, "field": self[visible_field_names[0]]})
+        return items
 
     def field_setting_is_active(self, key):
         return self.active_proposal_fields.get(key, True)
@@ -969,11 +999,11 @@ class ExhibitionProposalReviewForm(I18nModelForm):
             "review_notes",
         ]
         labels = {
-            "is_exhibitor": _("Approve as exhibitor"),
-            "is_sponsor": _("Approve as sponsor"),
+            "is_exhibitor": _("Approve As Exhibitor"),
+            "is_sponsor": _("Approve As Sponsor"),
             "booth_id": _("Booth ID"),
-            "booth_name": _("Booth name"),
-            "review_notes": _("Internal review notes"),
+            "booth_name": _("Booth Name"),
+            "review_notes": _("Internal Review Notes"),
         }
         widgets = {
             "review_notes": forms.Textarea(attrs={"rows": 4}),
@@ -1003,7 +1033,7 @@ class ExhibitionProposalReviewNotesForm(I18nModelForm):
         localized_fields = "__all__"
         fields = ["review_notes"]
         labels = {
-            "review_notes": _("Internal review notes"),
+            "review_notes": _("Internal Review Notes"),
         }
         widgets = {
             "review_notes": forms.Textarea(attrs={"rows": 4}),
@@ -1029,9 +1059,9 @@ class ExhibitionQuestionForm(I18nModelForm):
             "active",
         ]
         labels = {
-            "variant": _("Field type"),
-            "question": _("Custom question"),
-            "help_text": _("Help text"),
+            "variant": _("Field Type"),
+            "question": _("Custom Question"),
+            "help_text": _("Help Text"),
             "required": _("Required"),
             "active": _("Active"),
         }

--- a/exhibition/forms.py
+++ b/exhibition/forms.py
@@ -222,11 +222,15 @@ class ExhibitorInfoForm(I18nModelForm):
     def _apply_profile_field_settings(self):
         for key, field_names in self.PROFILE_SETTING_FIELD_MAP.items():
             if self.profile_key_is_active(key):
+                setting = self.profile_field_settings[key]
+                first_field = self.fields.get(field_names[0]) if field_names else None
+                if first_field is not None and setting.get("custom_label"):
+                    first_field.label = setting["custom_label"]
                 if key in self.PROFILE_COMPOSITE_KEYS or key == "booth_name":
                     continue
                 for field_name in field_names:
                     if field_name in self.fields:
-                        self.fields[field_name].required = self.profile_field_settings[key]["required"]
+                        self.fields[field_name].required = setting["required"]
             else:
                 self._drop_fields(field_names)
 
@@ -772,10 +776,16 @@ class ExhibitionProposalForm(ExhibitionQuestionFieldsMixin, I18nModelForm):
                     self.fields.pop(field_name, None)
                 continue
 
-            for field_name in form_fields:
+            setting = self.proposal_field_settings.get(key, {})
+            for index, field_name in enumerate(form_fields):
                 field = self.fields.get(field_name)
                 if field is None:
                     continue
+                if index == 0:
+                    if setting.get("custom_label"):
+                        field.label = setting["custom_label"]
+                    if setting.get("custom_help_text"):
+                        field.help_text = setting["custom_help_text"]
                 field._required = is_required
                 if key in file_field_keys or key == "booth_name":
                     continue
@@ -1034,6 +1044,29 @@ class ExhibitionProposalReviewNotesForm(I18nModelForm):
         widgets = {
             "review_notes": forms.Textarea(attrs={"rows": 4}),
         }
+
+
+class ExhibitionDefaultFieldForm(forms.Form):
+    label = forms.CharField(
+        required=False,
+        max_length=200,
+        label=_("Field label"),
+    )
+    help_text = forms.CharField(
+        required=False,
+        max_length=500,
+        label=_("Help text"),
+        help_text=_("Shown below the field on the exhibitor form."),
+        widget=forms.Textarea(attrs={"rows": 3}),
+    )
+
+    def __init__(self, *args, **kwargs):
+        self.field_setting = kwargs.pop("field_setting")
+        super().__init__(*args, **kwargs)
+        self.fields["label"].help_text = _("Leave empty to use the default: %(label)s") % {
+            "label": self.field_setting["default_label"]
+        }
+        self.fields["label"].widget.attrs.setdefault("placeholder", self.field_setting["default_label"])
 
 
 class ExhibitionQuestionForm(I18nModelForm):

--- a/exhibition/forms.py
+++ b/exhibition/forms.py
@@ -144,7 +144,7 @@ class ExhibitorInfoForm(I18nModelForm):
         labels = {
             "name": _("Organization name"),
             "description": _("Organization description"),
-            "email": _("Contact email"),
+            "email": _("E-mail"),
             "contact_url": _("Contact page URL"),
             "video_url": _("Promotional video URL"),
             "slides": _("Promotional slides"),
@@ -698,7 +698,7 @@ class ExhibitionProposalForm(ExhibitionQuestionFieldsMixin, I18nModelForm):
         labels = {
             "name": _("Organization name"),
             "description": _("Organization description"),
-            "email": _("Contact email"),
+            "email": _("E-mail"),
             "contact_url": _("Contact page URL"),
             "video_url": _("Promotional video URL"),
             "slides": _("Promotional slides"),

--- a/exhibition/models.py
+++ b/exhibition/models.py
@@ -120,41 +120,39 @@ def proposal_slides_path(instance, filename):
 PROPOSAL_DEFAULT_FIELDS = (
     {
         "key": "name",
-        "label": _("Organization Name"),
+        "label": _("Organization name"),
         "active": True,
         "required": True,
         "active_locked": True,
         "required_locked": True,
     },
-    {"key": "description", "label": _("Organization Description"), "active": True},
-    {"key": "email", "label": _("Contact Email"), "active": False},
-    {"key": "url", "label": _("Organization Website"), "active": False},
-    {"key": "contact_url", "label": _("Contact Page URL"), "active": False},
-    {"key": "video_url", "label": _("Promotional Video URL"), "active": False},
-    {"key": "slides", "label": _("Promotional Slides"), "active": False},
+    {"key": "description", "label": _("Organization description"), "active": True},
+    {"key": "email", "label": _("Contact email"), "active": False},
+    {"key": "url", "label": _("Organization website"), "active": False},
+    {"key": "contact_url", "label": _("Contact page URL"), "active": False},
+    {"key": "video_url", "label": _("Promotional video URL"), "active": False},
+    {"key": "slides", "label": _("Promotional slides"), "active": False},
     {"key": "logo", "label": _("Logo"), "active": False},
     {
         "key": "header_image",
-        "label": _("Header Image"),
+        "label": _("Header image"),
         "active": False,
     },
-    {"key": "booth_name", "label": _("Preferred Booth Name"), "active": False},
+    {"key": "booth_name", "label": _("Preferred booth name"), "active": False},
     {
         "key": "notes",
-        "label": _("Message To The Organizers"),
+        "label": _("Message to the organizers"),
         "active": False,
     },
     {
         "key": "social_links",
-        "label": _("Social Media"),
+        "label": _("Social media"),
         "active": False,
-        "supports_required": False,
     },
     {
         "key": "extra_links",
-        "label": _("Extra Links"),
+        "label": _("Extra links"),
         "active": False,
-        "supports_required": False,
     },
 )
 
@@ -262,7 +260,7 @@ class ExhibitorSettings(models.Model):
 
 class SponsorGroup(models.Model):
     event = models.ForeignKey(Event, on_delete=models.CASCADE, related_name="sponsor_groups")
-    name = I18nCharField(max_length=120, verbose_name=_("Group Name"))
+    name = I18nCharField(max_length=120, verbose_name=_("Group name"))
     level = models.PositiveIntegerField(default=1, db_index=True, verbose_name=_("Level"))
     show_on_front_page = models.BooleanField(
         default=False,
@@ -298,7 +296,7 @@ class ExhibitorInfo(models.Model):
     logo = models.ImageField(upload_to=exhibitor_logo_path, null=True, blank=True)
     logo_url = models.URLField(verbose_name=_("Logo URL"), null=True, blank=True)
     header_image = models.ImageField(upload_to=exhibitor_header_image_path, null=True, blank=True)
-    header_image_url = models.URLField(verbose_name=_("Header Image URL"), null=True, blank=True)
+    header_image_url = models.URLField(verbose_name=_("Header image URL"), null=True, blank=True)
     key = models.CharField(
         max_length=8,
         default=generate_key,
@@ -320,7 +318,7 @@ class ExhibitorInfo(models.Model):
     )
     booth_name = I18nCharField(
         max_length=100,
-        verbose_name=_("Booth Name"),
+        verbose_name=_("Booth name"),
         blank=True,
     )
     lead_scanning_enabled = models.BooleanField(default=False)
@@ -498,7 +496,7 @@ class ExhibitionProposal(models.Model):
     logo = models.ImageField(upload_to=proposal_logo_path, null=True, blank=True)
     logo_url = models.URLField(verbose_name=_("Logo URL"), null=True, blank=True)
     header_image = models.ImageField(upload_to=proposal_header_image_path, null=True, blank=True)
-    header_image_url = models.URLField(verbose_name=_("Header Image URL"), null=True, blank=True)
+    header_image_url = models.URLField(verbose_name=_("Header image URL"), null=True, blank=True)
     is_sponsor = models.BooleanField(default=False)
     sponsor_group = models.ForeignKey(
         SponsorGroup,
@@ -515,18 +513,18 @@ class ExhibitionProposal(models.Model):
     )
     booth_name = I18nCharField(
         max_length=100,
-        verbose_name=_("Booth Name"),
+        verbose_name=_("Booth name"),
         blank=True,
     )
     notes = models.TextField(
         null=True,
         blank=True,
-        verbose_name=_("Message To The Organizers"),
+        verbose_name=_("Message to the organizers"),
     )
     review_notes = models.TextField(
         null=True,
         blank=True,
-        verbose_name=_("Internal Review Notes"),
+        verbose_name=_("Internal review notes"),
     )
     submitted = models.DateTimeField(null=True, blank=True)
     profile_edited_at = models.DateTimeField(null=True, blank=True)
@@ -686,7 +684,7 @@ class ExhibitionQuestion(models.Model):
         choices=ExhibitionQuestionVariant.choices,
         default=ExhibitionQuestionVariant.STRING,
     )
-    question = I18nCharField(max_length=800, verbose_name=_("Custom Question"))
+    question = I18nCharField(max_length=800, verbose_name=_("Custom question"))
     help_text = I18nCharField(
         null=True,
         blank=True,
@@ -769,7 +767,7 @@ class Lead(models.Model):
     booth_id = models.CharField(max_length=100, editable=True)
     booth_name = models.CharField(
         max_length=100,
-        verbose_name=_("Booth Name"),
+        verbose_name=_("Booth name"),
     )
 
     def __str__(self):

--- a/exhibition/models.py
+++ b/exhibition/models.py
@@ -127,7 +127,7 @@ PROPOSAL_DEFAULT_FIELDS = (
         "required_locked": True,
     },
     {"key": "description", "label": _("Organization Description"), "active": True},
-    {"key": "email", "label": _("Contact email"), "active": False},
+    {"key": "email", "label": _("Contact Email"), "active": False},
     {"key": "url", "label": _("Organization Website"), "active": False},
     {"key": "contact_url", "label": _("Contact Page URL"), "active": False},
     {"key": "video_url", "label": _("Promotional Video URL"), "active": False},
@@ -138,10 +138,10 @@ PROPOSAL_DEFAULT_FIELDS = (
         "label": _("Header Image"),
         "active": False,
     },
-    {"key": "booth_name", "label": _("Preferred booth name"), "active": False},
+    {"key": "booth_name", "label": _("Preferred Booth Name"), "active": False},
     {
         "key": "notes",
-        "label": _("Message to the organizers"),
+        "label": _("Message To The Organizers"),
         "active": False,
     },
     {
@@ -521,12 +521,12 @@ class ExhibitionProposal(models.Model):
     notes = models.TextField(
         null=True,
         blank=True,
-        verbose_name=_("Message to the organizers"),
+        verbose_name=_("Message To The Organizers"),
     )
     review_notes = models.TextField(
         null=True,
         blank=True,
-        verbose_name=_("Internal review notes"),
+        verbose_name=_("Internal Review Notes"),
     )
     submitted = models.DateTimeField(null=True, blank=True)
     profile_edited_at = models.DateTimeField(null=True, blank=True)
@@ -686,7 +686,7 @@ class ExhibitionQuestion(models.Model):
         choices=ExhibitionQuestionVariant.choices,
         default=ExhibitionQuestionVariant.STRING,
     )
-    question = I18nCharField(max_length=800, verbose_name=_("Custom question"))
+    question = I18nCharField(max_length=800, verbose_name=_("Custom Question"))
     help_text = I18nCharField(
         null=True,
         blank=True,

--- a/exhibition/models.py
+++ b/exhibition/models.py
@@ -168,8 +168,24 @@ def default_proposal_field_settings():
             "active": field.get("active", True),
             "required": field.get("required", False),
             "position": index,
+            "label": None,
+            "help_text": None,
         }
         for index, field in enumerate(PROPOSAL_DEFAULT_FIELDS)
+    }
+
+
+def storable_proposal_field_settings(normalized):
+    """Strip the derived keys added by normalization so only raw overrides are persisted."""
+    return {
+        key: {
+            "active": value["active"],
+            "required": value["required"],
+            "position": value["position"],
+            "label": value["custom_label"],
+            "help_text": value["custom_help_text"],
+        }
+        for key, value in normalized.items()
     }
 
 
@@ -229,6 +245,13 @@ class ExhibitorSettings(models.Model):
             normalized[key]["active"] = bool(stored_field.get("active", normalized[key]["active"]))
             normalized[key]["required"] = bool(stored_field.get("required", normalized[key]["required"]))
             normalized[key]["position"] = stored_field.get("position", index)
+            custom_label = (stored_field.get("label") or "").strip() or None
+            custom_help_text = (stored_field.get("help_text") or "").strip() or None
+            normalized[key]["custom_label"] = custom_label
+            normalized[key]["custom_help_text"] = custom_help_text
+            normalized[key]["label"] = custom_label or field["label"]
+            normalized[key]["help_text"] = custom_help_text or ""
+            normalized[key]["default_label"] = field["label"]
             if field.get("active_locked"):
                 normalized[key]["active"] = True
             if field.get("required_locked"):

--- a/exhibition/static/exhibition/js/call-questions.js
+++ b/exhibition/static/exhibition/js/call-questions.js
@@ -1,0 +1,32 @@
+document.addEventListener("DOMContentLoaded", () => {
+    const table = document.querySelector(".dragsort-table");
+    if (!table) return;
+
+    const syncRequiredDropdown = (row) => {
+        const activeInput = row.querySelector(".field-active-input");
+        const wrapper = row.querySelector(".required-status-wrapper");
+        const dropdown = wrapper ? wrapper.querySelector(".required-status-dropdown") : null;
+        if (!activeInput || !wrapper || !dropdown || dropdown.dataset.locked === "1") return;
+
+        const isActive = activeInput.checked;
+        dropdown.disabled = !isActive;
+        wrapper.classList.toggle("is-disabled", !isActive);
+    };
+
+    table.querySelectorAll("tbody tr").forEach((row) => {
+        const activeInput = row.querySelector(".field-active-input");
+        if (activeInput) {
+            activeInput.addEventListener("change", () => syncRequiredDropdown(row));
+        }
+    });
+
+    table.querySelectorAll(".required-status-dropdown").forEach((dropdown) => {
+        dropdown.addEventListener("change", () => {
+            dropdown.dataset.current = dropdown.value;
+            const wrapper = dropdown.closest(".required-status-wrapper");
+            if (wrapper) {
+                wrapper.dataset.current = dropdown.value;
+            }
+        });
+    });
+});

--- a/exhibition/templates/exhibitors/call_default_field_form.html
+++ b/exhibition/templates/exhibitors/call_default_field_form.html
@@ -1,0 +1,27 @@
+{% extends "exhibitors/base.html" %}
+{% load i18n %}
+{% load bootstrap3 %}
+
+{% block title %}{{ request.event.name }} - {% trans "Form field" %}{% endblock %}
+
+{% block exhibitors_header %}
+    <h1>{% trans "Form field" %}</h1>
+{% endblock %}
+
+{% block exhibitors_content %}
+    <form action="" method="post" class="form-horizontal">
+        {% csrf_token %}
+        {% bootstrap_form_errors form %}
+        <fieldset>
+            <legend>{{ field_setting.default_label }}</legend>
+            {% bootstrap_field form.label layout="control" %}
+            {% bootstrap_field form.help_text layout="control" %}
+        </fieldset>
+        <div class="form-group submit-group">
+            <button type="submit" class="btn btn-primary btn-save">{% trans "Save" %}</button>
+            <a class="btn btn-default btn-lg" href="{% url 'plugins:exhibition:call.questions' organizer=request.event.organizer.slug event=request.event.slug %}">
+                {% trans "Cancel" %}
+            </a>
+        </div>
+    </form>
+{% endblock %}

--- a/exhibition/templates/exhibitors/call_default_field_reset.html
+++ b/exhibition/templates/exhibitors/call_default_field_reset.html
@@ -1,0 +1,28 @@
+{% extends "exhibitors/base.html" %}
+{% load i18n %}
+
+{% block title %}{{ request.event.name }} - {% trans "Reset form field" %}{% endblock %}
+
+{% block exhibitors_header %}
+    <h1>{% trans "Reset form field" %}</h1>
+{% endblock %}
+
+{% block exhibitors_content %}
+    <form action="" method="post">
+        {% csrf_token %}
+        <p>
+            {% blocktrans trimmed with label=field_setting.label default_label=field_setting.default_label %}
+                Are you sure you want to reset "{{ label }}" back to the default "{{ default_label }}"?
+            {% endblocktrans %}
+        </p>
+        <p class="text-muted">
+            {% trans "This clears the custom label and help text. Default fields are part of the form and cannot be deleted; turn the field off with the Active toggle to hide it." %}
+        </p>
+        <div class="form-group submit-group">
+            <button type="submit" class="btn btn-danger">{% trans "Reset" %}</button>
+            <a class="btn btn-default" href="{% url 'plugins:exhibition:call.questions' organizer=request.event.organizer.slug event=request.event.slug %}">
+                {% trans "Cancel" %}
+            </a>
+        </div>
+    </form>
+{% endblock %}

--- a/exhibition/templates/exhibitors/call_questions.html
+++ b/exhibition/templates/exhibitors/call_questions.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="{% static 'pretixcontrol/css/order-form-toggles.css' %}">
     <link rel="stylesheet" href="{% static 'exhibition/css/dragsort-table.css' %}">
     <script defer src="{% static 'orga/js/dragsort.js' %}"></script>
+    <script defer src="{% static 'exhibition/js/call-questions.js' %}"></script>
 {% endblock %}
 
 {% block exhibitors_header %}
@@ -20,7 +21,7 @@
         {% csrf_token %}
         <fieldset>
             <legend>{% trans "Form fields" %}</legend>
-            <p>{% trans "Choose which fields are shown on the exhibitor form. Custom fields can be reordered alongside the default fields." %}</p>
+            <p>{% trans "Choose which fields are shown on the exhibitor form and drag any row to reorder it." %}</p>
             <div class="table-responsive table-responsive-always mw-100">
                 <table class="table table-hover dragsort-table">
                     <thead>
@@ -34,7 +35,7 @@
                     </thead>
                     <tbody dragsort-url="{% url 'plugins:exhibition:call.questions' organizer=request.event.organizer.slug event=request.event.slug %}">
                     {% for field in proposal_fields %}
-                        <tr {% if field.orderable %}dragsort-id="{{ field.dragsort_id }}"{% endif %}>
+                        <tr dragsort-id="{{ field.dragsort_id }}">
                             <th>
                                 {% if field.is_custom %}
                                     <a href="{% url 'plugins:exhibition:call.questions.edit' organizer=request.event.organizer.slug event=request.event.slug pk=field.pk %}">{{ field.label }}</a>
@@ -44,17 +45,24 @@
                                 {% endif %}
                             </th>
                             <td class="text-center">
-                                <label class="toggle-switch {% if field.active_locked %}always-on{% endif %}" aria-label="{% blocktrans trimmed with field=field.label %}Toggle active state for {{ field }}{% endblocktrans %}">
-                                    <input type="checkbox" name="{{ field.input_prefix }}_active" {% if field.active %}checked{% endif %} {% if field.active_locked %}disabled{% endif %}>
+                                <label class="toggle-switch field-active-toggle {% if field.active_locked %}always-on{% endif %}" aria-label="{% blocktrans trimmed with field=field.label %}Toggle active state for {{ field }}{% endblocktrans %}">
+                                    <input type="checkbox" class="field-active-input" name="{{ field.input_prefix }}_active" {% if field.active %}checked{% endif %} {% if field.active_locked %}disabled{% endif %}>
                                     <span class="toggle-slider"></span>
                                 </label>
                             </td>
                             <td class="text-center">
                                 {% if field.supports_required %}
-                                    <label class="toggle-switch {% if field.required_locked %}always-on{% endif %}" aria-label="{% blocktrans trimmed with field=field.label %}Toggle required state for {{ field }}{% endblocktrans %}">
-                                        <input type="checkbox" name="{{ field.input_prefix }}_required" {% if field.required %}checked{% endif %} {% if field.required_locked %}disabled{% endif %}>
-                                        <span class="toggle-slider"></span>
-                                    </label>
+                                    <div class="required-status-wrapper {% if not field.active %}is-disabled{% endif %}" data-current="{% if field.required %}required{% else %}optional{% endif %}">
+                                        <select class="required-status-dropdown"
+                                                name="{{ field.input_prefix }}_required"
+                                                data-current="{% if field.required %}required{% else %}optional{% endif %}"
+                                                {% if field.required_locked %}data-locked="1"{% endif %}
+                                                {% if field.required_locked or not field.active %}disabled{% endif %}
+                                                aria-label="{% blocktrans trimmed with field=field.label %}Required status for {{ field }}{% endblocktrans %}">
+                                            <option value="optional" {% if not field.required %}selected{% endif %}>{% trans "Optional" %}</option>
+                                            <option value="required" {% if field.required %}selected{% endif %}>{% trans "Required" %}</option>
+                                        </select>
+                                    </div>
                                 {% else %}
                                     <span class="text-muted">-</span>
                                 {% endif %}
@@ -65,15 +73,9 @@
                                     <a class="btn btn-default btn-sm" href="{% url 'plugins:exhibition:call.questions.edit' organizer=request.event.organizer.slug event=request.event.slug pk=field.pk %}" title="{% trans 'Edit' %}"><i class="fa fa-edit"></i></a>
                                     <a class="btn btn-delete btn-danger btn-sm" href="{% url 'plugins:exhibition:call.questions.delete' organizer=request.event.organizer.slug event=request.event.slug pk=field.pk %}" title="{% trans 'Delete' %}"><i class="fa fa-trash"></i></a>
                                 {% endif %}
-                                {% if field.orderable %}
-                                    <button type="button" draggable="true" class="btn btn-primary btn-sm dragsort-button" title="{% trans 'Move field' %}" aria-label="{% trans 'Move field' %}">
-                                        <i class="fa fa-arrows"></i>
-                                    </button>
-                                {% else %}
-                                    <span class="text-muted" title="{% trans 'This field always appears at the end of the form.' %}">
-                                        <i class="fa fa-thumb-tack"></i>
-                                    </span>
-                                {% endif %}
+                                <button type="button" draggable="true" class="btn btn-primary btn-sm dragsort-button" title="{% trans 'Move field' %}" aria-label="{% trans 'Move field' %}">
+                                    <i class="fa fa-arrows"></i>
+                                </button>
                             </td>
                         </tr>
                     {% endfor %}

--- a/exhibition/templates/exhibitors/call_questions.html
+++ b/exhibition/templates/exhibitors/call_questions.html
@@ -72,6 +72,9 @@
                                 {% if field.is_custom %}
                                     <a class="btn btn-default btn-sm" href="{% url 'plugins:exhibition:call.questions.edit' organizer=request.event.organizer.slug event=request.event.slug pk=field.pk %}" title="{% trans 'Edit' %}"><i class="fa fa-edit"></i></a>
                                     <a class="btn btn-delete btn-danger btn-sm" href="{% url 'plugins:exhibition:call.questions.delete' organizer=request.event.organizer.slug event=request.event.slug pk=field.pk %}" title="{% trans 'Delete' %}"><i class="fa fa-trash"></i></a>
+                                {% else %}
+                                    <a class="btn btn-default btn-sm" href="{% url 'plugins:exhibition:call.fields.edit' organizer=request.event.organizer.slug event=request.event.slug key=field.dragsort_id %}" title="{% trans 'Edit' %}"><i class="fa fa-edit"></i></a>
+                                    <a class="btn btn-delete btn-danger btn-sm" href="{% url 'plugins:exhibition:call.fields.reset' organizer=request.event.organizer.slug event=request.event.slug key=field.dragsort_id %}" title="{% trans 'Reset to default' %}"><i class="fa fa-trash"></i></a>
                                 {% endif %}
                                 <button type="button" draggable="true" class="btn btn-primary btn-sm dragsort-button" title="{% trans 'Move field' %}" aria-label="{% trans 'Move field' %}">
                                     <i class="fa fa-arrows"></i>

--- a/exhibition/templates/exhibitors/public_proposal_form.html
+++ b/exhibition/templates/exhibitors/public_proposal_form.html
@@ -25,97 +25,141 @@
     <form action="" method="post" class="form-horizontal" enctype="multipart/form-data" novalidate>
         {% csrf_token %}
         {% bootstrap_form_errors form %}
-        {% bootstrap_form form layout="control" %}
 
-        {% if can_edit and show_social_links %}
-            <div class="form-group">
-                <div class="col-md-3 control-label partner-link-group-label">{% trans "Social Media" %}</div>
-                <div class="col-md-9">
-                    <div id="social-links-formset" class="partner-link-formset formset" data-formset-prefix="{{ social_media_formset.prefix }}" data-social-link-prefixes='{{ social_link_prefixes|escapejson_dumps }}'>
-                        {{ social_media_formset.management_form }}
-                        {{ social_media_formset.non_form_errors }}
-                        <div data-formset-body>
-                            {% for social_form in social_media_formset %}
+        {% for item in form.proposal_items %}
+            {% if item.kind == 'social_links' and can_edit %}
+                <div class="form-group">
+                    <label class="col-md-3 control-label partner-link-group-label">{% trans "Social Media" %}</label>
+                    <div class="col-md-9">
+                        <div id="social-links-formset" class="partner-link-formset formset" data-formset-prefix="{{ social_media_formset.prefix }}" data-social-link-prefixes='{{ social_link_prefixes|escapejson_dumps }}'>
+                            {{ social_media_formset.management_form }}
+                            {{ social_media_formset.non_form_errors }}
+                            <div data-formset-body>
+                                {% for social_form in social_media_formset %}
+                                    <div class="row partner-link-row" data-formset-form data-social-link-row>
+                                        <div class="sr-only">{{ social_form.id }} {{ social_form.DELETE }}</div>
+                                        <div class="col-md-3">{{ social_form.network.errors }}{{ social_form.network }}</div>
+                                        <div class="col-md-8">
+                                            {{ social_form.path.errors }}
+                                            <div class="input-group">
+                                                <span class="input-group-addon partner-link-prefix" data-social-prefix>https://</span>
+                                                {{ social_form.path }}
+                                            </div>
+                                        </div>
+                                        <div class="col-md-1 text-right">
+                                            <button type="button" class="btn btn-delete btn-danger btn-sm partner-link-remove" data-formset-delete-button><i class="fa fa-minus"></i></button>
+                                        </div>
+                                    </div>
+                                {% endfor %}
+                            </div>
+                            <template data-formset-empty-form>
                                 <div class="row partner-link-row" data-formset-form data-social-link-row>
-                                    <div class="sr-only">{{ social_form.id }} {{ social_form.DELETE }}</div>
-                                    <div class="col-md-3">{{ social_form.network.errors }}{{ social_form.network }}</div>
+                                    <div class="sr-only">{{ social_media_formset.empty_form.id }} {{ social_media_formset.empty_form.DELETE }}</div>
+                                    <div class="col-md-3">{{ social_media_formset.empty_form.network.errors }}{{ social_media_formset.empty_form.network }}</div>
                                     <div class="col-md-8">
-                                        {{ social_form.path.errors }}
+                                        {{ social_media_formset.empty_form.path.errors }}
                                         <div class="input-group">
                                             <span class="input-group-addon partner-link-prefix" data-social-prefix>https://</span>
-                                            {{ social_form.path }}
+                                            {{ social_media_formset.empty_form.path }}
                                         </div>
                                     </div>
                                     <div class="col-md-1 text-right">
                                         <button type="button" class="btn btn-delete btn-danger btn-sm partner-link-remove" data-formset-delete-button><i class="fa fa-minus"></i></button>
                                     </div>
                                 </div>
-                            {% endfor %}
-                        </div>
-                        <template data-formset-empty-form>
-                            <div class="row partner-link-row" data-formset-form data-social-link-row>
-                                <div class="sr-only">{{ social_media_formset.empty_form.id }} {{ social_media_formset.empty_form.DELETE }}</div>
-                                <div class="col-md-3">{{ social_media_formset.empty_form.network.errors }}{{ social_media_formset.empty_form.network }}</div>
-                                <div class="col-md-8">
-                                    {{ social_media_formset.empty_form.path.errors }}
-                                    <div class="input-group">
-                                        <span class="input-group-addon partner-link-prefix" data-social-prefix>https://</span>
-                                        {{ social_media_formset.empty_form.path }}
-                                    </div>
-                                </div>
-                                <div class="col-md-1 text-right">
-                                    <button type="button" class="btn btn-delete btn-danger btn-sm partner-link-remove" data-formset-delete-button><i class="fa fa-minus"></i></button>
-                                </div>
+                            </template>
+                            <div class="partner-link-actions">
+                                <button type="button" class="btn btn-default btn-sm partner-link-add" data-formset-add>
+                                    <i class="fa fa-plus"></i> {% trans "Add social media link" %}
+                                </button>
                             </div>
-                        </template>
-                        <div class="partner-link-actions">
-                            <button type="button" class="btn btn-default btn-sm partner-link-add" data-formset-add>
-                                <i class="fa fa-plus"></i> {% trans "Add social media link" %}
-                            </button>
                         </div>
                     </div>
                 </div>
-            </div>
-        {% endif %}
-
-        {% if can_edit and show_extra_links %}
-            <div class="form-group">
-                <div class="col-md-3 control-label partner-link-group-label">{% trans "Extra Links" %}</div>
-                <div class="col-md-9">
-                    <div id="extra-links-formset" class="partner-link-formset formset" data-formset-prefix="{{ extra_links_formset.prefix }}">
-                        {{ extra_links_formset.management_form }}
-                        {{ extra_links_formset.non_form_errors }}
-                        <div data-formset-body>
-                            {% for extra_form in extra_links_formset %}
+            {% elif item.kind == 'extra_links' and can_edit %}
+                <div class="form-group">
+                    <label class="col-md-3 control-label partner-link-group-label">{% trans "Extra Links" %}</label>
+                    <div class="col-md-9">
+                        <div id="extra-links-formset" class="partner-link-formset formset" data-formset-prefix="{{ extra_links_formset.prefix }}">
+                            {{ extra_links_formset.management_form }}
+                            {{ extra_links_formset.non_form_errors }}
+                            <div data-formset-body>
+                                {% for extra_form in extra_links_formset %}
+                                    <div class="row partner-link-row" data-formset-form>
+                                        <div class="sr-only">{{ extra_form.id }} {{ extra_form.DELETE }}</div>
+                                        <div class="col-md-4">{{ extra_form.label.errors }}{{ extra_form.label }}</div>
+                                        <div class="col-md-7">{{ extra_form.url.errors }}{{ extra_form.url }}</div>
+                                        <div class="col-md-1 text-right">
+                                            <button type="button" class="btn btn-delete btn-danger btn-sm partner-link-remove" data-formset-delete-button><i class="fa fa-minus"></i></button>
+                                        </div>
+                                    </div>
+                                {% endfor %}
+                            </div>
+                            <template data-formset-empty-form>
                                 <div class="row partner-link-row" data-formset-form>
-                                    <div class="sr-only">{{ extra_form.id }} {{ extra_form.DELETE }}</div>
-                                    <div class="col-md-4">{{ extra_form.label.errors }}{{ extra_form.label }}</div>
-                                    <div class="col-md-7">{{ extra_form.url.errors }}{{ extra_form.url }}</div>
+                                    <div class="sr-only">{{ extra_links_formset.empty_form.id }} {{ extra_links_formset.empty_form.DELETE }}</div>
+                                    <div class="col-md-4">{{ extra_links_formset.empty_form.label.errors }}{{ extra_links_formset.empty_form.label }}</div>
+                                    <div class="col-md-7">{{ extra_links_formset.empty_form.url.errors }}{{ extra_links_formset.empty_form.url }}</div>
                                     <div class="col-md-1 text-right">
                                         <button type="button" class="btn btn-delete btn-danger btn-sm partner-link-remove" data-formset-delete-button><i class="fa fa-minus"></i></button>
                                     </div>
                                 </div>
-                            {% endfor %}
-                        </div>
-                        <template data-formset-empty-form>
-                            <div class="row partner-link-row" data-formset-form>
-                                <div class="sr-only">{{ extra_links_formset.empty_form.id }} {{ extra_links_formset.empty_form.DELETE }}</div>
-                                <div class="col-md-4">{{ extra_links_formset.empty_form.label.errors }}{{ extra_links_formset.empty_form.label }}</div>
-                                <div class="col-md-7">{{ extra_links_formset.empty_form.url.errors }}{{ extra_links_formset.empty_form.url }}</div>
-                                <div class="col-md-1 text-right">
-                                    <button type="button" class="btn btn-delete btn-danger btn-sm partner-link-remove" data-formset-delete-button><i class="fa fa-minus"></i></button>
-                                </div>
+                            </template>
+                            <div class="partner-link-actions">
+                                <button type="button" class="btn btn-default btn-sm partner-link-add" data-formset-add>
+                                    <i class="fa fa-plus"></i> {% trans "Add extra link" %}
+                                </button>
                             </div>
-                        </template>
-                        <div class="partner-link-actions">
-                            <button type="button" class="btn btn-default btn-sm partner-link-add" data-formset-add>
-                                <i class="fa fa-plus"></i> {% trans "Add extra link" %}
-                            </button>
                         </div>
                     </div>
                 </div>
-            </div>
-        {% endif %}
+            {% elif item.kind == 'slides' %}
+                {% bootstrap_field form.slides layout="control" %}
+                {% bootstrap_field form.slides_url layout="control" %}
+            {% elif item.kind == 'logo' %}
+                <div
+                    data-partner-image-source-pair
+                    data-file-input-id="{{ form.logo.id_for_label }}"
+                    data-url-input-id="{{ form.logo_url.id_for_label }}"
+                    data-current-preview-url="{{ form.instance.visible_logo_url }}"
+                    data-has-current-file="{{ form.instance.logo|yesno:'true,false' }}"
+                >
+                    {% bootstrap_field form.logo layout="control" %}
+                    {% bootstrap_field form.logo_url layout="control" %}
+                    <div class="form-group" data-image-preview hidden>
+                        <label class="col-md-3 control-label">{% trans "Logo preview" %}</label>
+                        <div class="col-md-9">
+                            <a data-image-preview-link href="" target="_blank" rel="noopener noreferrer" hidden>
+                                <img loading="lazy" data-image-preview-image class="img-responsive img-thumbnail partner-image-preview partner-image-preview-logo" alt="{% trans 'Logo preview' %}" hidden>
+                            </a>
+                            <p class="help-block text-danger" data-image-preview-error hidden>{% trans "We could not load this image preview." %}</p>
+                        </div>
+                    </div>
+                </div>
+            {% elif item.kind == 'header_image' %}
+                <div
+                    data-partner-image-source-pair
+                    data-file-input-id="{{ form.header_image.id_for_label }}"
+                    data-url-input-id="{{ form.header_image_url.id_for_label }}"
+                    data-current-preview-url="{{ form.instance.visible_header_image_url }}"
+                    data-has-current-file="{{ form.instance.header_image|yesno:'true,false' }}"
+                >
+                    {% bootstrap_field form.header_image layout="control" %}
+                    {% bootstrap_field form.header_image_url layout="control" %}
+                    <div class="form-group" data-image-preview hidden>
+                        <label class="col-md-3 control-label">{% trans "Header image preview" %}</label>
+                        <div class="col-md-9">
+                            <a data-image-preview-link href="" target="_blank" rel="noopener noreferrer" hidden>
+                                <img loading="lazy" data-image-preview-image class="img-responsive img-thumbnail partner-image-preview partner-image-preview-header" alt="{% trans 'Header image preview' %}" hidden>
+                            </a>
+                            <p class="help-block text-danger" data-image-preview-error hidden>{% trans "We could not load this image preview." %}</p>
+                        </div>
+                    </div>
+                </div>
+            {% elif item.kind == 'field' %}
+                {% bootstrap_field item.field layout="control" %}
+            {% endif %}
+        {% endfor %}
 
         {% if can_edit %}
             <div class="row checkout-button-row">

--- a/exhibition/templates/exhibitors/public_proposal_form.html
+++ b/exhibition/templates/exhibitors/public_proposal_form.html
@@ -28,12 +28,13 @@
 
         {% for item in form.proposal_items %}
             {% if item.kind == 'social_links' and can_edit %}
-                <div class="form-group">
-                    <label class="col-md-3 control-label partner-link-group-label">{% trans "Social Media" %}</label>
+                <div class="form-group {% if social_media_formset.non_form_errors %}has-error{% endif %}">
+                    <label class="col-md-3 control-label partner-link-group-label">
+                        <span class="label-text">{% trans "Social Media" %}{% if form.proposal_field_settings.social_links.required %}<span aria-hidden="true" class="required-indicator text-danger"> *</span><span class="sr-only">, {% trans "required" %}</span>{% endif %}</span>
+                    </label>
                     <div class="col-md-9">
                         <div id="social-links-formset" class="partner-link-formset formset" data-formset-prefix="{{ social_media_formset.prefix }}" data-social-link-prefixes='{{ social_link_prefixes|escapejson_dumps }}'>
                             {{ social_media_formset.management_form }}
-                            {{ social_media_formset.non_form_errors }}
                             <div data-formset-body>
                                 {% for social_form in social_media_formset %}
                                     <div class="row partner-link-row" data-formset-form data-social-link-row>
@@ -74,15 +75,19 @@
                                 </button>
                             </div>
                         </div>
+                        {% if social_media_formset.non_form_errors %}
+                            <p class="help-block">{{ social_media_formset.non_form_errors.0 }}</p>
+                        {% endif %}
                     </div>
                 </div>
             {% elif item.kind == 'extra_links' and can_edit %}
-                <div class="form-group">
-                    <label class="col-md-3 control-label partner-link-group-label">{% trans "Extra Links" %}</label>
+                <div class="form-group {% if extra_links_formset.non_form_errors %}has-error{% endif %}">
+                    <label class="col-md-3 control-label partner-link-group-label">
+                        <span class="label-text">{% trans "Extra Links" %}{% if form.proposal_field_settings.extra_links.required %}<span aria-hidden="true" class="required-indicator text-danger"> *</span><span class="sr-only">, {% trans "required" %}</span>{% endif %}</span>
+                    </label>
                     <div class="col-md-9">
                         <div id="extra-links-formset" class="partner-link-formset formset" data-formset-prefix="{{ extra_links_formset.prefix }}">
                             {{ extra_links_formset.management_form }}
-                            {{ extra_links_formset.non_form_errors }}
                             <div data-formset-body>
                                 {% for extra_form in extra_links_formset %}
                                     <div class="row partner-link-row" data-formset-form>
@@ -111,6 +116,9 @@
                                 </button>
                             </div>
                         </div>
+                        {% if extra_links_formset.non_form_errors %}
+                            <p class="help-block">{{ extra_links_formset.non_form_errors.0 }}</p>
+                        {% endif %}
                     </div>
                 </div>
             {% elif item.kind == 'slides' %}

--- a/exhibition/urls.py
+++ b/exhibition/urls.py
@@ -20,6 +20,8 @@ from .views import (
     EmailSentListView,
     EmailTemplatePreviewView,
     EmailTemplatesView,
+    ExhibitionDefaultFieldEditView,
+    ExhibitionDefaultFieldResetView,
     ExhibitionQuestionCreateView,
     ExhibitionQuestionDeleteView,
     ExhibitionQuestionEditView,
@@ -198,6 +200,16 @@ urlpatterns = [
         "exhibitors/event/<orgslug:organizer>/<slug:event>/call/questions/<int:pk>/delete",
         ExhibitionQuestionDeleteView.as_view(),
         name="call.questions.delete",
+    ),
+    path(
+        "exhibitors/event/<orgslug:organizer>/<slug:event>/call/fields/<slug:key>/edit",
+        ExhibitionDefaultFieldEditView.as_view(),
+        name="call.fields.edit",
+    ),
+    path(
+        "exhibitors/event/<orgslug:organizer>/<slug:event>/call/fields/<slug:key>/reset",
+        ExhibitionDefaultFieldResetView.as_view(),
+        name="call.fields.reset",
     ),
     path(
         "exhibitors/event/<orgslug:organizer>/<slug:event>/add",

--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -513,6 +513,20 @@ class ProposalLinkFormsetMixin:
     def proposal_field_is_active(self, key):
         return self.get_proposal_field_settings()[key]["active"]
 
+    def proposal_field_is_required(self, key):
+        return self.get_proposal_field_settings()[key]["required"]
+
+    @staticmethod
+    def _formset_has_entries(formset):
+        if formset is None:
+            return True
+        for form in formset.forms:
+            if not form.cleaned_data or form.cleaned_data.get("DELETE"):
+                continue
+            if any(value for name, value in form.cleaned_data.items() if name != "DELETE"):
+                return True
+        return False
+
     def get_formset_instance(self):
         obj = getattr(self, "object", None)
         if obj is not None:
@@ -540,11 +554,32 @@ class ProposalLinkFormsetMixin:
             self.get_extra_link_formset() if self.proposal_field_is_active("extra_links") else None
         )
 
-        if (
+        valid = (
             form.is_valid()
             and (self.social_media_formset is None or self.social_media_formset.is_valid())
             and (self.extra_links_formset is None or self.extra_links_formset.is_valid())
+        )
+
+        if (
+            valid
+            and self.proposal_field_is_required("social_links")
+            and not self._formset_has_entries(self.social_media_formset)
         ):
+            self.social_media_formset._non_form_errors = self.social_media_formset.error_class(
+                [_("Add at least one social media link.")]
+            )
+            valid = False
+        if (
+            valid
+            and self.proposal_field_is_required("extra_links")
+            and not self._formset_has_entries(self.extra_links_formset)
+        ):
+            self.extra_links_formset._non_form_errors = self.extra_links_formset.error_class(
+                [_("Add at least one extra link.")]
+            )
+            valid = False
+
+        if valid:
             return self.form_valid(form)
         return self.form_invalid(form)
 

--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -42,7 +42,6 @@ from .forms import (
 from .models import (
     PROPOSAL_DEFAULT_FIELD_KEYS,
     PROPOSAL_DEFAULT_FIELDS,
-    PROPOSAL_FORMSET_FIELD_KEYS,
     PROPOSAL_REVIEW_ACTIONS,
     ExhibitionEmailQueue,
     ExhibitionProposal,
@@ -561,8 +560,6 @@ class ProposalLinkFormsetMixin:
         )
         context["social_link_prefixes"] = social_link_prefixes()
         context["settings"] = self.get_exhibition_settings()
-        context["show_social_links"] = self.proposal_field_is_active("social_links")
-        context["show_extra_links"] = self.proposal_field_is_active("extra_links")
         context.setdefault("can_edit", True)
         return context
 
@@ -1221,14 +1218,11 @@ class ExhibitionQuestionListView(EventPermissionRequiredMixin, ListView):
         field_settings = settings.normalized_proposal_field_settings
         answer_counts = self.get_default_field_answer_counts()
         field_definitions = {field["key"]: field for field in PROPOSAL_DEFAULT_FIELDS}
-        formset_keys = set(PROPOSAL_FORMSET_FIELD_KEYS)
 
-        orderable_rows = []
+        rows = []
         for key in PROPOSAL_DEFAULT_FIELD_KEYS:
-            if key in formset_keys:
-                continue
             definition = field_definitions[key]
-            orderable_rows.append(
+            rows.append(
                 {
                     "sort_position": field_settings[key]["position"],
                     "sort_kind": 0,
@@ -1241,12 +1235,11 @@ class ExhibitionQuestionListView(EventPermissionRequiredMixin, ListView):
                     "active_locked": definition.get("active_locked", False),
                     "required_locked": definition.get("required_locked", False),
                     "answer_count": answer_counts.get(key, 0),
-                    "orderable": True,
                     "is_custom": False,
                 }
             )
         for question in context["questions"]:
-            orderable_rows.append(
+            rows.append(
                 {
                     "sort_position": question.position,
                     "sort_kind": 1,
@@ -1259,30 +1252,12 @@ class ExhibitionQuestionListView(EventPermissionRequiredMixin, ListView):
                     "active_locked": False,
                     "required_locked": False,
                     "answer_count": question.answer_count,
-                    "orderable": True,
                     "is_custom": True,
                     "pk": question.pk,
                 }
             )
-        orderable_rows.sort(key=lambda row: (row["sort_position"], row["sort_kind"]))
-
-        formset_rows = [
-            {
-                "dragsort_id": key,
-                "input_prefix": key,
-                "label": field_definitions[key]["label"],
-                "active": field_settings[key]["active"],
-                "required": field_settings[key]["required"],
-                "supports_required": field_definitions[key].get("supports_required", True),
-                "active_locked": field_definitions[key].get("active_locked", False),
-                "required_locked": field_definitions[key].get("required_locked", False),
-                "answer_count": answer_counts.get(key, 0),
-                "orderable": False,
-                "is_custom": False,
-            }
-            for key in PROPOSAL_FORMSET_FIELD_KEYS
-        ]
-        context["proposal_fields"] = orderable_rows + formset_rows
+        rows.sort(key=lambda row: (row["sort_position"], row["sort_kind"]))
+        context["proposal_fields"] = rows
         return context
 
     def get_default_field_answer_counts(self):
@@ -1334,7 +1309,7 @@ class ExhibitionQuestionListView(EventPermissionRequiredMixin, ListView):
             proposal_field_settings[key]["active"] = is_active
             proposal_field_settings[key]["required"] = is_active and (
                 field.get("required_locked")
-                or (field.get("supports_required", True) and request.POST.get(f"{key}_required") == "on")
+                or (field.get("supports_required", True) and request.POST.get(f"{key}_required") == "required")
             )
             if field.get("supports_required") is False:
                 proposal_field_settings[key]["required"] = False
@@ -1345,7 +1320,7 @@ class ExhibitionQuestionListView(EventPermissionRequiredMixin, ListView):
         questions = list(ExhibitionQuestion.objects.filter(event=request.event))
         for question in questions:
             question.active = request.POST.get(f"question_{question.pk}_active") == "on"
-            question.required = request.POST.get(f"question_{question.pk}_required") == "on"
+            question.required = request.POST.get(f"question_{question.pk}_required") == "required"
         if questions:
             ExhibitionQuestion.objects.bulk_update(questions, ["active", "required"])
 
@@ -1354,8 +1329,7 @@ class ExhibitionQuestionListView(EventPermissionRequiredMixin, ListView):
 
     def save_field_order(self, settings, order_str):
         proposal_field_settings = settings.normalized_proposal_field_settings
-        orderable_keys = [key for key in PROPOSAL_DEFAULT_FIELD_KEYS if key not in PROPOSAL_FORMSET_FIELD_KEYS]
-        orderable_key_set = set(orderable_keys)
+        orderable_key_set = set(PROPOSAL_DEFAULT_FIELD_KEYS)
         questions = {question.pk: question for question in ExhibitionQuestion.objects.filter(event=settings.event)}
         seen_keys = set()
         seen_question_pks = set()
@@ -1372,7 +1346,7 @@ class ExhibitionQuestionListView(EventPermissionRequiredMixin, ListView):
                 seen_question_pks.add(question.pk)
                 reordered_questions.append(question)
                 position += 1
-        for key in orderable_keys:
+        for key in PROPOSAL_DEFAULT_FIELD_KEYS:
             if key not in seen_keys:
                 proposal_field_settings[key]["position"] = position
                 position += 1
@@ -1383,9 +1357,6 @@ class ExhibitionQuestionListView(EventPermissionRequiredMixin, ListView):
         for question in remaining_questions:
             question.position = position
             reordered_questions.append(question)
-            position += 1
-        for key in PROPOSAL_FORMSET_FIELD_KEYS:
-            proposal_field_settings[key]["position"] = position
             position += 1
         settings.proposal_field_settings = proposal_field_settings
         settings.save(update_fields=["proposal_field_settings"])

--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -25,6 +25,7 @@ from . import mail as mail_helpers
 from .forms import (
     CallSettingsForm,
     ExhibitionComposeForm,
+    ExhibitionDefaultFieldForm,
     ExhibitionEmailQueueForm,
     ExhibitionMailTemplatesForm,
     ExhibitionProposalExtraLinkFormSet,
@@ -52,6 +53,7 @@ from .models import (
     SponsorGroup,
     generate_booth_id,
     get_next_sponsor_group_level,
+    storable_proposal_field_settings,
 )
 from .social_links import serialize_social_link
 from .utils import (
@@ -1263,7 +1265,7 @@ class ExhibitionQuestionListView(EventPermissionRequiredMixin, ListView):
                     "sort_kind": 0,
                     "dragsort_id": key,
                     "input_prefix": key,
-                    "label": definition["label"],
+                    "label": field_settings[key]["label"],
                     "active": field_settings[key]["active"],
                     "required": field_settings[key]["required"],
                     "supports_required": definition.get("supports_required", True),
@@ -1349,7 +1351,7 @@ class ExhibitionQuestionListView(EventPermissionRequiredMixin, ListView):
             if field.get("supports_required") is False:
                 proposal_field_settings[key]["required"] = False
 
-        settings.proposal_field_settings = proposal_field_settings
+        settings.proposal_field_settings = storable_proposal_field_settings(proposal_field_settings)
         settings.save(update_fields=["proposal_field_settings"])
 
         questions = list(ExhibitionQuestion.objects.filter(event=request.event))
@@ -1393,7 +1395,7 @@ class ExhibitionQuestionListView(EventPermissionRequiredMixin, ListView):
             question.position = position
             reordered_questions.append(question)
             position += 1
-        settings.proposal_field_settings = proposal_field_settings
+        settings.proposal_field_settings = storable_proposal_field_settings(proposal_field_settings)
         settings.save(update_fields=["proposal_field_settings"])
         if reordered_questions:
             ExhibitionQuestion.objects.bulk_update(reordered_questions, ["position"])
@@ -1451,6 +1453,76 @@ class ExhibitionQuestionDeleteView(EventPermissionRequiredMixin, DeleteView):
             "plugins:exhibition:call.questions",
             kwargs=event_kwargs(self.request.event),
         )
+
+
+class DefaultFieldMixin(EventPermissionRequiredMixin):
+    permission = "can_change_settings"
+
+    def dispatch(self, request, *args, **kwargs):
+        if kwargs.get("key") not in PROPOSAL_DEFAULT_FIELD_KEYS:
+            raise Http404(_("The requested form field does not exist."))
+        return super().dispatch(request, *args, **kwargs)
+
+    def get_exhibition_settings(self):
+        return ExhibitorSettings.objects.get_or_create(event=self.request.event)[0]
+
+    def get_field_setting(self):
+        return self.get_exhibition_settings().normalized_proposal_field_settings[self.kwargs["key"]]
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["field_setting"] = self.get_field_setting()
+        return context
+
+    def get_success_url(self):
+        return reverse(
+            "plugins:exhibition:call.questions",
+            kwargs=event_kwargs(self.request.event),
+        )
+
+
+class ExhibitionDefaultFieldEditView(DefaultFieldMixin, FormView):
+    form_class = ExhibitionDefaultFieldForm
+    template_name = "exhibitors/call_default_field_form.html"
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        field_setting = self.get_field_setting()
+        kwargs["field_setting"] = field_setting
+        kwargs.setdefault(
+            "initial",
+            {
+                "label": field_setting["custom_label"] or "",
+                "help_text": field_setting["custom_help_text"] or "",
+            },
+        )
+        return kwargs
+
+    def form_valid(self, form):
+        settings = self.get_exhibition_settings()
+        proposal_field_settings = settings.normalized_proposal_field_settings
+        key = self.kwargs["key"]
+        proposal_field_settings[key]["custom_label"] = form.cleaned_data["label"].strip() or None
+        proposal_field_settings[key]["custom_help_text"] = form.cleaned_data["help_text"].strip() or None
+        settings.proposal_field_settings = storable_proposal_field_settings(proposal_field_settings)
+        settings.save(update_fields=["proposal_field_settings"])
+        messages.success(self.request, _("Your changes have been saved."))
+        return redirect(self.get_success_url())
+
+
+class ExhibitionDefaultFieldResetView(DefaultFieldMixin, TemplateView):
+    template_name = "exhibitors/call_default_field_reset.html"
+
+    def post(self, request, *args, **kwargs):
+        settings = self.get_exhibition_settings()
+        proposal_field_settings = settings.normalized_proposal_field_settings
+        key = kwargs["key"]
+        proposal_field_settings[key]["custom_label"] = None
+        proposal_field_settings[key]["custom_help_text"] = None
+        settings.proposal_field_settings = storable_proposal_field_settings(proposal_field_settings)
+        settings.save(update_fields=["proposal_field_settings"])
+        messages.success(request, _("The field has been reset to its default."))
+        return redirect(self.get_success_url())
 
 
 class ExhibitorCreateView(ExhibitorLinkFormsetMixin, EventPermissionRequiredMixin, CreateView):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -22,6 +22,8 @@ from exhibition.models import (
 )
 from exhibition.views import (
     CallTextPreviewView,
+    ExhibitionDefaultFieldEditView,
+    ExhibitionDefaultFieldResetView,
     ExhibitionQuestionListView,
     ExhibitorListView,
     SettingsView,
@@ -331,6 +333,68 @@ def test_required_dropdown_value_persists_as_boolean(event):
 
     settings.refresh_from_db()
     assert settings.normalized_proposal_field_settings["url"]["required"] is True
+
+
+def _default_field_request(event, method="post", data=None):
+    factory = RequestFactory()
+    request = getattr(factory, method)("/", data=data or {})
+    request.event = event
+    request.session = {}
+    setattr(request, "_messages", FallbackStorage(request))
+    return request
+
+
+@pytest.mark.django_db
+def test_default_field_edit_overrides_label_and_help_text(event):
+    settings = make_exhibitor_settings(event)
+    view = ExhibitionDefaultFieldEditView()
+    view.request = _default_field_request(event)
+    view.kwargs = {"key": "name"}
+    form = view.get_form_class()(
+        data={"label": "University name", "help_text": "Use the official name."},
+        field_setting=view.get_field_setting(),
+    )
+    assert form.is_valid(), form.errors
+    view.form_valid(form)
+
+    settings.refresh_from_db()
+    normalized = settings.normalized_proposal_field_settings
+    assert normalized["name"]["label"] == "University name"
+    assert normalized["name"]["help_text"] == "Use the official name."
+
+    proposal_form = ExhibitionProposalForm(event=event)
+    assert str(proposal_form.fields["name"].label) == "University name"
+    assert str(proposal_form.fields["name"].help_text) == "Use the official name."
+
+
+@pytest.mark.django_db
+def test_default_field_reset_restores_builtin_label(event):
+    settings = make_exhibitor_settings(event)
+    stored = settings.proposal_field_settings
+    stored["name"]["label"] = "University name"
+    settings.save(update_fields=["proposal_field_settings"])
+
+    view = ExhibitionDefaultFieldResetView()
+    view.request = _default_field_request(event)
+    view.kwargs = {"key": "name"}
+    view.post(view.request, key="name")
+
+    settings.refresh_from_db()
+    normalized = settings.normalized_proposal_field_settings
+    assert normalized["name"]["custom_label"] is None
+    assert str(normalized["name"]["label"]) == "Organization name"
+
+
+@pytest.mark.django_db
+def test_saving_settings_does_not_freeze_default_labels_as_overrides(event):
+    settings = make_exhibitor_settings(event)
+    view = ExhibitionQuestionListView()
+    view.request = _default_field_request(event, data={"url_active": "on"})
+    view.post(view.request)
+
+    settings.refresh_from_db()
+    assert settings.proposal_field_settings["url"]["label"] is None
+    assert settings.normalized_proposal_field_settings["url"]["custom_label"] is None
 
 
 @pytest.mark.django_db

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 from django.conf import settings as django_settings
+from django.contrib.messages.storage.fallback import FallbackStorage
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import RequestFactory
 from django_scopes import scopes_disabled
@@ -284,8 +285,7 @@ def test_save_field_order_persists_new_order(event):
     view.save_field_order(settings, "social_links,logo,header_image,name")
 
     settings.refresh_from_db()
-    assert settings.ordered_proposal_field_keys[:3] == ["logo", "header_image", "name"]
-    assert settings.ordered_proposal_field_keys[-2:] == ["social_links", "extra_links"]
+    assert settings.ordered_proposal_field_keys[:4] == ["social_links", "logo", "header_image", "name"]
     assert set(settings.ordered_proposal_field_keys) == set(PROPOSAL_DEFAULT_FIELD_KEYS)
 
 
@@ -298,6 +298,39 @@ def test_proposal_form_reflects_saved_field_order(event):
     form = ExhibitionProposalForm(event=event)
     field_names = list(form.fields.keys())
     assert field_names.index("description") < field_names.index("name")
+
+
+@pytest.mark.django_db
+def test_proposal_items_interleaves_reordered_formset_field(event):
+    settings = make_exhibitor_settings(event)
+    stored = settings.proposal_field_settings
+    stored["social_links"]["active"] = True
+    settings.save(update_fields=["proposal_field_settings"])
+
+    view = ExhibitionQuestionListView()
+    view.save_field_order(settings, "social_links,name")
+
+    form = ExhibitionProposalForm(event=event)
+    items = form.proposal_items
+    assert items[0]["kind"] == "social_links"
+    assert items[1]["kind"] == "field"
+    assert items[1]["key"] == "name"
+    assert items[1]["field"].name == "name"
+
+
+@pytest.mark.django_db
+def test_required_dropdown_value_persists_as_boolean(event):
+    settings = make_exhibitor_settings(event)
+    view = ExhibitionQuestionListView()
+    request = RequestFactory().post("/", data={"url_active": "on", "url_required": "required"})
+    request.event = event
+    request.session = {}
+    setattr(request, "_messages", FallbackStorage(request))
+    view.request = request
+    view.post(request)
+
+    settings.refresh_from_db()
+    assert settings.normalized_proposal_field_settings["url"]["required"] is True
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
fixes #125 

<img width="1512" height="909" alt="image" src="https://github.com/user-attachments/assets/2c48143f-c9c4-48cc-bf5a-2b791f696172" />

## Summary by Sourcery

Align exhibitor proposal form behavior and configuration with the ticket order form, including unified field ordering, visibility, and required-status handling.

New Features:
- Expose an ordered proposal_items collection on the exhibitor proposal form to drive dynamic rendering of simple fields, composite media fields, and formset-based link sections.
- Add a dropdown-based required/optional control for exhibitor form fields that persists selection semantics consistently in settings.

Bug Fixes:
- Ensure the required-state configuration for exhibitor fields is correctly persisted as booleans when using the new dropdown UI.

Enhancements:
- Allow all exhibitor proposal fields, including social and extra link formsets, to participate in custom ordering instead of being pinned to the end of the form.
- Update exhibitor-facing and organizer-facing field labels to use consistent title-style capitalization.
- Show live logo and header image previews on the exhibitor proposal form using a shared image source/preview pattern.
- Unify the exhibitor form field configuration UI text and drag-and-drop affordances with the ticket order form, removing non-draggable rows and pinned-field indicators.

Tests:
- Extend tests to cover reordered formset field interleaving, required dropdown persistence, and updated proposal field ordering semantics.