### PR TITLE
feat: add overview page for stats

### DIFF
--- a/exhibition/signals.py
+++ b/exhibition/signals.py
@@ -75,7 +75,7 @@ def exhibition_dashboard_component(sender, request=None, **kwargs):
         description = _("Screen and evaluate exhibitor and sponsor requests for the event.")
         link_label = _("Request Review Dashboard")
     else:
-        url = reverse("plugins:exhibition:info", kwargs=kwargs_url)
+        url = reverse("plugins:exhibition:dashboard", kwargs=kwargs_url)
         description = _(
             "Manage exhibitors and sponsors, maintain booth details, and create partner profiles for the event."
         )

--- a/exhibition/templates/exhibitors/base.html
+++ b/exhibition/templates/exhibitors/base.html
@@ -5,6 +5,12 @@
 {% block title %}{{ request.event.name }} - {% trans "Exhibitors & Sponsors" %}{% endblock %}
 
 {% block nav %}
+  <li>
+    <a href="{% url 'plugins:exhibition:dashboard' organizer=request.event.organizer.slug event=request.event.slug %}" {% if url_name == 'dashboard' %}class="active"{% endif %}>
+      <span class="fa fa-fw fa-dashboard"></span>
+      <span class="sidebar-text">{% trans "Overview" %}</span>
+    </a>
+  </li>
   {% if 'can_change_event_settings' in request.eventpermset %}
     <li>
       <a href="{% url 'plugins:exhibition:settings.exhibitors' organizer=request.event.organizer.slug event=request.event.slug %}" class="has-children">
@@ -59,7 +65,7 @@
   {% endif %}
   {% if 'can_change_event_settings' in request.eventpermset or 'can_view_orders' in request.eventpermset %}
     <li>
-      <a href="{% url 'plugins:exhibition:exhibitors' organizer=request.event.organizer.slug event=request.event.slug %}" {% if url_name == 'exhibitors' or url_name == 'exhibitors.add' or url_name == 'info' or url_name == 'add' or url_name == 'edit' and request.GET.type != 'sponsor' or url_name == 'delete' and request.GET.type != 'sponsor' %}class="active"{% endif %}>
+      <a href="{% url 'plugins:exhibition:exhibitors' organizer=request.event.organizer.slug event=request.event.slug %}" {% if url_name == 'exhibitors' or url_name == 'exhibitors.add' or url_name == 'add' or url_name == 'edit' and request.GET.type != 'sponsor' or url_name == 'delete' and request.GET.type != 'sponsor' %}class="active"{% endif %}>
         <span class="fa fa-fw fa-map-pin"></span>
         <span class="sidebar-text">{% trans "Exhibitors" %}</span>
       </a>

