### PR TITLE
feat: add change history for profiles and requests

### DIFF
--- a/exhibition/models.py
+++ b/exhibition/models.py
@@ -486,6 +486,7 @@ PROPOSAL_LOG_ACTIONS = {
     "reopen": f"{LOG_PREFIX}.proposal.reopened",
 }
 
+LOG_PROPOSAL_CHANGED = f"{LOG_PREFIX}.proposal.changed"
 LOG_PARTNER_CREATED = f"{LOG_PREFIX}.partner.created"
 LOG_PARTNER_REACTIVATED = f"{LOG_PREFIX}.partner.reactivated"
 LOG_PARTNER_ADDED = f"{LOG_PREFIX}.partner.added"

--- a/exhibition/models.py
+++ b/exhibition/models.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 from django.utils.crypto import get_random_string
 from django.utils.translation import gettext_lazy as _
 from eventyay.base.models import Event, Voucher
+from eventyay.base.models.base import LoggedModel
 from eventyay.common.utils.language import localize_event_text
 from i18nfield.fields import I18nCharField, I18nTextField
 from i18nfield.strings import LazyI18nString
@@ -197,7 +198,7 @@ def default_allowed_fields():
     return ["attendee_name", "attendee_email"]
 
 
-class ExhibitorSettings(models.Model):
+class ExhibitorSettings(LoggedModel):
     event = models.ForeignKey("base.Event", on_delete=models.CASCADE)
     exhibitors_access_mail_subject = models.CharField(max_length=255)
     exhibitors_access_mail_body = models.TextField()
@@ -231,9 +232,10 @@ class ExhibitorSettings(models.Model):
             return False
         return not self.call_deadline or self.call_deadline >= timezone.now()
 
-    def regenerate_call_secret(self):
+    def regenerate_call_secret(self, requestor=None):
         self.call_secret = generate_call_secret()
         self.save(update_fields=["call_secret"])
+        self.log_action(LOG_CALL_SECRET_REGENERATED, user=requestor)
 
     @property
     def normalized_proposal_field_settings(self):
@@ -281,7 +283,7 @@ class ExhibitorSettings(models.Model):
         unique_together = ("event",)
 
 
-class SponsorGroup(models.Model):
+class SponsorGroup(LoggedModel):
     event = models.ForeignKey(Event, on_delete=models.CASCADE, related_name="sponsor_groups")
     name = I18nCharField(max_length=120, verbose_name=_("Group name"))
     level = models.PositiveIntegerField(default=1, db_index=True, verbose_name=_("Level"))
@@ -301,7 +303,7 @@ class SponsorGroup(models.Model):
         return self.localized_name or str(self.name)
 
 
-class ExhibitorInfo(models.Model):
+class ExhibitorInfo(LoggedModel):
     event = models.ForeignKey(Event, on_delete=models.CASCADE)
     name = I18nCharField(max_length=190, verbose_name=_("Name"))
     description = I18nTextField(verbose_name=_("Description"), null=True, blank=True)
