### PR TITLE
Remove url fields for logo, header image, and slides

### DIFF
--- a/exhibition/forms.py
+++ b/exhibition/forms.py
@@ -50,21 +50,6 @@ def get_tz_help(event):
 
 
 class ExhibitorInfoForm(I18nModelForm):
-    slides_url = forms.URLField(
-        required=False,
-        label=_("Slides URL"),
-        help_text=_("Use an external PDF URL instead of uploading a slides file."),
-    )
-    logo_url = forms.URLField(
-        required=False,
-        label=_("Logo URL"),
-        help_text=_("Use an external image URL instead of uploading a logo file."),
-    )
-    header_image_url = forms.URLField(
-        required=False,
-        label=_("Header image URL"),
-        help_text=_("Use an external image URL instead of uploading a header image file."),
-    )
     sponsor_group = forms.ModelChoiceField(
         queryset=SponsorGroup.objects.none(),
         required=False,
@@ -139,11 +124,8 @@ class ExhibitorInfoForm(I18nModelForm):
             "contact_url",
             "video_url",
             "slides",
-            "slides_url",
             "logo",
-            "logo_url",
             "header_image",
-            "header_image_url",
             "is_exhibitor",
             "is_sponsor",
             "sponsor_group",
@@ -183,9 +165,9 @@ class ExhibitorInfoForm(I18nModelForm):
         "url": ("url",),
         "contact_url": ("contact_url",),
         "video_url": ("video_url",),
-        "slides": ("slides", "slides_url"),
-        "logo": ("logo", "logo_url"),
-        "header_image": ("header_image", "header_image_url"),
+        "slides": ("slides",),
+        "logo": ("logo",),
+        "header_image": ("header_image",),
         "booth_name": ("booth_name",),
     }
     PROFILE_FORMSET_KEYS = ("social_links", "extra_links")
@@ -332,7 +314,6 @@ class ExhibitorInfoForm(I18nModelForm):
         if video_url:
             cleaned_data["video_url"] = normalize_url_scheme(video_url)
 
-        slides_url = cleaned_data.get("slides_url") or ""
         submitted_slides = None
         if "slides" in self.fields:
             submitted_slides = self.fields["slides"].widget.value_from_datadict(
@@ -340,54 +321,17 @@ class ExhibitorInfoForm(I18nModelForm):
                 self.files,
                 self.add_prefix("slides"),
             )
-        has_new_slides_upload = isinstance(submitted_slides, UploadedFile)
-        if slides_url and has_new_slides_upload:
-            message = _("Either upload a PDF or enter an external PDF URL, not both.")
-            self.add_error("slides", message)
-            self.add_error("slides_url", message)
-        else:
-            if slides_url:
-                normalized_slides_url = normalize_url_scheme(slides_url)
-                if not normalized_slides_url.lower().split("?", 1)[0].endswith(".pdf"):
-                    self.add_error("slides_url", _("Slides URL must point to a PDF file."))
-                else:
-                    cleaned_data["slides_url"] = normalized_slides_url
-
-            if has_new_slides_upload:
-                slides_file = self.files.get(self.add_prefix("slides"))
-                filename = (slides_file.name or "").lower() if slides_file else ""
-                content_type = (slides_file.content_type or "").lower() if slides_file else ""
-                if not filename.endswith(".pdf"):
-                    self.add_error("slides", _("Slides upload must be a PDF file."))
-                elif content_type and content_type not in {
-                    "application/pdf",
-                    "application/x-pdf",
-                }:
-                    self.add_error("slides", _("Slides upload must be a PDF file."))
-
-        for image_field, url_field in self.file_url_fields.items():
-            if image_field == "slides":
-                continue
-            if image_field not in self.fields and url_field not in self.fields:
-                continue
-            image_url = cleaned_data.get(url_field) or ""
-            submitted_image = None
-            if image_field in self.fields:
-                submitted_image = self.fields[image_field].widget.value_from_datadict(
-                    self.data,
-                    self.files,
-                    self.add_prefix(image_field),
-                )
-            has_new_upload = isinstance(submitted_image, UploadedFile)
-
-            if image_url and has_new_upload:
-                message = _("Either upload a file or enter an external URL, not both.")
-                self.add_error(image_field, message)
-                self.add_error(url_field, message)
-                continue
-
-            if image_url:
-                cleaned_data[url_field] = normalize_url_scheme(image_url)
+        if isinstance(submitted_slides, UploadedFile):
+            slides_file = self.files.get(self.add_prefix("slides"))
+            filename = (slides_file.name or "").lower() if slides_file else ""
+            content_type = (slides_file.content_type or "").lower() if slides_file else ""
+            if not filename.endswith(".pdf"):
+                self.add_error("slides", _("Slides upload must be a PDF file."))
+            elif content_type and content_type not in {
+                "application/pdf",
+                "application/x-pdf",
+            }:
+                self.add_error("slides", _("Slides upload must be a PDF file."))
 
         if self.partner_type == "sponsor":
             is_sponsor = True
