### PR TITLE
fix: remove duplicate voucher fields and improve help text

### DIFF
--- a/exhibition/forms.py
+++ b/exhibition/forms.py
@@ -70,7 +70,7 @@ class ExhibitorInfoForm(I18nModelForm):
         required=False,
         label=_("Can view voucher redemptions"),
         help_text=_(
-            "Lets this exhibitor retrieve the attendees who redeemed vouchers issued to them. "
+            "Lets this exhibitor or sponsor retrieve the attendees who redeemed vouchers issued to them. "
             "Separate from lead scanning, which covers attendees scanned at the booth."
         ),
     )
@@ -232,6 +232,43 @@ class ExhibitorInfoForm(I18nModelForm):
                 key for key in settings.ordered_proposal_field_keys if self.profile_key_is_active(key)
             ]
             self._apply_profile_field_order()
+        self._set_voucher_access_help_text()
+
+    VOUCHER_ACCESS_HELP_TEXTS = {
+        "exhibitor": _(
+            "Lets this exhibitor retrieve the attendees who redeemed vouchers issued to them. "
+            "Separate from lead scanning, which covers attendees scanned at the booth."
+        ),
+        "sponsor": _(
+            "Lets this sponsor retrieve the attendees who redeemed vouchers issued to them. "
+            "Separate from lead scanning, which covers attendees scanned at the booth."
+        ),
+        "both": _(
+            "Lets this exhibitor and sponsor retrieve the attendees who redeemed vouchers issued to them. "
+            "Separate from lead scanning, which covers attendees scanned at the booth."
+        ),
+        "unset": _(
+            "Lets this exhibitor or sponsor retrieve the attendees who redeemed vouchers issued to them. "
+            "Separate from lead scanning, which covers attendees scanned at the booth."
+        ),
+    }
+
+    def _voucher_access_audience(self):
+        if self.partner_type in ("exhibitor", "sponsor"):
+            return self.partner_type
+        if self.instance and self.instance.pk:
+            if self.instance.is_exhibitor and self.instance.is_sponsor:
+                return "both"
+            if self.instance.is_exhibitor:
+                return "exhibitor"
+            if self.instance.is_sponsor:
+                return "sponsor"
+        return "unset"
+
+    def _set_voucher_access_help_text(self):
+        field = self.fields.get("allow_voucher_access")
+        if field is not None:
+            field.help_text = self.VOUCHER_ACCESS_HELP_TEXTS[self._voucher_access_audience()]
 
     def _apply_profile_field_settings(self):
         for key, field_names in self.PROFILE_SETTING_FIELD_MAP.items():

--- a/exhibition/templates/exhibitors/add.html
+++ b/exhibition/templates/exhibitors/add.html
@@ -219,7 +219,6 @@
         {% bootstrap_field form.lead_scanning_enabled layout="control" %}
         {% bootstrap_field form.allow_lead_access layout="control" %}
         {% bootstrap_field form.lead_scanning_scope_by_device layout="control" %}
-        {% bootstrap_field form.allow_voucher_access layout="control" %}
     </fieldset>
     {% endif %}
 


### PR DESCRIPTION
fixes #139

1. fixes the duplicate voucher redemption fields bug 
2. improves help text for voucher redemption field and makes the help text conditional

<img width="1512" height="866" alt="image" src="https://github.com/user-attachments/assets/4aa756ee-3657-4999-9af4-e77a6e1f15fc" />

## Summary by Sourcery

Fix voucher redemption access configuration by removing duplicate form rendering and making the help text audience-aware based on exhibitor/sponsor context.

Bug Fixes:
- Remove duplicate rendering of the voucher access field from the exhibitor creation form to prevent redundant voucher redemption configuration.

Enhancements:
- Make the voucher access help text dynamic so it reflects whether access applies to exhibitors, sponsors, or both, improving clarity for admins configuring partners.