@@ -475,6 +477,32 @@ PROPOSAL_REVIEW_ACTIONS = {
 
 PROPOSAL_BULK_ACTIONS = ("approve", "reject")
 
+LOG_PREFIX = "eventyay.plugins.exhibition"
+
+PROPOSAL_LOG_ACTIONS = {
+    "approve": f"{LOG_PREFIX}.proposal.approved",
+    "reject": f"{LOG_PREFIX}.proposal.rejected",
+    "withdraw": f"{LOG_PREFIX}.proposal.withdrawn",
+    "reopen": f"{LOG_PREFIX}.proposal.reopened",
+}
+
+LOG_PARTNER_CREATED = f"{LOG_PREFIX}.partner.created"
+LOG_PARTNER_REACTIVATED = f"{LOG_PREFIX}.partner.reactivated"
+LOG_PARTNER_ADDED = f"{LOG_PREFIX}.partner.added"
+LOG_PARTNER_CHANGED = f"{LOG_PREFIX}.partner.changed"
+LOG_PARTNER_DELETED = f"{LOG_PREFIX}.partner.deleted"
+LOG_PARTNER_SYNCED = f"{LOG_PREFIX}.partner.synced"
+LOG_SETTINGS_CHANGED = f"{LOG_PREFIX}.settings.changed"
+LOG_CALL_SETTINGS_CHANGED = f"{LOG_PREFIX}.call.settings.changed"
+LOG_CALL_SECRET_REGENERATED = f"{LOG_PREFIX}.call.secret.regenerated"
+LOG_GROUP_ADDED = f"{LOG_PREFIX}.sponsorgroup.added"
+LOG_GROUP_CHANGED = f"{LOG_PREFIX}.sponsorgroup.changed"
+LOG_GROUP_DELETED = f"{LOG_PREFIX}.sponsorgroup.deleted"
+LOG_QUESTION_ADDED = f"{LOG_PREFIX}.question.added"
+LOG_QUESTION_CHANGED = f"{LOG_PREFIX}.question.changed"
+LOG_QUESTION_DELETED = f"{LOG_PREFIX}.question.deleted"
+LOG_EMAIL_SENT = f"{LOG_PREFIX}.email.sent"
+
 SUBMITTER_PROFILE_FIELD_LABELS = {
     "description": _("Organization Description"),
     "email": _("Contact email"),
@@ -491,7 +519,7 @@ SUBMITTER_PROFILE_FIELD_LABELS = {
 }
 
 
-class ExhibitionProposal(models.Model):
+class ExhibitionProposal(LoggedModel):
     code = models.CharField(
         max_length=12,
         unique=True,
@@ -595,17 +623,32 @@ class ExhibitionProposal(models.Model):
     def available_bulk_actions(self):
         return [action for action in PROPOSAL_BULK_ACTIONS if self.can_transition_to(PROPOSAL_REVIEW_ACTIONS[action])]
 
-    def set_partner_active(self, active):
+    def set_partner_active(self, active, requestor=None):
         if self.approved_exhibitor_id and self.approved_exhibitor.active != active:
             self.approved_exhibitor.active = active
             self.approved_exhibitor.save(update_fields=["active"])
+            self.approved_exhibitor.log_action(
+                LOG_PARTNER_CHANGED,
+                data={"active": active, "reason": "proposal_state_change", "proposal": self.code},
+                user=requestor,
+            )
+
+    def log_transition(self, action, previous, requestor=None):
+        """Record who moved the request between states, and in which direction."""
+        self.log_action(
+            PROPOSAL_LOG_ACTIONS[action],
+            data={"from": previous, "to": self.state, "code": self.code},
+            user=requestor,
+        )
 
     def approve(self, requestor=None):
         """Accept the request, create or reactivate its partner profile and queue the acceptance email."""
         from .mail import PROPOSAL_ACCEPTED, queue_proposal_email
         from .utils import create_exhibitor_from_proposal
 
-        exhibitor = create_exhibitor_from_proposal(self)
+        previous = self.state
+        exhibitor = create_exhibitor_from_proposal(self, requestor=requestor)
+        self.log_transition("approve", previous, requestor=requestor)
         queue_proposal_email(self.event, self, PROPOSAL_ACCEPTED, requestor=requestor)
         return exhibitor
 
@@ -613,9 +656,11 @@ class ExhibitionProposal(models.Model):
         """Reject the request, hide any partner profile and queue the rejection email."""
         from .mail import PROPOSAL_REJECTED, queue_proposal_email
 
+        previous = self.state
         self.state = ExhibitionProposalState.REJECTED
         self.save(update_fields=["state", "updated"])
-        self.set_partner_active(False)
+        self.set_partner_active(False, requestor=requestor)
+        self.log_transition("reject", previous, requestor=requestor)
         queue_proposal_email(self.event, self, PROPOSAL_REJECTED, requestor=requestor)
 
     @property
@@ -626,17 +671,21 @@ class ExhibitionProposal(models.Model):
     def can_be_reinstated(self):
         return self.state == ExhibitionProposalState.WITHDRAWN
 
-    def withdraw(self):
+    def withdraw(self, requestor=None):
+        previous = self.state
         self.state = ExhibitionProposalState.WITHDRAWN
         self.save(update_fields=["state", "updated"])
-        self.set_partner_active(False)
+        self.set_partner_active(False, requestor=requestor)
+        self.log_transition("withdraw", previous, requestor=requestor)
 
-    def reopen(self):
+    def reopen(self, requestor=None):
         """Move the request back to submitted for a fresh decision; sends no decision email."""
+        previous = self.state
         self.state = ExhibitionProposalState.SUBMITTED
         self.submitted = self.submitted or timezone.now()
         self.save(update_fields=["state", "submitted", "updated"])
-        self.set_partner_active(False)
+        self.set_partner_active(False, requestor=requestor)
+        self.log_transition("reopen", previous, requestor=requestor)
 
     @property
     def requires_open_call_to_edit(self):
@@ -781,7 +830,7 @@ class ExhibitionQuestionVariant(models.TextChoices):
     SELECT = "select", _("Select (one option)")
 
 
-class ExhibitionQuestion(models.Model):
+class ExhibitionQuestion(LoggedModel):
     event = models.ForeignKey(
         Event,
         on_delete=models.CASCADE,
@@ -908,7 +957,7 @@ class ExhibitorVoucher(models.Model):
         return f"{self.voucher.code} ({self.exhibitor.name})"
 
 
-class ExhibitionEmailQueue(models.Model):
+class ExhibitionEmailQueue(LoggedModel):
     """A single email queued for one recipient, with placeholders already rendered."""
 
     event = models.ForeignKey(
@@ -970,10 +1019,10 @@ class ExhibitionEmailQueue(models.Model):
         self.sent_at = timezone.now()
         self.scheduled_at = None
         self.save(update_fields=["sent_at", "scheduled_at", "updated"])
-        self.event.log_action(
-            "eventyay.plugins.exhibition.email.sent",
+        self.log_action(
+            LOG_EMAIL_SENT,
             user=requestor,
-            data={"queue_id": self.pk, "to": self.to_email, "subject": self.subject},
+            data={"to": self.to_email, "subject": self.subject},
         )
 
     send.alters_data = True

--- a/exhibition/signals.py
+++ b/exhibition/signals.py
@@ -42,6 +42,8 @@ from .models import (
     LOG_SETTINGS_CHANGED,
     PROPOSAL_LOG_ACTIONS,
     ExhibitionProposal,
+    ExhibitionProposalState,
+    ExhibitionQuestion,
     ExhibitorInfo,
     ExhibitorSettings,
     ExhibitorVoucher,
@@ -299,6 +301,14 @@ LOG_ENTRY_LABELS = {
 }
 
 
+def proposal_state_label(value):
+    """Render a stored state slug with its translated label."""
+    try:
+        return ExhibitionProposalState(value).label
+    except ValueError:
+        return value
+
+
 @receiver(signal=logentry_display, dispatch_uid="exhibition_logentry_display")
 def exhibition_logentry_display(sender, logentry, **kwargs):
     if not logentry.action_type.startswith(LOG_PREFIX):
@@ -311,7 +321,10 @@ def exhibition_logentry_display(sender, logentry, **kwargs):
     if logentry.action_type in PROPOSAL_LOG_ACTIONS.values():
         data = logentry.parsed_data
         if data.get("from") and data.get("to"):
-            transition = _("State changed from {old} to {new}.").format(old=data["from"], new=data["to"])
+            transition = _("State changed from {old} to {new}.").format(
+                old=proposal_state_label(data["from"]),
+                new=proposal_state_label(data["to"]),
+            )
             return f"{label} {transition}"
     return label
 
@@ -342,6 +355,15 @@ def exhibition_logentry_object_link(sender, logentry, **kwargs):
                 kwargs={"organizer": sender.organizer.slug, "event": sender.slug, "pk": target.pk},
             ),
             "val": escape(localize_event_text(target.name) or str(target.name)),
+        }
+    elif isinstance(target, ExhibitionQuestion):
+        a_text = _("Exhibitor form question {val}")
+        a_map = {
+            "href": reverse(
+                "plugins:exhibition:call.questions.edit",
+                kwargs={"organizer": sender.organizer.slug, "event": sender.slug, "pk": target.pk},
+            ),
+            "val": escape(target.localized_question),
         }
     elif isinstance(target, SponsorGroup):
         return _("Sponsor group {val}").format(val=escape(target.localized_name))

--- a/exhibition/signals.py
+++ b/exhibition/signals.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import FieldDoesNotExist
 from django.db.models import Prefetch
 from django.db.models.signals import pre_delete
 from django.dispatch import receiver
@@ -36,6 +37,7 @@ from .models import (
     LOG_PARTNER_REACTIVATED,
     LOG_PARTNER_SYNCED,
     LOG_PREFIX,
+    LOG_PROPOSAL_CHANGED,
     LOG_QUESTION_ADDED,
     LOG_QUESTION_CHANGED,
     LOG_QUESTION_DELETED,
@@ -282,6 +284,7 @@ LOG_ENTRY_LABELS = {
     PROPOSAL_LOG_ACTIONS["reject"]: _("Exhibition request rejected."),
     PROPOSAL_LOG_ACTIONS["withdraw"]: _("Exhibition request withdrawn."),
     PROPOSAL_LOG_ACTIONS["reopen"]: _("Exhibition request reopened for review."),
+    LOG_PROPOSAL_CHANGED: _("Exhibition request changed."),
     LOG_PARTNER_CREATED: _("Organization profile created from an approved request."),
     LOG_PARTNER_REACTIVATED: _("Organization profile reactivated after re-approval."),
     LOG_PARTNER_SYNCED: _("Organization profile updated from the submitter's changes."),
@@ -299,6 +302,24 @@ LOG_ENTRY_LABELS = {
     LOG_QUESTION_DELETED: _("Exhibitor form question deleted."),
     LOG_EMAIL_SENT: _("Email sent."),
 }
+
+
+def changed_field_labels(logentry):
+    """Render the stored field names of a change entry using their model labels."""
+    names = logentry.parsed_data.get("changed") or []
+    if not names:
+        return ""
+    model = type(logentry.content_object) if logentry.content_object else None
+    labels = []
+    for name in names:
+        label = name.replace("_", " ")
+        if model is not None:
+            try:
+                label = str(model._meta.get_field(name).verbose_name)
+            except (FieldDoesNotExist, AttributeError):
+                pass
+        labels.append(label)
+    return _("Updated: {fields}.").format(fields=", ".join(labels))
 
 
 def proposal_state_label(value):
@@ -326,6 +347,10 @@ def exhibition_logentry_display(sender, logentry, **kwargs):
                 new=proposal_state_label(data["to"]),
             )
             return f"{label} {transition}"
+
+    changed = changed_field_labels(logentry)
+    if changed:
+        return f"{label} {changed}"
     return label
 
 

--- a/exhibition/signals.py
+++ b/exhibition/signals.py
@@ -282,12 +282,12 @@ LOG_ENTRY_LABELS = {
     PROPOSAL_LOG_ACTIONS["reject"]: _("Exhibition request rejected."),
     PROPOSAL_LOG_ACTIONS["withdraw"]: _("Exhibition request withdrawn."),
     PROPOSAL_LOG_ACTIONS["reopen"]: _("Exhibition request reopened for review."),
-    LOG_PARTNER_CREATED: _("Partner profile created from an approved request."),
-    LOG_PARTNER_REACTIVATED: _("Partner profile reactivated after re-approval."),
-    LOG_PARTNER_SYNCED: _("Partner profile updated from the submitter's changes."),
-    LOG_PARTNER_ADDED: _("Partner created."),
-    LOG_PARTNER_CHANGED: _("Partner changed."),
-    LOG_PARTNER_DELETED: _("Partner deleted."),
+    LOG_PARTNER_CREATED: _("Organization profile created from an approved request."),
+    LOG_PARTNER_REACTIVATED: _("Organization profile reactivated after re-approval."),
+    LOG_PARTNER_SYNCED: _("Organization profile updated from the submitter's changes."),
+    LOG_PARTNER_ADDED: _("Organization profile created."),
+    LOG_PARTNER_CHANGED: _("Organization profile changed."),
+    LOG_PARTNER_DELETED: _("Organization profile deleted."),
     LOG_SETTINGS_CHANGED: _("Exhibition settings changed."),
     LOG_CALL_SETTINGS_CHANGED: _("Call for exhibitors settings changed."),
     LOG_CALL_SECRET_REGENERATED: _("Private call link regenerated."),
@@ -348,7 +348,7 @@ def exhibition_logentry_object_link(sender, logentry, **kwargs):
             "val": escape(localize_event_text(target.name) or str(target.name)),
         }
     elif isinstance(target, ExhibitorInfo):
-        a_text = _("Partner {val}")
+        a_text = _("Organization profile {val}")
         a_map = {
             "href": reverse(
                 "plugins:exhibition:edit",

--- a/exhibition/signals.py
+++ b/exhibition/signals.py
@@ -4,10 +4,14 @@ from django.dispatch import receiver
 from django.template.loader import get_template
 from django.templatetags.static import static
 from django.urls import reverse
-from django.utils.html import format_html, format_html_join
+from django.utils.html import escape, format_html, format_html_join
 from django.utils.translation import gettext_lazy as _
 from eventyay.base.email import SimpleFunctionalMailTextPlaceholder
-from eventyay.base.signals import register_mail_placeholders
+from eventyay.base.signals import (
+    logentry_display,
+    logentry_object_link,
+    register_mail_placeholders,
+)
 from eventyay.common.signals import user_menu_items
 from eventyay.common.utils.language import localize_event_text
 from eventyay.control.signals import event_dashboard_components
@@ -18,7 +22,31 @@ from eventyay.presale.signals import (
 )
 
 from .mail import proposal_public_url
-from .models import ExhibitionProposal, ExhibitorInfo, ExhibitorSettings, ExhibitorVoucher, SponsorGroup
+from .models import (
+    LOG_CALL_SECRET_REGENERATED,
+    LOG_CALL_SETTINGS_CHANGED,
+    LOG_EMAIL_SENT,
+    LOG_GROUP_ADDED,
+    LOG_GROUP_CHANGED,
+    LOG_GROUP_DELETED,
+    LOG_PARTNER_ADDED,
+    LOG_PARTNER_CHANGED,
+    LOG_PARTNER_CREATED,
+    LOG_PARTNER_DELETED,
+    LOG_PARTNER_REACTIVATED,
+    LOG_PARTNER_SYNCED,
+    LOG_PREFIX,
+    LOG_QUESTION_ADDED,
+    LOG_QUESTION_CHANGED,
+    LOG_QUESTION_DELETED,
+    LOG_SETTINGS_CHANGED,
+    PROPOSAL_LOG_ACTIONS,
+    ExhibitionProposal,
+    ExhibitorInfo,
+    ExhibitorSettings,
+    ExhibitorVoucher,
+    SponsorGroup,
+)
 from .utils import add_external_image_csp_sources, public_exhibitors_queryset
 
 
@@ -245,3 +273,79 @@ def exhibition_user_menu_item(sender, request=None, icon_class="", **kwargs):
         icon_class,
         _("Exhibition requests"),
     )
+
+
+LOG_ENTRY_LABELS = {
+    PROPOSAL_LOG_ACTIONS["approve"]: _("Exhibition request approved."),
+    PROPOSAL_LOG_ACTIONS["reject"]: _("Exhibition request rejected."),
+    PROPOSAL_LOG_ACTIONS["withdraw"]: _("Exhibition request withdrawn."),
+    PROPOSAL_LOG_ACTIONS["reopen"]: _("Exhibition request reopened for review."),
+    LOG_PARTNER_CREATED: _("Partner profile created from an approved request."),
+    LOG_PARTNER_REACTIVATED: _("Partner profile reactivated after re-approval."),
+    LOG_PARTNER_SYNCED: _("Partner profile updated from the submitter's changes."),
+    LOG_PARTNER_ADDED: _("Partner created."),
+    LOG_PARTNER_CHANGED: _("Partner changed."),
+    LOG_PARTNER_DELETED: _("Partner deleted."),
+    LOG_SETTINGS_CHANGED: _("Exhibition settings changed."),
+    LOG_CALL_SETTINGS_CHANGED: _("Call for exhibitors settings changed."),
+    LOG_CALL_SECRET_REGENERATED: _("Private call link regenerated."),
+    LOG_GROUP_ADDED: _("Sponsor group created."),
+    LOG_GROUP_CHANGED: _("Sponsor group changed."),
+    LOG_GROUP_DELETED: _("Sponsor group deleted."),
+    LOG_QUESTION_ADDED: _("Exhibitor form question created."),
+    LOG_QUESTION_CHANGED: _("Exhibitor form question changed."),
+    LOG_QUESTION_DELETED: _("Exhibitor form question deleted."),
+    LOG_EMAIL_SENT: _("Email sent."),
+}
+
+
+@receiver(signal=logentry_display, dispatch_uid="exhibition_logentry_display")
+def exhibition_logentry_display(sender, logentry, **kwargs):
+    if not logentry.action_type.startswith(LOG_PREFIX):
+        return
+
+    label = LOG_ENTRY_LABELS.get(logentry.action_type)
+    if not label:
+        return
+
+    if logentry.action_type in PROPOSAL_LOG_ACTIONS.values():
+        data = logentry.parsed_data
+        if data.get("from") and data.get("to"):
+            transition = _("State changed from {old} to {new}.").format(old=data["from"], new=data["to"])
+            return f"{label} {transition}"
+    return label
+
+
+@receiver(signal=logentry_object_link, dispatch_uid="exhibition_logentry_object_link")
+def exhibition_logentry_object_link(sender, logentry, **kwargs):
+    if not logentry.action_type.startswith(LOG_PREFIX):
+        return
+
+    target = logentry.content_object
+    a_text = None
+    a_map = None
+
+    if isinstance(target, ExhibitionProposal):
+        a_text = _("Exhibition request {val}")
+        a_map = {
+            "href": reverse(
+                "plugins:exhibition:proposal.detail",
+                kwargs={"organizer": sender.organizer.slug, "event": sender.slug, "code": target.code},
+            ),
+            "val": escape(localize_event_text(target.name) or str(target.name)),
+        }
+    elif isinstance(target, ExhibitorInfo):
+        a_text = _("Partner {val}")
+        a_map = {
+            "href": reverse(
+                "plugins:exhibition:edit",
+                kwargs={"organizer": sender.organizer.slug, "event": sender.slug, "pk": target.pk},
+            ),
+            "val": escape(localize_event_text(target.name) or str(target.name)),
+        }
+    elif isinstance(target, SponsorGroup):
+        return _("Sponsor group {val}").format(val=escape(target.localized_name))
+
+    if a_text and a_map:
+        a_map["val"] = '<a href="{href}">{val}</a>'.format_map(a_map)
+        return a_text.format_map(a_map)

--- a/exhibition/static/exhibition/css/history-panel.css
+++ b/exhibition/static/exhibition/css/history-panel.css
@@ -1,0 +1,7 @@
+.exhibition-history {
+    margin-top: 30px;
+}
+
+.exhibition-history .list-group {
+    margin-bottom: 0;
+}

--- a/exhibition/templates/exhibitors/add.html
+++ b/exhibition/templates/exhibitors/add.html
@@ -8,6 +8,7 @@
 {% block custom_header %}
     {{ block.super }}
     <link rel="stylesheet" href="{% static 'exhibition/css/exhibitors-add.css' %}">
+    <link rel="stylesheet" href="{% static 'exhibition/css/history-panel.css' %}">
 {% endblock %}
 
 {% block exhibitors_header %}

--- a/exhibition/templates/exhibitors/add.html
+++ b/exhibition/templates/exhibitors/add.html
@@ -253,5 +253,13 @@
         </a>
     </div>
 </form>
+{% if action == 'edit' %}
+    <div class="panel panel-default exhibition-history">
+        <div class="panel-heading">
+            <h3 class="panel-title">{% trans "History" %}</h3>
+        </div>
+        {% include "pretixcontrol/includes/logs.html" with obj=object %}
+    </div>
+{% endif %}
 <script type="text/javascript" src="{% static 'exhibition/js/exhibitors-add.js' %}"></script>
 {% endblock %}

--- a/exhibition/templates/exhibitors/proposal_detail.html
+++ b/exhibition/templates/exhibitors/proposal_detail.html
@@ -185,4 +185,12 @@
             {% endif %}
         </div>
     </form>
+    {% if can_manage %}
+        <div class="panel panel-default exhibition-history">
+            <div class="panel-heading">
+                <h3 class="panel-title">{% trans "History" %}</h3>
+            </div>
+            {% include "pretixcontrol/includes/logs.html" with obj=proposal %}
+        </div>
+    {% endif %}
 {% endblock %}

--- a/exhibition/templates/exhibitors/proposal_detail.html
+++ b/exhibition/templates/exhibitors/proposal_detail.html
@@ -2,6 +2,12 @@
 {% load i18n %}
 {% load bootstrap3 %}
 {% load event_tags %}
+{% load static %}
+
+{% block custom_header %}
+    {{ block.super }}
+    <link rel="stylesheet" href="{% static 'exhibition/css/history-panel.css' %}">
+{% endblock %}
 
 {% block title %}{{ request.event.name }} - {% trans "Review exhibition request" %}{% endblock %}
 

--- a/exhibition/utils.py
+++ b/exhibition/utils.py
@@ -115,8 +115,10 @@ def build_exhibitor_video_embed(url: str) -> dict | None:
     return None
 
 
-def create_exhibitor_from_proposal(proposal):
+def create_exhibitor_from_proposal(proposal, requestor=None):
     from .models import (
+        LOG_PARTNER_CREATED,
+        LOG_PARTNER_REACTIVATED,
         ExhibitionProposalState,
         ExhibitorExtraLink,
         ExhibitorInfo,
@@ -144,6 +146,11 @@ def create_exhibitor_from_proposal(proposal):
         proposal.profile_edited_at = None
         proposal.capture_profile_snapshot()
         proposal.save(update_fields=["state", "submitted", "profile_edited_at", "accepted_profile_snapshot", "updated"])
+        exhibitor.log_action(
+            LOG_PARTNER_REACTIVATED,
+            data={"proposal": proposal.code},
+            user=requestor,
+        )
         return exhibitor
 
     exhibitor = ExhibitorInfo.objects.create(
@@ -201,6 +208,11 @@ def create_exhibitor_from_proposal(proposal):
             "updated",
         ]
     )
+    exhibitor.log_action(
+        LOG_PARTNER_CREATED,
+        data={"proposal": proposal.code, "booth_id": exhibitor.booth_id},
+        user=requestor,
+    )
     return exhibitor
 
 
@@ -241,9 +253,9 @@ PROPOSAL_SYNCED_PROFILE_FIELDS = (
 )
 
 
-def sync_exhibitor_from_proposal(proposal):
+def sync_exhibitor_from_proposal(proposal, requestor=None):
     """Push submitter-owned profile fields of an accepted proposal onto its partner profile."""
-    from .models import ExhibitorExtraLink, ExhibitorSocialLink
+    from .models import LOG_PARTNER_SYNCED, ExhibitorExtraLink, ExhibitorSocialLink
 
     exhibitor = proposal.approved_exhibitor
     if not exhibitor:
@@ -276,5 +288,10 @@ def sync_exhibitor_from_proposal(proposal):
             )
             for link in proposal.extra_links.all()
         ]
+    )
+    exhibitor.log_action(
+        LOG_PARTNER_SYNCED,
+        data={"proposal": proposal.code},
+        user=requestor,
     )
     return exhibitor

--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -60,6 +60,7 @@ from .models import (
     LOG_PARTNER_ADDED,
     LOG_PARTNER_CHANGED,
     LOG_PARTNER_DELETED,
+    LOG_PROPOSAL_CHANGED,
     LOG_QUESTION_ADDED,
     LOG_QUESTION_CHANGED,
     LOG_QUESTION_DELETED,
@@ -855,6 +856,12 @@ class UserProposalEditView(
             and previous_state != ExhibitionProposalState.SUBMITTED
         ):
             send_proposal_confirmation(self.request.event, self.object, self.request.user)
+        if form.changed_data:
+            self.object.log_action(
+                LOG_PROPOSAL_CHANGED,
+                data={"changed": form.changed_data, "by": "submitter"},
+                user=self.request.user,
+            )
         if self.object.approved_exhibitor_id:
             sync_exhibitor_from_proposal(self.object, requestor=self.request.user)
         messages.success(self.request, _("Your changes have been saved."))
@@ -1248,6 +1255,12 @@ class ProposalDetailView(EventPermissionRequiredMixin, UpdateView):
     @transaction.atomic
     def form_valid(self, form):
         self.object = form.save()
+        if form.changed_data:
+            self.object.log_action(
+                LOG_PROPOSAL_CHANGED,
+                data={"changed": form.changed_data},
+                user=self.request.user,
+            )
         action = self.request.POST.get("action", "save")
         if action in PROPOSAL_REVIEW_ACTIONS:
             if not self.can_manage():

--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -360,7 +360,7 @@ class SettingsView(EventPermissionRequiredMixin, ListView):
                 group = form.save(commit=False)
                 group.event = request.event
                 group.save()
-                group.log_action(LOG_GROUP_ADDED, data={"name": str(group.name)}, user=request.user)
+                group.log_action(LOG_GROUP_ADDED, data={"name": group.localized_name}, user=request.user)
                 messages.success(self.request, _("Sponsor group added."))
                 return redirect(self.get_settings_url("sponsors"))
 
@@ -400,7 +400,7 @@ class SettingsView(EventPermissionRequiredMixin, ListView):
                     _("This sponsor group cannot be deleted while it is assigned to partners."),
                 )
             else:
-                group.log_action(LOG_GROUP_DELETED, data={"name": str(group.name)}, user=request.user)
+                group.log_action(LOG_GROUP_DELETED, data={"name": group.localized_name}, user=request.user)
                 group.delete()
                 messages.success(self.request, _("Sponsor group deleted."))
             return redirect(self.get_settings_url("sponsors"))
@@ -1567,7 +1567,7 @@ class ExhibitionQuestionCreateView(EventPermissionRequiredMixin, CreateView):
         response = super().form_valid(form)
         self.object.log_action(
             LOG_QUESTION_ADDED,
-            data={"question": str(self.object.question)},
+            data={"question": self.object.localized_question},
             user=self.request.user,
         )
         return response
@@ -1620,7 +1620,7 @@ class ExhibitionQuestionDeleteView(EventPermissionRequiredMixin, DeleteView):
     def form_valid(self, form):
         self.object.log_action(
             LOG_QUESTION_DELETED,
-            data={"question": str(self.object.question)},
+            data={"question": self.object.localized_question},
             user=self.request.user,
         )
         return super().form_valid(form)
@@ -1730,7 +1730,7 @@ class ExhibitorCreateView(ExhibitorLinkFormsetMixin, EventPermissionRequiredMixi
         self.save_link_formsets()
         self.object.log_action(
             LOG_PARTNER_ADDED,
-            data={"name": str(self.object.name), "booth_id": self.object.booth_id},
+            data={"name": localize_event_text(self.object.name), "booth_id": self.object.booth_id},
             user=self.request.user,
         )
         if access_newly_granted(form.instance) and queue_exhibitor_access_mail(
@@ -1830,7 +1830,7 @@ class ExhibitorDeleteView(EventPermissionRequiredMixin, DeleteView):
     def form_valid(self, form):
         self.object.log_action(
             LOG_PARTNER_DELETED,
-            data={"name": str(self.object.name), "booth_id": self.object.booth_id},
+            data={"name": localize_event_text(self.object.name), "booth_id": self.object.booth_id},
             user=self.request.user,
         )
         return super().form_valid(form)

--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -53,6 +53,17 @@ from .forms import (
     social_link_prefixes,
 )
 from .models import (
+    LOG_CALL_SETTINGS_CHANGED,
+    LOG_GROUP_ADDED,
+    LOG_GROUP_CHANGED,
+    LOG_GROUP_DELETED,
+    LOG_PARTNER_ADDED,
+    LOG_PARTNER_CHANGED,
+    LOG_PARTNER_DELETED,
+    LOG_QUESTION_ADDED,
+    LOG_QUESTION_CHANGED,
+    LOG_QUESTION_DELETED,
+    LOG_SETTINGS_CHANGED,
     PROPOSAL_DEFAULT_FIELD_KEYS,
     PROPOSAL_DEFAULT_FIELDS,
     PROPOSAL_REVIEW_ACTIONS,
@@ -306,6 +317,11 @@ class SettingsView(EventPermissionRequiredMixin, ListView):
             settings.exhibitors_access_mail_subject = request.POST.get("exhibitors_access_mail_subject", "")
             settings.exhibitors_access_mail_body = request.POST.get("exhibitors_access_mail_body", "")
             settings.save()
+            settings.log_action(
+                LOG_SETTINGS_CHANGED,
+                data={"allowed_fields": settings.allowed_fields},
+                user=request.user,
+            )
             messages.success(self.request, _("Settings have been saved."))
             return redirect(self.get_settings_url("exhibitors"))
 
@@ -317,12 +333,17 @@ class SettingsView(EventPermissionRequiredMixin, ListView):
             )
             if form.is_valid():
                 form.save()
+                settings.log_action(
+                    LOG_CALL_SETTINGS_CHANGED,
+                    data={"changed": form.changed_data},
+                    user=request.user,
+                )
                 messages.success(self.request, _("Call settings have been saved."))
                 return redirect(self.get_settings_url("call"))
             return self.render_to_response(self.get_context_data(call_settings_form=form))
 
         if action == "regenerate_call_secret":
-            settings.regenerate_call_secret()
+            settings.regenerate_call_secret(requestor=request.user)
             messages.success(
                 self.request,
                 _("A new secret call link has been generated. The old link no longer works."),
@@ -339,6 +360,7 @@ class SettingsView(EventPermissionRequiredMixin, ListView):
                 group = form.save(commit=False)
                 group.event = request.event
                 group.save()
+                group.log_action(LOG_GROUP_ADDED, data={"name": str(group.name)}, user=request.user)
                 messages.success(self.request, _("Sponsor group added."))
                 return redirect(self.get_settings_url("sponsors"))
 
@@ -359,6 +381,7 @@ class SettingsView(EventPermissionRequiredMixin, ListView):
             )
             if form.is_valid():
                 form.save()
+                group.log_action(LOG_GROUP_CHANGED, data={"changed": form.changed_data}, user=request.user)
                 messages.success(self.request, _("Sponsor group updated."))
                 return redirect(self.get_settings_url("sponsors"))
 
@@ -377,6 +400,7 @@ class SettingsView(EventPermissionRequiredMixin, ListView):
                     _("This sponsor group cannot be deleted while it is assigned to partners."),
                 )
             else:
+                group.log_action(LOG_GROUP_DELETED, data={"name": str(group.name)}, user=request.user)
                 group.delete()
                 messages.success(self.request, _("Sponsor group deleted."))
             return redirect(self.get_settings_url("sponsors"))
@@ -832,7 +856,7 @@ class UserProposalEditView(
         ):
             send_proposal_confirmation(self.request.event, self.object, self.request.user)
         if self.object.approved_exhibitor_id:
-            sync_exhibitor_from_proposal(self.object)
+            sync_exhibitor_from_proposal(self.object, requestor=self.request.user)
         messages.success(self.request, _("Your changes have been saved."))
         return response
 
@@ -873,7 +897,7 @@ class UserProposalWithdrawView(PublicCallEnabledMixin, PublicEventLoginRequiredM
     def post(self, request, *args, **kwargs):
         self.object = self.get_object()
         if self.object.can_be_withdrawn:
-            self.object.withdraw()
+            self.object.withdraw(requestor=request.user)
             messages.success(request, _("Your request has been withdrawn."))
         else:
             messages.error(request, _("This request can no longer be withdrawn."))
@@ -909,7 +933,7 @@ class UserProposalReinstateView(PublicCallEnabledMixin, PublicEventLoginRequired
     def post(self, request, *args, **kwargs):
         self.object = self.get_object()
         if self.object.can_be_reinstated:
-            self.object.reopen()
+            self.object.reopen(requestor=request.user)
             messages.success(request, _("Your request has been reinstated and is pending review again."))
         else:
             messages.error(request, _("This request can no longer be reinstated."))
@@ -1254,10 +1278,10 @@ class ProposalDetailView(EventPermissionRequiredMixin, UpdateView):
             self.object.reject(requestor=requestor)
             messages.success(self.request, _("Request rejected. A rejection email was placed in the outbox."))
         elif action == "withdraw":
-            self.object.withdraw()
+            self.object.withdraw(requestor=requestor)
             messages.success(self.request, _("Request withdrawn."))
         elif action == "reopen":
-            self.object.reopen()
+            self.object.reopen(requestor=requestor)
             messages.success(self.request, _("Request reopened for review."))
         return redirect(self.get_success_url())
 
@@ -1330,9 +1354,9 @@ class ProposalActionView(EventPermissionRequiredMixin, View):
         elif action == "reject":
             proposal.reject(requestor=self.request.user)
         elif action == "withdraw":
-            proposal.withdraw()
+            proposal.withdraw(requestor=self.request.user)
         elif action == "reopen":
-            proposal.reopen()
+            proposal.reopen(requestor=self.request.user)
 
     def build_message(self, action, count, skipped):
         if count:
@@ -1539,6 +1563,15 @@ class ExhibitionQuestionCreateView(EventPermissionRequiredMixin, CreateView):
         kwargs["event"] = self.request.event
         return kwargs
 
+    def form_valid(self, form):
+        response = super().form_valid(form)
+        self.object.log_action(
+            LOG_QUESTION_ADDED,
+            data={"question": str(self.object.question)},
+            user=self.request.user,
+        )
+        return response
+
     def get_success_url(self):
         return reverse(
             "plugins:exhibition:call.questions",
@@ -1560,6 +1593,15 @@ class ExhibitionQuestionEditView(EventPermissionRequiredMixin, UpdateView):
         kwargs["event"] = self.request.event
         return kwargs
 
+    def form_valid(self, form):
+        response = super().form_valid(form)
+        self.object.log_action(
+            LOG_QUESTION_CHANGED,
+            data={"changed": form.changed_data},
+            user=self.request.user,
+        )
+        return response
+
     def get_success_url(self):
         return reverse(
             "plugins:exhibition:call.questions",
@@ -1574,6 +1616,14 @@ class ExhibitionQuestionDeleteView(EventPermissionRequiredMixin, DeleteView):
 
     def get_queryset(self):
         return ExhibitionQuestion.objects.filter(event=self.request.event)
+
+    def form_valid(self, form):
+        self.object.log_action(
+            LOG_QUESTION_DELETED,
+            data={"question": str(self.object.question)},
+            user=self.request.user,
+        )
+        return super().form_valid(form)
 
     def get_success_url(self):
         return reverse(
@@ -1678,6 +1728,11 @@ class ExhibitorCreateView(ExhibitorLinkFormsetMixin, EventPermissionRequiredMixi
 
         response = super().form_valid(form)
         self.save_link_formsets()
+        self.object.log_action(
+            LOG_PARTNER_ADDED,
+            data={"name": str(self.object.name), "booth_id": self.object.booth_id},
+            user=self.request.user,
+        )
         if access_newly_granted(form.instance) and queue_exhibitor_access_mail(
             self.request.event, self.object, self.request.user
         ):
@@ -1735,6 +1790,11 @@ class ExhibitorEditView(ExhibitorLinkFormsetMixin, EventPermissionRequiredMixin,
 
         response = super().form_valid(form)
         self.save_link_formsets()
+        self.object.log_action(
+            LOG_PARTNER_CHANGED,
+            data={"changed": form.changed_data},
+            user=self.request.user,
+        )
         if access_newly_granted(form.instance, previous) and queue_exhibitor_access_mail(
             self.request.event, self.object, self.request.user
         ):
@@ -1766,6 +1826,14 @@ class ExhibitorDeleteView(EventPermissionRequiredMixin, DeleteView):
 
     def get_queryset(self):
         return ExhibitorInfo.objects.filter(event=self.request.event)
+
+    def form_valid(self, form):
+        self.object.log_action(
+            LOG_PARTNER_DELETED,
+            data={"name": str(self.object.name), "booth_id": self.object.booth_id},
+            user=self.request.user,
+        )
+        return super().form_valid(form)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
fixes #132

adds logs for:
1. Exhibition Requests
2. Exhibitors
3. Sponsors

<img width="1512" height="866" alt="image" src="https://github.com/user-attachments/assets/06deb70a-c54c-4830-89d2-5a21f6a2f2a4" />


## Summary by Sourcery

Add audit logging and history views for exhibition requests, exhibitor profiles, form questions, sponsor groups, settings, and outgoing emails.

New Features:
- Expose change history panels on exhibition request review and exhibitor profile pages using the global log view.
- Provide human-readable log messages and object links for exhibition-related actions via dedicated logentry display and object link signal handlers.

Enhancements:
- Adopt the shared LoggedModel base for key exhibition models to centralize action logging.
- Track proposal state transitions and partner activation changes with structured log entries including the acting user.
- Record detailed log entries for settings, call configuration, sponsor groups, exhibitor questions, exhibitor profiles, and profile sync operations.
- Log individual exhibition emails on the queue model instead of the event for more granular history.