### PR TITLE
fix: make reset button size match search button on exhibition search bar

### DIFF
--- a/exhibition/static/exhibition/css/exhibitors-public-list.css
+++ b/exhibition/static/exhibition/css/exhibitors-public-list.css
@@ -30,6 +30,7 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    gap: 6px;
     min-width: 110px;
     height: 34px;
     box-sizing: border-box;

--- a/exhibition/static/exhibition/css/exhibitors-public-list.css
+++ b/exhibition/static/exhibition/css/exhibitors-public-list.css
@@ -27,6 +27,12 @@
 .exhibition-public-filter-submit,
 .exhibition-public-filter-reset {
     flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 110px;
+    height: 34px;
+    box-sizing: border-box;
 }
 
 .exhibition-public-grid {

--- a/exhibition/templates/exhibitors/_filter_form.html
+++ b/exhibition/templates/exhibitors/_filter_form.html
@@ -15,9 +15,9 @@
             </div>
             <div class="advanced-filter-search-actions">
                 <a href="{{ request.path }}" class="btn btn-default btn-clear-filter"
-                   aria-label="{% trans 'Clear filters' %}" title="{% trans 'Clear filters' %}">
+                   aria-label="{% trans 'Clear' %}" title="{% trans 'Clear' %}">
                     <span class="fa fa-eraser" aria-hidden="true"></span>
-                    <span class="sr-only">{% trans "Clear filters" %}</span>
+                    {% trans "Clear" %}
                 </a>
                 {% if filter_form.advanced_fields %}
                     <button type="button"

--- a/exhibition/templates/exhibitors/public_list.html
+++ b/exhibition/templates/exhibitors/public_list.html
@@ -29,7 +29,7 @@
                     {% trans "Search" %}
                 </button>
                 <a href="{{ request.path }}" class="btn btn-default exhibition-public-filter-reset">
-                    {% trans "Reset" %}
+                    {% trans "Clear" %}
                 </a>
             </form>
             {% if exhibitors %}


### PR DESCRIPTION
## What
The "Clear filters" button on the exhibition search bar was icon-only
(its label was screen-reader-only), making it visually smaller than the
"Search" button next to it. This makes the label visible and renames it
to "Clear", matching Search's icon+text style.

## Why
Related to #170 (button-sizing part only). The fieldset-alignment part
of that issue needs visual verification in a running app before I can
confidently fix it, so I've scoped this PR to just the button fix.

## Testing
Template-only change, no logic touched. No existing tests reference
the button's text/markup.

## Summary by Sourcery

Align exhibition search-bar clear controls with the search button for a more consistent and accessible interface.

Bug Fixes:
- Make exhibition search and filter-clear controls consistent in size and presentation.

Enhancements:
- Display the clear action label alongside its icon and standardize its wording to “Clear” across exhibition search forms.