@@ -437,19 +381,9 @@ class ExhibitorInfoForm(I18nModelForm):
         files_to_delete: set[str] = set()
 
         for image_field, url_field in self.file_url_fields.items():
-            if image_field == "slides":
-                continue
             previous_file = getattr(old_instance, image_field, None) if old_instance else None
             uploaded_file = self.files.get(self.add_prefix(image_field))
             clear_selected = bool(self.data.get(self.add_prefix(f"{image_field}-clear")))
-            image_url = self.cleaned_data.get(url_field) or ""
-
-            if image_url:
-                if previous_file and previous_file.name:
-                    files_to_delete.add(previous_file.name)
-                setattr(instance, image_field, None)
-                setattr(instance, url_field, image_url)
-                continue
 
             if uploaded_file:
                 if previous_file and previous_file.name:
@@ -462,26 +396,6 @@ class ExhibitorInfoForm(I18nModelForm):
                     files_to_delete.add(previous_file.name)
                 setattr(instance, image_field, None)
                 setattr(instance, url_field, "")
-
-        previous_slides = getattr(old_instance, "slides", None) if old_instance else None
-        uploaded_slides = self.files.get(self.add_prefix("slides"))
-        clear_slides = bool(self.data.get(self.add_prefix("slides-clear")))
-        slides_url = self.cleaned_data.get("slides_url") or ""
-
-        if slides_url:
-            if previous_slides and previous_slides.name:
-                files_to_delete.add(previous_slides.name)
-            instance.slides = None
-            instance.slides_url = slides_url
-        elif uploaded_slides:
-            if previous_slides and previous_slides.name:
-                files_to_delete.add(previous_slides.name)
-            instance.slides_url = ""
-        elif clear_slides:
-            if previous_slides and previous_slides.name:
-                files_to_delete.add(previous_slides.name)
-            instance.slides = None
-            instance.slides_url = ""
 
         if commit:
             instance.save()
@@ -773,22 +687,6 @@ class ExhibitionQuestionFieldsMixin:
 
 
 class ExhibitionProposalForm(ExhibitionQuestionFieldsMixin, I18nModelForm):
-    slides_url = forms.URLField(
-        required=False,
-        label=_("Slides URL"),
-        help_text=_("Use an external PDF URL instead of uploading a slides file."),
-    )
-    logo_url = forms.URLField(
-        required=False,
-        label=_("Logo URL"),
-        help_text=_("Use an external image URL instead of uploading a logo file."),
-    )
-    header_image_url = forms.URLField(
-        required=False,
-        label=_("Header image URL"),
-        help_text=_("Use an external image URL instead of uploading a header image file."),
-    )
-
     file_url_fields = {
         "slides": "slides_url",
         "logo": "logo_url",
@@ -801,9 +699,9 @@ class ExhibitionProposalForm(ExhibitionQuestionFieldsMixin, I18nModelForm):
         "url": ("url",),
         "contact_url": ("contact_url",),
         "video_url": ("video_url",),
-        "slides": ("slides", "slides_url"),
-        "logo": ("logo", "logo_url"),
-        "header_image": ("header_image", "header_image_url"),
+        "slides": ("slides",),
+        "logo": ("logo",),
+        "header_image": ("header_image",),
         "booth_name": ("booth_name",),
         "notes": ("notes",),
     }
