### PR TITLE
fix: remove english template text from other locales

### DIFF
--- a/exhibition/forms.py
+++ b/exhibition/forms.py
@@ -1433,7 +1433,7 @@ class ExhibitionMailTemplatesForm(SettingsForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         for role in mail_helpers.LIFECYCLE_ROLES:
-            default_subject, default_body = mail_helpers.DEFAULT_TEMPLATES[role]
+            default_subject, default_body = mail_helpers.default_template_initial(role, self.locales)
             label = self._ROLE_LABELS[role]
             self.fields[mail_helpers.subject_settings_key(role)] = I18nFormField(
                 label=_("%(role)s — subject") % {"role": label},

--- a/exhibition/mail.py
+++ b/exhibition/mail.py
@@ -10,7 +10,7 @@ from urllib.parse import urljoin
 from django.conf import settings as django_settings
 from django.urls import reverse
 from django.utils.html import escape
-from django.utils.translation import gettext_lazy as _lazy, gettext_noop
+from django.utils.translation import gettext, gettext_lazy as _lazy, gettext_noop, override
 from i18nfield.strings import LazyI18nString
 
 logger = logging.getLogger(__name__)
@@ -51,67 +51,79 @@ def body_settings_key(role):
     return f"{_SETTINGS_PREFIX}{role}_body"
 
 
-DEFAULT_TEMPLATES = {
+DEFAULT_TEMPLATE_SOURCES = {
     PROPOSAL_NEW: (
-        LazyI18nString.from_gettext(gettext_noop("We received your request for {event_name}")),
-        LazyI18nString.from_gettext(
-            gettext_noop(
-                "Hello,\n\n"
-                "thank you for submitting your request “{request_name}” to "
-                "{event_name}. We have received it and will get back to you once it has "
-                "been reviewed.\n\n"
-                "You can review or edit your request here:\n{request_url}\n\n"
-                "Best regards,\n"
-                "The {event_name} team"
-            )
+        gettext_noop("We received your request for {event_name}"),
+        gettext_noop(
+            "Hello,\n\n"
+            "thank you for submitting your request \u201c{request_name}\u201d to "
+            "{event_name}. We have received it and will get back to you once it has "
+            "been reviewed.\n\n"
+            "You can review or edit your request here:\n{request_url}\n\n"
+            "Best regards,\n"
+            "The {event_name} team"
         ),
     ),
     PROPOSAL_ACCEPTED: (
-        LazyI18nString.from_gettext(gettext_noop("Your request for {event_name} has been accepted")),
-        LazyI18nString.from_gettext(
-            gettext_noop(
-                "Hello,\n\n"
-                "we are happy to let you know that your request “{request_name}” "
-                "for {event_name} has been accepted. We will be in touch with the next "
-                "steps.\n\n"
-                "Best regards,\n"
-                "The {event_name} team"
-            )
+        gettext_noop("Your request for {event_name} has been accepted"),
+        gettext_noop(
+            "Hello,\n\n"
+            "we are happy to let you know that your request \u201c{request_name}\u201d "
+            "for {event_name} has been accepted. We will be in touch with the next "
+            "steps.\n\n"
+            "Best regards,\n"
+            "The {event_name} team"
         ),
     ),
     PROPOSAL_REJECTED: (
-        LazyI18nString.from_gettext(gettext_noop("Update on your request for {event_name}")),
-        LazyI18nString.from_gettext(
-            gettext_noop(
-                "Hello,\n\n"
-                "thank you for your interest in {event_name}. Unfortunately we are unable "
-                "to accept your request “{request_name}” this time.\n\n"
-                "We hope to see you at a future event.\n\n"
-                "Best regards,\n"
-                "The {event_name} team"
-            )
+        gettext_noop("Update on your request for {event_name}"),
+        gettext_noop(
+            "Hello,\n\n"
+            "thank you for your interest in {event_name}. Unfortunately we are unable "
+            "to accept your request \u201c{request_name}\u201d this time.\n\n"
+            "We hope to see you at a future event.\n\n"
+            "Best regards,\n"
+            "The {event_name} team"
         ),
     ),
     EXHIBITOR_ACCESS: (
-        LazyI18nString.from_gettext(gettext_noop("Lead Scanning Access for {event_name}")),
-        LazyI18nString.from_gettext(
-            gettext_noop(
-                "Hello {exhibitor_name},\n\n"
-                "Please use the information below to activate the **Lead Scanning app**:\n\n"
-                "**Step 1 — Open the Web App:** access.eventyay.com\n\n"
-                "**Step 2 — Enter the Exhibitor Key:** {exhibitor_access_code}\n\n"
-                "**Step 3 — Set up each device** by scanning its QR code, or by entering its "
-                "setup URL and token manually:\n\n"
-                "{device_tokens}\n\n"
-                "*Each token is unique to one device and can only be used once. "
-                "If you set up additional devices, each device will require its own token.*\n\n"
-                "Please share these details with the team members who will be scanning leads at the event.\n\n"
-                "Best regards,\n"
-                "The {event_name} Team"
-            )
+        gettext_noop("Lead Scanning Access for {event_name}"),
+        gettext_noop(
+            "Hello {exhibitor_name},\n\n"
+            "Please use the information below to activate the **Lead Scanning app**:\n\n"
+            "**Step 1 \u2014 Open the Web App:** access.eventyay.com\n\n"
+            "**Step 2 \u2014 Enter the Exhibitor Key:** {exhibitor_access_code}\n\n"
+            "**Step 3 \u2014 Set up each device** by scanning its QR code, or by entering its "
+            "setup URL and token manually:\n\n"
+            "{device_tokens}\n\n"
+            "*Each token is unique to one device and can only be used once. "
+            "If you set up additional devices, each device will require its own token.*\n\n"
+            "Please share these details with the team members who will be scanning leads at the event.\n\n"
+            "Best regards,\n"
+            "The {event_name} Team"
         ),
     ),
 }
+
+DEFAULT_TEMPLATES = {
+    role: (LazyI18nString.from_gettext(subject), LazyI18nString.from_gettext(body))
+    for role, (subject, body) in DEFAULT_TEMPLATE_SOURCES.items()
+}
+
+
+def default_template_initial(role, locales):
+    """Default subject and body per locale, left blank where no translation exists."""
+    source_language = django_settings.LANGUAGE_CODE.split("-")[0]
+    initials = []
+    for msgid in DEFAULT_TEMPLATE_SOURCES[role]:
+        values = {}
+        for code in locales:
+            with override(code):
+                translated = gettext(msgid)
+            if translated != msgid or code.split("-")[0] == source_language:
+                values[code] = translated
+        initials.append(LazyI18nString(values))
+    return tuple(initials)
 
 
 def get_email_template(event, role):
@@ -132,7 +144,6 @@ _PREVIEW_URL_RE = re.compile(r"^(https?://|www\.)[^\s]+$")
 
 def build_preview_placeholders(event):
     """Sample placeholder values for previews, wrapped like the tickets preview."""
-    from django.utils.translation import gettext
     from eventyay.base.email import get_available_placeholders
 
     context = {}

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -6,6 +6,7 @@ import pytest
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.test import RequestFactory
 from django.utils import timezone
+from django.utils.translation import get_language
 from django_scopes import scopes_disabled
 from eventyay.base.models.auth import User
 
@@ -99,6 +100,48 @@ def test_templates_form_saves_to_event_settings(mail_event):
     subject, body = mail_helpers.get_email_template(mail_event, mail_helpers.PROPOSAL_NEW)
     assert str(subject) == "Saved subject"
     assert str(body) == "Saved body"
+
+
+@pytest.mark.django_db
+def test_default_template_initial_blanks_locales_without_translation():
+    """A locale with no catalog entry stays empty instead of inheriting the English msgid."""
+    source_subject, source_body = mail_helpers.DEFAULT_TEMPLATE_SOURCES[mail_helpers.PROPOSAL_NEW]
+
+    with patch("exhibition.mail.gettext", side_effect=lambda msgid: msgid):
+        subject, body = mail_helpers.default_template_initial(mail_helpers.PROPOSAL_NEW, ["en", "th"])
+
+    assert subject.data["en"] == source_subject
+    assert body.data["en"] == source_body
+    assert "th" not in subject.data
+    assert "th" not in body.data
+
+
+@pytest.mark.django_db
+def test_default_template_initial_uses_available_translation():
+    def fake_gettext(msgid):
+        return f"TH:{msgid}" if get_language() == "th" else msgid
+
+    with patch("exhibition.mail.gettext", side_effect=fake_gettext):
+        subject, body = mail_helpers.default_template_initial(mail_helpers.PROPOSAL_NEW, ["en", "th"])
+
+    source_subject, source_body = mail_helpers.DEFAULT_TEMPLATE_SOURCES[mail_helpers.PROPOSAL_NEW]
+    assert subject.data["th"] == f"TH:{source_subject}"
+    assert body.data["th"] == f"TH:{source_body}"
+    assert subject.data["en"] == source_subject
+
+
+@pytest.mark.django_db
+def test_templates_form_does_not_prefill_untranslated_locale(mail_event):
+    mail_event.settings.locales = ["en", "th"]
+
+    with patch("exhibition.mail.gettext", side_effect=lambda msgid: msgid):
+        form = ExhibitionMailTemplatesForm(obj=mail_event)
+
+    for role in mail_helpers.LIFECYCLE_ROLES:
+        for key in (mail_helpers.subject_settings_key(role), mail_helpers.body_settings_key(role)):
+            initial = form.fields[key].initial
+            assert initial.data["en"]
+            assert "th" not in initial.data
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
fixes #164 

Note: no data migration, if the templates were changed for existing event and saved, those wont get empty

<img width="1442" height="541" alt="image" src="https://github.com/user-attachments/assets/676fe25d-63d0-4cf0-8c1d-49050245944a" />

## Summary by Sourcery

Ensure email template defaults leave untranslated locales blank instead of copying English text into them.

Bug Fixes:
- Prevent untranslated locale fields from being prefilled with English email template text.

Enhancements:
- Generate localized default email template values only for locales with available translations while retaining English defaults and existing saved templates.

Tests:
- Add coverage for missing translations, available translations, and form initialization across locales.