--- a/exhibition/templates/exhibitors/dashboard.html
+++ b/exhibition/templates/exhibitors/dashboard.html
@@ -1,0 +1,165 @@
+{% extends "exhibitors/base.html" %}
+{% load i18n %}
+{% load exhibition_email %}
+
+{% block title %}{{ request.event.name }} - {% trans "Exhibition overview" %}{% endblock %}
+
+{% block exhibitors_header %}
+  <h1>
+    {% trans "Exhibition overview" %}
+    <small class="text-muted">{{ request.event.get_date_range_display }}</small>
+  </h1>
+{% endblock %}
+
+{% block exhibitors_content %}
+  <div class="dashboard">
+    {% if show_partners %}
+      <div class="widget-container widget-small">
+        <a href="{% url 'plugins:exhibition:exhibitors' organizer=request.event.organizer.slug event=request.event.slug %}" class="widget">
+          <div class="numwidget">
+            <span class="num">{{ exhibitor_count }}</span>
+            <span class="text">{% trans "Exhibitors" %}</span>
+          </div>
+        </a>
+      </div>
+      <div class="widget-container widget-small">
+        <a href="{% url 'plugins:exhibition:sponsors' organizer=request.event.organizer.slug event=request.event.slug %}" class="widget">
+          <div class="numwidget">
+            <span class="num">{{ sponsor_count }}</span>
+            <span class="text">{% trans "Sponsors" %}</span>
+          </div>
+        </a>
+      </div>
+    {% endif %}
+    {% if show_requests %}
+      <div class="widget-container widget-small">
+        <a href="{% url 'plugins:exhibition:proposal.list' organizer=request.event.organizer.slug event=request.event.slug %}?state=submitted" class="widget">
+          <div class="numwidget">
+            <span class="num">{{ pending_request_count }}</span>
+            <span class="text">{% trans "Requests awaiting review" %}</span>
+          </div>
+        </a>
+      </div>
+      <div class="widget-container widget-small">
+        {% pending_email_count request.event as pending_emails %}
+        <a href="{% url 'plugins:exhibition:email.outbox' organizer=request.event.organizer.slug event=request.event.slug %}" class="widget">
+          <div class="numwidget">
+            <span class="num">{{ pending_emails }}</span>
+            <span class="text">{% trans "Emails in outbox" %}</span>
+          </div>
+        </a>
+      </div>
+    {% endif %}
+  </div>
+
+  <div class="row">
+    {% if show_requests %}
+      <div class="col-md-8">
+        <div class="panel panel-default">
+          <div class="panel-heading">
+            <h3 class="panel-title">
+              {% trans "Recent requests" %}
+              <a href="{% url 'plugins:exhibition:proposal.list' organizer=request.event.organizer.slug event=request.event.slug %}"
+                 class="pull-right flip">
+                <small>{% trans "View all" %}</small>
+              </a>
+            </h3>
+          </div>
+          {% if recent_requests %}
+            <div class="table-responsive">
+              <table class="table table-condensed table-hover">
+                <thead>
+                  <tr>
+                    <th>{% trans "Name" %}</th>
+                    <th>{% trans "Type" %}</th>
+                    <th>{% trans "State" %}</th>
+                    <th>{% trans "Submitted" %}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for proposal in recent_requests %}
+                    <tr>
+                      <td>
+                        <a href="{% url 'plugins:exhibition:proposal.detail' organizer=request.event.organizer.slug event=request.event.slug code=proposal.code %}">
+                          {{ proposal.name }}
+                        </a>
+                      </td>
+                      <td>
+                        {% if proposal.is_exhibitor and proposal.is_sponsor %}
+                          {% trans "Exhibitor and sponsor" %}
+                        {% elif proposal.is_sponsor %}
+                          {% trans "Sponsor" %}
+                        {% else %}
+                          {% trans "Exhibitor" %}
+                        {% endif %}
+                      </td>
+                      <td>{{ proposal.get_state_display }}</td>
+                      <td>{{ proposal.submitted|date:"SHORT_DATETIME_FORMAT"|default:"—" }}</td>
+                    </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+          {% else %}
+            <div class="panel-body text-muted">
+              {% trans "No requests have been submitted yet." %}
+            </div>
+          {% endif %}
+        </div>
+      </div>
+    {% endif %}
+
+    {% if exhibition_settings %}
+      <div class="col-md-4">
+        <div class="panel panel-default">
+          <div class="panel-heading">
+            <h3 class="panel-title">
+              {% trans "Call for exhibitors" %}
+              <a href="{% url 'plugins:exhibition:settings.call' organizer=request.event.organizer.slug event=request.event.slug %}"
+                 class="pull-right flip">
+                <small>{% trans "Edit" %}</small>
+              </a>
+            </h3>
+          </div>
+          <div class="panel-body">
+            {% if not exhibition_settings.call_enabled %}
+              <p>
+                <span class="label label-default">{% trans "Disabled" %}</span>
+                {% trans "The call is not published, so nobody can submit a request." %}
+              </p>
+            {% elif exhibition_settings.call_is_open %}
+              <p><span class="label label-success">{% trans "Open" %}</span></p>
+              {% if exhibition_settings.call_deadline %}
+                <p class="text-muted">
+                  {% blocktrans trimmed with deadline=exhibition_settings.call_deadline|date:"SHORT_DATETIME_FORMAT" %}
+                    Closes on {{ deadline }}.
+                  {% endblocktrans %}
+                </p>
+              {% else %}
+                <p class="text-muted">{% trans "No deadline set." %}</p>
+              {% endif %}
+            {% else %}
+              <p><span class="label label-warning">{% trans "Closed" %}</span></p>
+              <p class="text-muted">
+                {% blocktrans trimmed with deadline=exhibition_settings.call_deadline|date:"SHORT_DATETIME_FORMAT" %}
+                  The deadline passed on {{ deadline }}.
+                {% endblocktrans %}
+              </p>
+            {% endif %}
+            {% if exhibition_settings.call_private %}
+              <p class="text-muted">
+                <i class="fa fa-lock"></i> {% trans "Private — reachable only with the secret link." %}
+              </p>
+            {% endif %}
+            {% if exhibition_settings.call_enabled and not exhibition_settings.call_private %}
+              <a class="btn btn-default btn-sm"
+                 href="{% url 'plugins:exhibition:public_call' organizer=request.event.organizer.slug event=request.event.slug %}">
+                {% trans "View call page" %}
+              </a>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+    {% endif %}
+  </div>
+{% endblock %}

--- a/exhibition/templates/exhibitors/delete.html
+++ b/exhibition/templates/exhibitors/delete.html
@@ -19,7 +19,7 @@
     <button type="submit" class="btn btn-danger">{% trans "Delete" %}</button>
     <a
       class="btn btn-default"
-      href="{% url 'plugins:exhibition:info' organizer=request.event.organizer.slug event=request.event.slug %}"
+      href="{% url 'plugins:exhibition:exhibitors' organizer=request.event.organizer.slug event=request.event.slug %}"
     >
       {% trans "Cancel" %}
     </a>