@@ -819,11 +717,8 @@ class ExhibitionProposalForm(ExhibitionQuestionFieldsMixin, I18nModelForm):
             "contact_url",
             "video_url",
             "slides",
-            "slides_url",
             "logo",
-            "logo_url",
             "header_image",
-            "header_image_url",
             "url",
             "booth_name",
             "notes",
@@ -1015,7 +910,6 @@ class ExhibitionProposalForm(ExhibitionQuestionFieldsMixin, I18nModelForm):
         if "video_url" in self.fields and (video_url := cleaned_data.get("video_url")):
             cleaned_data["video_url"] = normalize_url_scheme(video_url)
 
-        slides_url = cleaned_data.get("slides_url") or ""
         submitted_slides = None
         if "slides" in self.fields:
             submitted_slides = self.fields["slides"].widget.value_from_datadict(
@@ -1024,53 +918,16 @@ class ExhibitionProposalForm(ExhibitionQuestionFieldsMixin, I18nModelForm):
                 self.add_prefix("slides"),
             )
         has_new_slides_upload = isinstance(submitted_slides, UploadedFile)
-        if slides_url and has_new_slides_upload:
-            message = _("Either upload a PDF or enter an external PDF URL, not both.")
-            self.add_error("slides", message)
-            self.add_error("slides_url", message)
-        elif slides_url:
-            normalized_slides_url = normalize_url_scheme(slides_url)
-            if not normalized_slides_url.lower().split("?", 1)[0].endswith(".pdf"):
-                self.add_error("slides_url", _("Slides URL must point to a PDF file."))
-            else:
-                cleaned_data["slides_url"] = normalized_slides_url
-
-        for image_field, url_field in self.file_url_fields.items():
-            if image_field == "slides":
-                continue
-            if image_field not in self.fields and url_field not in self.fields:
-                continue
-            image_url = cleaned_data.get(url_field) or ""
-            submitted_image = None
-            if image_field in self.fields:
-                submitted_image = self.fields[image_field].widget.value_from_datadict(
-                    self.data,
-                    self.files,
-                    self.add_prefix(image_field),
-                )
-            has_new_upload = isinstance(submitted_image, UploadedFile)
-            if image_url and has_new_upload:
-                message = _("Either upload a file or enter an external URL, not both.")
-                self.add_error(image_field, message)
-                self.add_error(url_field, message)
-            elif image_url:
-                cleaned_data[url_field] = normalize_url_scheme(image_url)
-
-        self.validate_required_file_or_url("slides", has_new_slides_upload)
+        self.validate_required_file("slides", has_new_slides_upload)
         for image_field in ("logo", "header_image"):
-            if image_field not in self.fields and self.file_url_fields[image_field] not in self.fields:
+            if image_field not in self.fields:
                 continue
