### PR TITLE
Simplify exhibitor form default fields 

### DIFF
--- a/exhibition/models.py
+++ b/exhibition/models.py
@@ -127,28 +127,63 @@ PROPOSAL_DEFAULT_FIELDS = (
         "active_locked": True,
         "required_locked": True,
     },
-    {"key": "description", "label": _("Organization description"), "active": True},
+    {
+        "key": "description",
+        "label": _("Organization description"),
+        "active": True,
+        "required": True,
+    },
     {"key": "email", "label": _("Contact email"), "active": False},
-    {"key": "url", "label": _("Organization website"), "active": False},
+    {
+        "key": "url",
+        "label": _("Organization website"),
+        "active": True,
+        "required": True,
+    },
     {"key": "contact_url", "label": _("Contact page URL"), "active": False},
     {"key": "video_url", "label": _("Promotional video URL"), "active": False},
     {"key": "slides", "label": _("Promotional slides"), "active": False},
-    {"key": "logo", "label": _("Logo"), "active": False},
+    {
+        "key": "logo",
+        "label": _("Logo"),
+        "active": True,
+        "required": True,
+        "active_locked": True,
+        "required_locked": True,
+        "help_text": _(
+            "Accepted formats: PNG, JPG, SVG. "
+            "Recommended size: 400 × 400 px. Maximum file size: 2 MB. "
+            "This field is required for the exhibitor profile to display on the public event page "
+            "and cannot be removed."
+        ),
+    },
     {
         "key": "header_image",
-        "label": _("Header image"),
-        "active": False,
+        "label": _("Exhibition banner"),
+        "active": True,
+        "required": True,
+        "active_locked": True,
+        "required_locked": True,
+        "help_text": _(
+            "Accepted formats: PNG, JPG, SVG. "
+            "Recommended size: 1200 × 400 px. Maximum file size: 5 MB. "
+            "This field is required for the exhibitor profile to display on the public event page "
+            "and cannot be removed."
+        ),
     },
     {"key": "booth_name", "label": _("Preferred booth name"), "active": False},
     {
         "key": "notes",
-        "label": _("Message to the organizers"),
-        "active": False,
+        "label": _("Notes"),
+        "active": True,
+        "required": False,
     },
     {
         "key": "social_links",
         "label": _("Social media"),
-        "active": False,
+        "active": True,
+        "required": True,
+        "supports_required": False,
     },
     {
         "key": "extra_links",
@@ -249,10 +284,12 @@ class ExhibitorSettings(LoggedModel):
             normalized[key]["position"] = stored_field.get("position", index)
             custom_label = (stored_field.get("label") or "").strip() or None
             custom_help_text = (stored_field.get("help_text") or "").strip() or None
+            # Fall back to the field-level default help text when no custom one is saved.
+            default_help_text = str(field.get("help_text") or "")
             normalized[key]["custom_label"] = custom_label
             normalized[key]["custom_help_text"] = custom_help_text
             normalized[key]["label"] = custom_label or field["label"]
-            normalized[key]["help_text"] = custom_help_text or ""
+            normalized[key]["help_text"] = custom_help_text or default_help_text
             normalized[key]["default_label"] = field["label"]
             if field.get("active_locked"):
                 normalized[key]["active"] = True

--- a/exhibition/templates/exhibitors/call_questions.html
+++ b/exhibition/templates/exhibitors/call_questions.html
@@ -22,6 +22,10 @@
         <fieldset>
             <legend>{% trans "Form fields" %}</legend>
             <p>{% trans "Choose which fields are shown on the exhibitor form and drag any row to reorder it." %}</p>
+            <div class="alert alert-info">
+                <i class="fa fa-lock"></i>
+                {% trans "Fields marked with a lock icon are required for the exhibitor profile to display on the public event page and cannot be removed." %}
+            </div>
             <div class="table-responsive table-responsive-always mw-100">
                 <table class="table table-hover dragsort-table">
                     <thead>
@@ -29,7 +33,6 @@
                         <th>{% trans "Field" %}</th>
                         <th class="text-center">{% trans "Active" %}</th>
                         <th class="text-center">{% trans "Required" %}</th>
-                        <th class="text-center">{% trans "Answers" %}</th>
                         <th class="text-right">{% trans "Settings" %}</th>
                     </tr>
                     </thead>
@@ -67,7 +70,6 @@
                                     <span class="text-muted">-</span>
                                 {% endif %}
                             </td>
-                            <td class="text-center">{{ field.answer_count }}</td>
                             <td class="text-right">
                                 {% if field.is_custom %}
                                     <a class="btn btn-default btn-sm" href="{% url 'plugins:exhibition:call.questions.edit' organizer=request.event.organizer.slug event=request.event.slug pk=field.pk %}" title="{% trans 'Edit' %}"><i class="fa fa-edit"></i></a>


### PR DESCRIPTION
Closes #163

Simplifies the exhibitor form by reducing the number of default active fields and removing the redundant **Answers** column from the form management table.

## Changes

### Task 1 — Reduce default fields

The form now shows only the fields needed for a correct public exhibitor profile by default:

| Field | Active | Required | Locked |
| --- | --- | --- | --- |
| Name | ✅ | ✅ | 🔒 Unchanged |
| Description | ✅ | ✅ | — |
| Website | ✅ | ✅ | — |
| Logo | ✅ | ✅ | 🔒 New |
| Exhibition banner | ✅ | ✅ | 🔒 New |
| Social media | ✅ | — | — |
| Notes | ✅ | Optional | — |

- **Logo** and **Exhibition banner** are now locked and cannot be deactivated because they are required for the exhibitor profile to display on the public event page.
- Both locked image fields include help text specifying accepted formats (PNG, JPG, SVG), recommended dimensions, maximum file size, and an explanation of why the field is locked.
- `header_image` label renamed to **Exhibition banner**.
- `notes` label renamed to **Notes** to match the issue specification.
- `normalized_proposal_field_settings` now falls back to the field-level default `help_text`, ensuring the image field help text appears without database customization.

### Task 2 — Remove the Answers column

- Removed the **Answers** column (header and data cell) from `call_questions.html`.
- Added a blue info notice above the table explaining that locked fields cannot be removed because they are required for the public exhibitor profile.

UI 

<img width="1463" height="656" alt="Screenshot 2026-08-22 at 11 52 43 PM" src="https://github.com/user-attachments/assets/e7e7ab97-dd90-4743-9bd6-ff528378bc25" />

## Summary by Sourcery

Simplify exhibitor form configuration around the fields required for public exhibitor profiles.

Enhancements:
- Simplify the default exhibitor form fields by enabling the core profile fields, making required image fields locked, and updating field labels and guidance.
- Preserve default field help text when no customized help text is configured.
- Remove the redundant Answers column from exhibitor form management and explain why locked fields cannot be removed.