--- a/exhibition/templates/exhibitors/vouchers.html
+++ b/exhibition/templates/exhibitors/vouchers.html
@@ -84,7 +84,7 @@
         <div class="form-group submit-group">
             <div class="col-md-9 col-md-offset-3">
                 <button type="submit" class="btn btn-primary">{% trans "Create vouchers" %}</button>
-                <a class="btn btn-default" href="{% url 'plugins:exhibition:info' organizer=request.event.organizer.slug event=request.event.slug %}">
+                <a class="btn btn-default" href="{% url 'plugins:exhibition:exhibitors' organizer=request.event.organizer.slug event=request.event.slug %}">
                     {% trans "Back" %}
                 </a>
             </div>

--- a/exhibition/urls.py
+++ b/exhibition/urls.py
@@ -15,6 +15,7 @@ from .views import (
     CallTextPreviewView,
     CustomEmailTemplateCreateView,
     CustomEmailTemplateDeleteView,
+    DashboardView,
     EmailBulkActionView,
     EmailComposeView,
     EmailDeleteView,
@@ -139,8 +140,8 @@ urlpatterns = [
     ),
     path(
         "exhibitors/event/<orgslug:organizer>/<slug:event>",
-        ExhibitorListView.as_view(partner_type="exhibitor"),
-        name="info",
+        DashboardView.as_view(),
+        name="dashboard",
     ),
     path(
         "exhibitors/event/<orgslug:organizer>/<slug:event>/exhibitors",

--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -203,6 +203,62 @@ class FilteredListMixin(PaginationMixin):
         return context
 
 
+class DashboardView(EventPermissionRequiredMixin, TemplateView):
+    """Landing page for the plugin: headline counts plus the most recent requests."""
+
+    template_name = "exhibitors/dashboard.html"
+    permission = (
+        "can_change_event_settings",
+        "can_view_orders",
+        "can_change_exhibition_proposals",
+        "is_exhibition_reviewer",
+    )
+
+    RECENT_REQUEST_LIMIT = 5
+
+    def can_view_partners(self):
+        return self.request.user.has_event_permission(
+            self.request.event.organizer,
+            self.request.event,
+            ("can_change_event_settings", "can_view_orders"),
+            request=self.request,
+        )
+
+    def can_review_requests(self):
+        return self.request.user.has_event_permission(
+            self.request.event.organizer,
+            self.request.event,
+            ("can_change_event_settings", "can_change_exhibition_proposals", "is_exhibition_reviewer"),
+            request=self.request,
+        )
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        event = self.request.event
+        context["show_partners"] = self.can_view_partners()
+        context["show_requests"] = self.can_review_requests()
+
+        if context["show_partners"]:
+            partners = ExhibitorInfo.objects.filter(event=event)
+            context["exhibitor_count"] = partners.filter(is_exhibitor=True).count()
+            context["sponsor_count"] = partners.filter(is_sponsor=True).count()
+
+        if context["show_requests"]:
+            proposals = ExhibitionProposal.objects.filter(event=event)
+            context["pending_request_count"] = proposals.filter(state=ExhibitionProposalState.SUBMITTED).count()
+            context["recent_requests"] = list(
+                proposals.exclude(state=ExhibitionProposalState.DRAFT).order_by("-submitted", "-pk")[
+                    : self.RECENT_REQUEST_LIMIT
+                ]
+            )
+
+        if self.request.user.has_event_permission(
+            event.organizer, event, "can_change_event_settings", request=self.request
+        ):
+            context["exhibition_settings"] = ExhibitorSettings.objects.filter(event=event).first()
+        return context
+
+
 class SettingsView(EventPermissionRequiredMixin, ListView):
     model = ExhibitorInfo
     template_name = "exhibitors/settings.html"
@@ -1888,13 +1944,7 @@ class ExhibitorDeleteView(EventPermissionRequiredMixin, DeleteView):
         return context
 
     def get_success_url(self) -> str:
-        return reverse(
-            "plugins:exhibition:info",
-            kwargs={
-                "organizer": self.request.event.organizer.slug,
-                "event": self.request.event.slug,
-            },
-        )
+        return partner_list_url(self.request.event, partner_type_of(self.object))
 
 
 class ExhibitorCopyKeyView(EventPermissionRequiredMixin, View):


### PR DESCRIPTION
fixes #172 


https://github.com/user-attachments/assets/abe546c7-5e09-4fcc-a3ac-890f11131a6d

## Summary by Sourcery

Add a permission-aware overview dashboard as the main landing page for exhibition management.

New Features:
- Add an exhibition overview dashboard with partner counts, pending requests, recent submissions, email outbox totals, and call-for-exhibitors status.

Bug Fixes:
- Update exhibition navigation and return links to route users to the appropriate dashboard or partner list pages.

Enhancements:
- Apply permission-aware dashboard sections so users only see exhibition information relevant to their event permissions.