-            submitted_image = None
-            if image_field in self.fields:
-                submitted_image = self.fields[image_field].widget.value_from_datadict(
-                    self.data,
-                    self.files,
-                    self.add_prefix(image_field),
-                )
-            self.validate_required_file_or_url(
-                image_field,
-                isinstance(submitted_image, UploadedFile),
+            submitted_image = self.fields[image_field].widget.value_from_datadict(
+                self.data,
+                self.files,
+                self.add_prefix(image_field),
             )
+            self.validate_required_file(image_field, isinstance(submitted_image, UploadedFile))
 
         if not cleaned_data["is_exhibitor"]:
             cleaned_data["booth_name"] = ""
@@ -1084,22 +941,17 @@ class ExhibitionProposalForm(ExhibitionQuestionFieldsMixin, I18nModelForm):
 
         return cleaned_data
 
-    def validate_required_file_or_url(self, field_name, has_new_upload):
+    def validate_required_file(self, field_name, has_new_upload):
+        """Flag a required file field when nothing is uploaded and nothing is stored."""
         if self.draft_save:
             return
         if not self.field_setting_is_active(field_name) or not self.field_setting_is_required(field_name):
             return
-        file_field = self.fields.get(field_name)
-        url_field_name = self.file_url_fields[field_name]
-        if file_field is None and url_field_name not in self.fields:
+        if field_name not in self.fields:
             return
-        has_url = bool(self.cleaned_data.get(url_field_name))
         has_existing = bool(getattr(self.instance, f"visible_{field_name}_url", ""))
-        if not has_new_upload and not has_url and not has_existing:
-            self.add_error(
-                field_name if file_field else url_field_name,
-                _("This field is required."),
-            )
+        if not has_new_upload and not has_existing:
+            self.add_error(field_name, _("This field is required."))
 
     def save(self, commit=True):
         instance = super().save(commit=False)

--- a/exhibition/static/exhibition/js/exhibitors-add.js
+++ b/exhibition/static/exhibition/js/exhibitors-add.js
@@ -33,13 +33,7 @@
             }
         }
 
-        function getImagePreviewSource(pair, fileInput, urlInput, clearCheckbox) {
-            var urlValue = urlInput.value.trim()
-            if (urlValue) {
-                revokePreviewObjectUrl(pair)
-                return urlValue
-            }
-
+        function getImagePreviewSource(pair, fileInput, clearCheckbox) {
             if (fileInput.files && fileInput.files.length > 0) {
                 revokePreviewObjectUrl(pair)
                 var objectUrl = URL.createObjectURL(fileInput.files[0])
@@ -57,13 +51,12 @@
 
         function initImageSourcePair(pair) {
             var fileInput = document.getElementById(pair.dataset.fileInputId)
-            var urlInput = document.getElementById(pair.dataset.urlInputId)
             var preview = pair.querySelector('[data-image-preview]')
             var previewLink = pair.querySelector('[data-image-preview-link]')
             var previewImage = pair.querySelector('[data-image-preview-image]')
             var previewError = pair.querySelector('[data-image-preview-error]')
 
-            if (!fileInput || !urlInput || !preview || !previewLink || !previewImage) {
+            if (!fileInput || !preview || !previewLink || !previewImage) {
                 return
             }
 
@@ -72,22 +65,7 @@
                 : null
 
             function syncImageState() {
-                var urlValue = urlInput.value.trim()
-                var hasUrl = urlValue.length > 0
-                var hasSelectedFile = Boolean(fileInput.files && fileInput.files.length > 0)
-                var hasCurrentFile = pair.dataset.hasCurrentFile === 'true' && !(clearCheckbox && clearCheckbox.checked)
-
-                if (hasUrl && hasSelectedFile) {
-                    fileInput.value = ''
-                }
-
-                fileInput.disabled = hasUrl
-                if (clearCheckbox) {
-                    clearCheckbox.disabled = hasUrl
-                }
-                urlInput.disabled = !hasUrl && (hasSelectedFile || hasCurrentFile)
-
-                var previewSource = getImagePreviewSource(pair, fileInput, urlInput, clearCheckbox)
+                var previewSource = getImagePreviewSource(pair, fileInput, clearCheckbox)
                 if (!previewSource) {
                     setVisibleState(preview, false)
                     setVisibleState(previewLink, false)
@@ -118,13 +96,7 @@
                 setVisibleState(previewError, true)
             })
 
-            urlInput.addEventListener('input', syncImageState)
-            fileInput.addEventListener('change', function () {
-                if (fileInput.files && fileInput.files.length > 0) {
-                    urlInput.value = ''
-                }
-                syncImageState()
-            })
+            fileInput.addEventListener('change', syncImageState)
             if (clearCheckbox) {
                 clearCheckbox.addEventListener('change', function () {
                     if (clearCheckbox.checked) {

--- a/exhibition/templates/exhibitors/add.html
+++ b/exhibition/templates/exhibitors/add.html
@@ -137,17 +137,14 @@
                 </div>
             {% elif item.kind == 'slides' %}
                 {% bootstrap_field form.slides layout="control" %}
-                {% bootstrap_field form.slides_url layout="control" %}
             {% elif item.kind == 'logo' %}
                 <div
                     data-partner-image-source-pair
                     data-file-input-id="{{ form.logo.id_for_label }}"
-                    data-url-input-id="{{ form.logo_url.id_for_label }}"
                     data-current-preview-url="{{ form.instance.visible_logo_url }}"
                     data-has-current-file="{{ form.instance.logo|yesno:'true,false' }}"
                 >
                     {% bootstrap_field form.logo layout="control" %}
-                    {% bootstrap_field form.logo_url layout="control" %}
                     <div class="form-group" data-image-preview hidden>
                         <label class="col-md-3 control-label">{% trans "Logo preview" %}</label>
                         <div class="col-md-9">
@@ -162,12 +159,10 @@
                 <div
                     data-partner-image-source-pair
                     data-file-input-id="{{ form.header_image.id_for_label }}"
-                    data-url-input-id="{{ form.header_image_url.id_for_label }}"
                     data-current-preview-url="{{ form.instance.visible_header_image_url }}"
                     data-has-current-file="{{ form.instance.header_image|yesno:'true,false' }}"
                 >
                     {% bootstrap_field form.header_image layout="control" %}
-                    {% bootstrap_field form.header_image_url layout="control" %}
                     <div class="form-group" data-image-preview hidden>
                         <label class="col-md-3 control-label">{% trans "Header image preview" %}</label>
                         <div class="col-md-9">

--- a/exhibition/templates/exhibitors/public_proposal_form.html
+++ b/exhibition/templates/exhibitors/public_proposal_form.html
@@ -123,17 +123,14 @@
                 </div>
             {% elif item.kind == 'slides' %}
                 {% bootstrap_field form.slides layout="control" %}
-                {% bootstrap_field form.slides_url layout="control" %}
             {% elif item.kind == 'logo' %}
                 <div
                     data-partner-image-source-pair
                     data-file-input-id="{{ form.logo.id_for_label }}"
-                    data-url-input-id="{{ form.logo_url.id_for_label }}"
                     data-current-preview-url="{{ form.instance.visible_logo_url }}"
                     data-has-current-file="{{ form.instance.logo|yesno:'true,false' }}"
                 >
                     {% bootstrap_field form.logo layout="control" %}
-                    {% bootstrap_field form.logo_url layout="control" %}
                     <div class="form-group" data-image-preview hidden>
                         <label class="col-md-3 control-label">{% trans "Logo preview" %}</label>
                         <div class="col-md-9">
@@ -148,12 +145,10 @@
                 <div
                     data-partner-image-source-pair
                     data-file-input-id="{{ form.header_image.id_for_label }}"
-                    data-url-input-id="{{ form.header_image_url.id_for_label }}"
                     data-current-preview-url="{{ form.instance.visible_header_image_url }}"
                     data-has-current-file="{{ form.instance.header_image|yesno:'true,false' }}"
                 >
                     {% bootstrap_field form.header_image layout="control" %}
-                    {% bootstrap_field form.header_image_url layout="control" %}
                     <div class="form-group" data-image-preview hidden>
                         <label class="col-md-3 control-label">{% trans "Header image preview" %}</label>
                         <div class="col-md-9">


### PR DESCRIPTION
fixes #153 

<img width="1509" height="870" alt="image" src="https://github.com/user-attachments/assets/1b42862b-dac9-48d3-a869-be2d34b427c6" />

## Summary by Sourcery

Remove external URL inputs for exhibition slides, logos, and header images and standardize these fields around file uploads.

Enhancements:
- Require uploaded files for slides, logos, and header images instead of allowing external URLs.
- Simplify image previews and form interactions to use uploaded files only.