### PR TITLE
fix(exhibition): align choice question options

### DIFF
--- a/exhibition/forms.py
+++ b/exhibition/forms.py
@@ -1384,6 +1384,21 @@ class ExhibitionDefaultFieldForm(forms.Form):
 
 
 class ExhibitionQuestionOptionForm(I18nModelForm):
+    def has_changed(self):
+        """Ignore the automatically submitted ordering value on blank extra rows."""
+        for name, field in self.fields.items():
+            if name in {"ORDER", "id"}:
+                continue
+
+            prefixed_name = self.add_prefix(name)
+            data_value = field.widget.value_from_datadict(self.data, self.files, prefixed_name)
+            initial_value = self.initial.get(name, field.initial)
+            if callable(initial_value):
+                initial_value = initial_value()
+            if field.has_changed(initial_value, data_value):
+                return True
+        return False
+
     class Meta:
         model = ExhibitionQuestionOption
         localized_fields = "__all__"

--- a/exhibition/forms.py
+++ b/exhibition/forms.py
@@ -1,6 +1,7 @@
 import dateutil.parser
 from django import forms
 from django.conf import settings as django_settings
+from django.core.exceptions import ValidationError
 from django.core.files.storage import default_storage
 from django.core.files.uploadedfile import UploadedFile
 from django.db import transaction
@@ -9,7 +10,7 @@ from django.forms import inlineformset_factory
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from django_countries.fields import CountryField
-from eventyay.base.forms import I18nModelForm, SettingsForm
+from eventyay.base.forms import I18nFormSet, I18nModelForm, SettingsForm
 from eventyay.base.forms.widgets import (
     DatePickerWidget,
     SplitDateTimePickerWidget,
@@ -1382,14 +1383,39 @@ class ExhibitionDefaultFieldForm(forms.Form):
         self.fields["label"].widget.attrs.setdefault("placeholder", self.field_setting["default_label"])
 
 
-class ExhibitionQuestionForm(I18nModelForm):
-    options_text = forms.CharField(
-        required=False,
-        label=_("Options"),
-        help_text=_("For choice fields, enter one option per line."),
-        widget=forms.Textarea(attrs={"rows": 6}),
-    )
+class ExhibitionQuestionOptionForm(I18nModelForm):
+    class Meta:
+        model = ExhibitionQuestionOption
+        localized_fields = "__all__"
+        fields = ["answer"]
 
+
+class BaseExhibitionQuestionOptionFormSet(I18nFormSet):
+    def __init__(self, *args, requires_option=False, **kwargs):
+        self.requires_option = requires_option
+        super().__init__(*args, **kwargs)
+
+    def clean(self):
+        super().clean()
+        if any(self.errors) or not self.requires_option:
+            return
+
+        if not any(form.cleaned_data.get("answer") and not form.cleaned_data.get("DELETE") for form in self.forms):
+            raise ValidationError(_("Please provide at least one option for this question type."))
+
+
+ExhibitionQuestionOptionFormSet = inlineformset_factory(
+    ExhibitionQuestion,
+    ExhibitionQuestionOption,
+    form=ExhibitionQuestionOptionForm,
+    formset=BaseExhibitionQuestionOptionFormSet,
+    can_order=True,
+    can_delete=True,
+    extra=0,
+)
+
+
+class ExhibitionQuestionForm(I18nModelForm):
     class Meta:
         model = ExhibitionQuestion
         localized_fields = "__all__"
@@ -1414,23 +1440,10 @@ class ExhibitionQuestionForm(I18nModelForm):
         self.event = kwargs.get("event")
         super().__init__(*args, **kwargs)
         self.fields["variant"].widget.attrs["data-question-variant"] = "1"
-        if self.instance and self.instance.pk:
-            self.fields["options_text"].initial = "\n".join(str(option) for option in self.instance.options.all())
 
     @property
     def choice_variant_values(self):
         return " ".join(sorted(str(variant) for variant in self.choice_variants))
-
-    def clean(self):
-        cleaned_data = super().clean()
-        variant = cleaned_data.get("variant")
-        options = [option.strip() for option in (cleaned_data.get("options_text") or "").splitlines() if option.strip()]
-        if variant in self.choice_variants and not options:
-            self.add_error(
-                "options_text",
-                _("Please provide at least one option for this question type."),
-            )
-        return cleaned_data
 
     def save(self, commit=True):
         instance = super().save(commit=False)
@@ -1443,28 +1456,7 @@ class ExhibitionQuestionForm(I18nModelForm):
             instance.position = max((max_position or -1) + 1, len(PROPOSAL_DEFAULT_FIELD_KEYS))
         if commit:
             instance.save()
-            self.save_options(instance)
         return instance
-
-    def save_options(self, question):
-        if question.variant not in self.choice_variants:
-            question.options.all().delete()
-            return
-        options = [
-            option.strip() for option in (self.cleaned_data.get("options_text") or "").splitlines() if option.strip()
-        ]
-        question.options.all().delete()
-        locale = self.event.locale if self.event else "en"
-        ExhibitionQuestionOption.objects.bulk_create(
-            [
-                ExhibitionQuestionOption(
-                    question=question,
-                    answer={locale: option},
-                    position=index,
-                )
-                for index, option in enumerate(options)
-            ]
-        )
 
 
 class ExhibitorSocialLinkForm(forms.ModelForm):

--- a/exhibition/static/exhibition/css/question-form.css
+++ b/exhibition/static/exhibition/css/question-form.css
@@ -1,0 +1,3 @@
+#answer-options.exhibition-answer-options .answer-options-group > .control-label {
+    padding-top: 7px;
+}

--- a/exhibition/static/exhibition/css/question-form.css
+++ b/exhibition/static/exhibition/css/question-form.css
@@ -13,3 +13,58 @@
 #exhibition-answer-options.exhibition-answer-options .answer-options-group > .control-label {
     padding-top: 7px;
 }
+
+#exhibition-answer-options .question-option-item {
+    margin-bottom: 12px;
+}
+
+#exhibition-answer-options .question-option-item:last-child {
+    margin-bottom: 0;
+}
+
+#exhibition-answer-options .question-option-label {
+    color: #777;
+    font-size: 12px;
+    margin-bottom: 4px;
+}
+
+#exhibition-answer-options .question-option-row {
+    align-items: center;
+    display: flex;
+    flex-wrap: nowrap;
+    gap: 8px;
+}
+
+#exhibition-answer-options .question-option-field {
+    flex: 1 1 0;
+    min-width: 0;
+}
+
+#exhibition-answer-options .question-option-field .form-group {
+    margin-bottom: 0;
+    width: 100%;
+}
+
+#exhibition-answer-options .question-option-field .i18n-form-group {
+    width: 100%;
+}
+
+#exhibition-answer-options .question-option-field input,
+#exhibition-answer-options .question-option-field textarea {
+    box-sizing: border-box;
+    width: 100%;
+}
+
+#exhibition-answer-options .question-option-actions {
+    flex: 0 0 auto;
+    padding: 0;
+    white-space: nowrap;
+}
+
+#exhibition-answer-options .question-option-actions .btn + .btn {
+    margin-left: 4px;
+}
+
+#exhibition-answer-options .question-option-add {
+    margin-top: 10px;
+}

--- a/exhibition/static/exhibition/css/question-form.css
+++ b/exhibition/static/exhibition/css/question-form.css
@@ -1,3 +1,15 @@
-#answer-options.exhibition-answer-options .answer-options-group > .control-label {
+#exhibition-answer-options.exhibition-answer-options {
+    display: none;
+}
+
+#exhibition-answer-options.exhibition-answer-options.is-choice-variant {
+    display: block;
+}
+
+#exhibition-answer-options.exhibition-answer-options .answer-options-group {
+    margin-bottom: 10px;
+}
+
+#exhibition-answer-options.exhibition-answer-options .answer-options-group > .control-label {
     padding-top: 7px;
 }

--- a/exhibition/static/exhibition/js/question-form.js
+++ b/exhibition/static/exhibition/js/question-form.js
@@ -11,7 +11,9 @@
         var choiceVariants = (optionsGroup.dataset.choiceVariants || "").split(" ");
 
         function sync() {
-            optionsGroup.hidden = choiceVariants.indexOf(variantField.value) === -1;
+            var isChoiceVariant = choiceVariants.indexOf(variantField.value) !== -1;
+            optionsGroup.hidden = !isChoiceVariant;
+            optionsGroup.style.display = isChoiceVariant ? "block" : "none";
         }
 
         variantField.addEventListener("change", sync);

--- a/exhibition/static/exhibition/js/question-form.js
+++ b/exhibition/static/exhibition/js/question-form.js
@@ -13,7 +13,7 @@
         function sync() {
             var isChoiceVariant = choiceVariants.indexOf(variantField.value) !== -1;
             optionsGroup.hidden = !isChoiceVariant;
-            optionsGroup.style.display = isChoiceVariant ? "block" : "none";
+            optionsGroup.classList.toggle("is-choice-variant", isChoiceVariant);
         }
 
         variantField.addEventListener("change", sync);

--- a/exhibition/templates/exhibitors/call_question_form.html
+++ b/exhibition/templates/exhibitors/call_question_form.html
@@ -7,6 +7,7 @@
 
 {% block custom_header %}
     {{ block.super }}
+    <link rel="stylesheet" href="{% static 'exhibition/css/question-form.css' %}">
     <script defer src="{% static 'exhibition/js/question-form.js' %}"></script>
 {% endblock %}
 
@@ -25,7 +26,7 @@
         {% bootstrap_field form.help_text layout="control" %}
         {% bootstrap_field form.required layout="control" %}
         {% bootstrap_field form.active layout="control" %}
-        <div id="answer-options" data-question-options data-choice-variants="{{ form.choice_variant_values }}">
+        <div id="answer-options" class="exhibition-answer-options" data-question-options data-choice-variants="{{ form.choice_variant_values }}">
             <div class="form-group answer-options-group">
                 <label id="answer-options-heading" class="col-md-3 control-label">{% trans "Answer options" %}</label>
                 <div class="col-md-9 answer-options-content" role="group" aria-labelledby="answer-options-heading">

--- a/exhibition/templates/exhibitors/call_question_form.html
+++ b/exhibition/templates/exhibitors/call_question_form.html
@@ -26,7 +26,7 @@
         {% bootstrap_field form.help_text layout="control" %}
         {% bootstrap_field form.required layout="control" %}
         {% bootstrap_field form.active layout="control" %}
-        <div id="answer-options" class="exhibition-answer-options" data-question-options data-choice-variants="{{ form.choice_variant_values }}">
+        <div id="exhibition-answer-options" class="exhibition-answer-options" data-question-options data-choice-variants="{{ form.choice_variant_values }}">
             <div class="form-group answer-options-group">
                 <label id="answer-options-heading" class="col-md-3 control-label">{% trans "Answer options" %}</label>
                 <div class="col-md-9 answer-options-content" role="group" aria-labelledby="answer-options-heading">
@@ -108,9 +108,6 @@
                         </div>
                     </div>
                 </div>
-            </div>
-            <div class="form-group answer-options-after-gap">
-                <div class="col-md-offset-3 col-md-9"></div>
             </div>
         </div>
         <div class="form-group submit-group">

--- a/exhibition/templates/exhibitors/call_question_form.html
+++ b/exhibition/templates/exhibitors/call_question_form.html
@@ -1,6 +1,8 @@
 {% extends "exhibitors/base.html" %}
 {% load i18n %}
 {% load bootstrap3 %}
+{% load formset_tags %}
+{% load escapejson %}
 {% load static %}
 
 {% block custom_header %}
@@ -23,8 +25,92 @@
         {% bootstrap_field form.help_text layout="control" %}
         {% bootstrap_field form.required layout="control" %}
         {% bootstrap_field form.active layout="control" %}
-        <div data-question-options data-choice-variants="{{ form.choice_variant_values }}">
-            {% bootstrap_field form.options_text layout="control" %}
+        <div id="answer-options" data-question-options data-choice-variants="{{ form.choice_variant_values }}">
+            <div class="form-group answer-options-group">
+                <label id="answer-options-heading" class="col-md-3 control-label">{% trans "Answer options" %}</label>
+                <div class="col-md-9 answer-options-content" role="group" aria-labelledby="answer-options-heading">
+                    <noscript>
+                        <p class="help-block">{% trans "Only applicable if you choose a choice field type above." %}</p>
+                    </noscript>
+                    <div class="formset" data-formset data-formset-prefix="{{ option_formset.prefix }}">
+                        {{ option_formset.management_form }}
+                        {% bootstrap_formset_errors option_formset %}
+                        <div data-formset-body>
+                            {% for option_form in option_formset %}
+                                <div data-formset-form class="question-option-item">
+                                    <div class="sr-only">
+                                        {{ option_form.id }}
+                                        {% bootstrap_field option_form.DELETE form_group_class="" layout="inline" %}
+                                        {% bootstrap_field option_form.ORDER form_group_class="" layout="inline" %}
+                                    </div>
+                                    <div class="question-option-label">
+                                        {% blocktrans trimmed with id=option_form.instance.pk %}Answer option {{ id }}{% endblocktrans %}
+                                    </div>
+                                    <div class="question-option-row">
+                                        <div class="question-option-field">
+                                            {% bootstrap_form_errors option_form %}
+                                            {% bootstrap_field option_form.answer layout="inline" form_group_class="" show_label=False %}
+                                        </div>
+                                        <div class="question-option-actions text-right flip">
+                                            <button type="button" class="btn btn-default" data-formset-move-up-button aria-label="{% trans 'Move option up' %}">
+                                                <i class="fa fa-arrow-up" aria-hidden="true"></i>
+                                                <span class="sr-only">{% trans "Move option up" %}</span>
+                                            </button>
+                                            <button type="button" class="btn btn-default" data-formset-move-down-button aria-label="{% trans 'Move option down' %}">
+                                                <i class="fa fa-arrow-down" aria-hidden="true"></i>
+                                                <span class="sr-only">{% trans "Move option down" %}</span>
+                                            </button>
+                                            <button type="button" class="btn btn-delete btn-danger" data-formset-delete-button aria-label="{% trans 'Delete option' %}">
+                                                <i class="fa fa-trash" aria-hidden="true"></i>
+                                                <span class="sr-only">{% trans "Delete option" %}</span>
+                                            </button>
+                                        </div>
+                                    </div>
+                                </div>
+                            {% endfor %}
+                        </div>
+                        <script type="form-template" data-formset-empty-form>
+                            {% escapescript %}
+                                <div data-formset-form class="question-option-item">
+                                    <div class="sr-only">
+                                        {{ option_formset.empty_form.id }}
+                                        {% bootstrap_field option_formset.empty_form.DELETE form_group_class="" layout="inline" %}
+                                        {% bootstrap_field option_formset.empty_form.ORDER form_group_class="" layout="inline" %}
+                                    </div>
+                                    <div class="question-option-label">{% trans "New answer option" %}</div>
+                                    <div class="question-option-row">
+                                        <div class="question-option-field">
+                                            {% bootstrap_field option_formset.empty_form.answer layout="inline" form_group_class="" show_label=False %}
+                                        </div>
+                                        <div class="question-option-actions text-right flip">
+                                            <button type="button" class="btn btn-default" data-formset-move-up-button aria-label="{% trans 'Move option up' %}">
+                                                <i class="fa fa-arrow-up" aria-hidden="true"></i>
+                                                <span class="sr-only">{% trans "Move option up" %}</span>
+                                            </button>
+                                            <button type="button" class="btn btn-default" data-formset-move-down-button aria-label="{% trans 'Move option down' %}">
+                                                <i class="fa fa-arrow-down" aria-hidden="true"></i>
+                                                <span class="sr-only">{% trans "Move option down" %}</span>
+                                            </button>
+                                            <button type="button" class="btn btn-delete btn-danger" data-formset-delete-button aria-label="{% trans 'Delete option' %}">
+                                                <i class="fa fa-trash" aria-hidden="true"></i>
+                                                <span class="sr-only">{% trans "Delete option" %}</span>
+                                            </button>
+                                        </div>
+                                    </div>
+                                </div>
+                            {% endescapescript %}
+                        </script>
+                        <div class="question-option-add">
+                            <button type="button" class="btn btn-default" data-formset-add>
+                                <i class="fa fa-plus" aria-hidden="true"></i> {% trans "Add a new option" %}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="form-group answer-options-after-gap">
+                <div class="col-md-offset-3 col-md-9"></div>
+            </div>
         </div>
         <div class="form-group submit-group">
             <button type="submit" class="btn btn-primary btn-save">{% trans "Save" %}</button>

--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -1612,16 +1612,23 @@ class ExhibitionQuestionOptionFormSetMixin:
             self.object.options.all().delete()
             return
 
-        for option_form in self.option_formset.deleted_forms:
-            option_form.instance.delete()
+        deleted_forms = self.option_formset.deleted_forms
+        for option_form in deleted_forms:
+            if option_form.instance.pk is not None:
+                option_form.instance.delete()
 
         ordered_forms = self.option_formset.ordered_forms + [
             option_form
             for option_form in self.option_formset.extra_forms
             if option_form not in self.option_formset.ordered_forms
-            and option_form not in self.option_formset.deleted_forms
+            and option_form not in deleted_forms
         ]
-        for position, option_form in enumerate(ordered_forms):
+        option_forms = [
+            option_form
+            for option_form in ordered_forms
+            if option_form not in deleted_forms and option_form.cleaned_data.get("answer")
+        ]
+        for position, option_form in enumerate(option_forms):
             option = option_form.save(commit=False)
             option.question = self.object
             option.position = position

--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -45,6 +45,7 @@ from .forms import (
     ExhibitionProposalReviewNotesForm,
     ExhibitionProposalSocialLinkFormSet,
     ExhibitionQuestionForm,
+    ExhibitionQuestionOptionFormSet,
     ExhibitorDeviceProvisionForm,
     ExhibitorExtraLinkFormSet,
     ExhibitorInfoForm,
@@ -69,6 +70,7 @@ from .models import (
     PROPOSAL_DEFAULT_FIELD_KEYS,
     PROPOSAL_DEFAULT_FIELDS,
     PROPOSAL_REVIEW_ACTIONS,
+    QUESTION_OPTION_VARIANTS,
     ExhibitionCustomEmailTemplate,
     ExhibitionEmailQueue,
     ExhibitionProposal,
@@ -1586,7 +1588,49 @@ class ExhibitionQuestionListView(EventPermissionRequiredMixin, ListView):
             ExhibitionQuestion.objects.bulk_update(reordered_questions, ["position"])
 
 
-class ExhibitionQuestionCreateView(EventPermissionRequiredMixin, CreateView):
+class ExhibitionQuestionOptionFormSetMixin:
+    option_formset_prefix = "options"
+
+    @cached_property
+    def option_formset(self):
+        queryset = self.object.options.all() if getattr(self, "object", None) else None
+        return ExhibitionQuestionOptionFormSet(
+            self.request.POST if self.request.method == "POST" else None,
+            queryset=queryset,
+            event=self.request.event,
+            prefix=self.option_formset_prefix,
+            requires_option=self.request.POST.get("variant") in QUESTION_OPTION_VARIANTS
+            if self.request.method == "POST"
+            else getattr(self.object, "variant", None) in QUESTION_OPTION_VARIANTS,
+        )
+
+    def save_option_formset(self):
+        if self.object.variant not in QUESTION_OPTION_VARIANTS:
+            self.object.options.all().delete()
+            return
+
+        for option_form in self.option_formset.deleted_forms:
+            option_form.instance.delete()
+
+        ordered_forms = self.option_formset.ordered_forms + [
+            option_form
+            for option_form in self.option_formset.extra_forms
+            if option_form not in self.option_formset.ordered_forms
+            and option_form not in self.option_formset.deleted_forms
+        ]
+        for position, option_form in enumerate(ordered_forms):
+            option = option_form.save(commit=False)
+            option.question = self.object
+            option.position = position
+            option.save()
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["option_formset"] = self.option_formset
+        return context
+
+
+class ExhibitionQuestionCreateView(EventPermissionRequiredMixin, ExhibitionQuestionOptionFormSetMixin, CreateView):
     model = ExhibitionQuestion
     form_class = ExhibitionQuestionForm
     permission = "can_change_settings"
@@ -1598,12 +1642,16 @@ class ExhibitionQuestionCreateView(EventPermissionRequiredMixin, CreateView):
         return kwargs
 
     def form_valid(self, form):
-        response = super().form_valid(form)
-        self.object.log_action(
-            LOG_QUESTION_ADDED,
-            data={"question": self.object.localized_question},
-            user=self.request.user,
-        )
+        if not self.option_formset.is_valid():
+            return self.form_invalid(form)
+        with transaction.atomic():
+            response = super().form_valid(form)
+            self.save_option_formset()
+            self.object.log_action(
+                LOG_QUESTION_ADDED,
+                data={"question": self.object.localized_question},
+                user=self.request.user,
+            )
         return response
 
     def get_success_url(self):
@@ -1613,7 +1661,7 @@ class ExhibitionQuestionCreateView(EventPermissionRequiredMixin, CreateView):
         )
 
 
-class ExhibitionQuestionEditView(EventPermissionRequiredMixin, UpdateView):
+class ExhibitionQuestionEditView(EventPermissionRequiredMixin, ExhibitionQuestionOptionFormSetMixin, UpdateView):
     model = ExhibitionQuestion
     form_class = ExhibitionQuestionForm
     permission = "can_change_settings"
@@ -1628,12 +1676,16 @@ class ExhibitionQuestionEditView(EventPermissionRequiredMixin, UpdateView):
         return kwargs
 
     def form_valid(self, form):
-        response = super().form_valid(form)
-        self.object.log_action(
-            LOG_QUESTION_CHANGED,
-            data={"changed": form.changed_data},
-            user=self.request.user,
-        )
+        if not self.option_formset.is_valid():
+            return self.form_invalid(form)
+        with transaction.atomic():
+            response = super().form_valid(form)
+            self.save_option_formset()
+            self.object.log_action(
+                LOG_QUESTION_CHANGED,
+                data={"changed": form.changed_data},
+                user=self.request.user,
+            )
         return response
 
     def get_success_url(self):

--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -76,6 +76,7 @@ from .models import (
     ExhibitionProposal,
     ExhibitionProposalState,
     ExhibitionQuestion,
+    ExhibitionQuestionOption,
     ExhibitorDevice,
     ExhibitorInfo,
     ExhibitorSettings,
@@ -1593,15 +1594,17 @@ class ExhibitionQuestionOptionFormSetMixin:
 
     @cached_property
     def option_formset(self):
-        queryset = self.object.options.all() if getattr(self, "object", None) else None
+        requires_option = (
+            self.request.POST.get("variant") in QUESTION_OPTION_VARIANTS
+            if self.request.method == "POST"
+            else self.object is not None and self.object.variant in QUESTION_OPTION_VARIANTS
+        )
         return ExhibitionQuestionOptionFormSet(
             self.request.POST if self.request.method == "POST" else None,
-            queryset=queryset,
+            queryset=self.object.options.all() if self.object else ExhibitionQuestionOption.objects.none(),
             event=self.request.event,
             prefix=self.option_formset_prefix,
-            requires_option=self.request.POST.get("variant") in QUESTION_OPTION_VARIANTS
-            if self.request.method == "POST"
-            else getattr(self.object, "variant", None) in QUESTION_OPTION_VARIANTS,
+            requires_option=requires_option,
         )
 
     def save_option_formset(self):

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -17,7 +17,7 @@ def option_formset_data(options, *, initial_forms):
         data.update(
             {
                 f"options-{index}-id": str(option.get("id", "")),
-                f"options-{index}-answer_0": option["answer"],
+                f"options-{index}-answer_0": option.get("answer", ""),
                 f"options-{index}-ORDER": str(option["order"]),
             }
         )
@@ -110,6 +110,19 @@ def test_choice_option_formset_requires_an_option(event):
 
 
 @pytest.mark.django_db
+def test_choice_option_formset_rejects_only_blank_options(event):
+    formset = ExhibitionQuestionOptionFormSet(
+        option_formset_data([{"answer": "", "order": 0}], initial_forms=0),
+        event=event,
+        prefix="options",
+        requires_option=True,
+    )
+
+    assert not formset.is_valid()
+    assert "Please provide at least one option" in formset.non_form_errors().as_text()
+
+
+@pytest.mark.django_db
 def test_choice_option_formset_saves_ordered_options(event):
     question = ExhibitionQuestion.objects.create(
         event=event,
@@ -139,6 +152,66 @@ def test_choice_option_formset_saves_ordered_options(event):
         ({"en": "First"}, 1),
         ({"en": "Third"}, 2),
     ]
+
+
+@pytest.mark.django_db
+def test_choice_option_formset_ignores_empty_extra_options(event):
+    question = ExhibitionQuestion.objects.create(
+        event=event,
+        variant=ExhibitionQuestionVariant.CHOICES,
+        question={"en": "Which option?"},
+    )
+    existing_option = ExhibitionQuestionOption.objects.create(
+        question=question,
+        answer={"en": "Existing option"},
+        position=0,
+    )
+    view = option_formset_view(
+        event,
+        question,
+        option_formset_data(
+            [
+                {"id": existing_option.pk, "answer": "Existing option", "order": 0},
+                {"answer": "", "order": 1},
+            ],
+            initial_forms=1,
+        ),
+    )
+
+    assert view.option_formset.is_valid()
+    view.save_option_formset()
+
+    assert list(question.options.values_list("answer", "position")) == [({"en": "Existing option"}, 0)]
+
+
+@pytest.mark.django_db
+def test_choice_option_formset_ignores_deleted_extra_options(event):
+    question = ExhibitionQuestion.objects.create(
+        event=event,
+        variant=ExhibitionQuestionVariant.CHOICES,
+        question={"en": "Which option?"},
+    )
+    existing_option = ExhibitionQuestionOption.objects.create(
+        question=question,
+        answer={"en": "Existing option"},
+        position=0,
+    )
+    view = option_formset_view(
+        event,
+        question,
+        option_formset_data(
+            [
+                {"id": existing_option.pk, "answer": "Existing option", "order": 0},
+                {"answer": "", "order": 1, "delete": True},
+            ],
+            initial_forms=1,
+        ),
+    )
+
+    assert view.option_formset.is_valid()
+    view.save_option_formset()
+
+    assert list(question.options.values_list("answer", "position")) == [({"en": "Existing option"}, 0)]
 
 
 @pytest.mark.django_db

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -1,0 +1,123 @@
+import pytest
+from django.test import RequestFactory
+
+from exhibition.forms import ExhibitionQuestionOptionFormSet
+from exhibition.models import ExhibitionQuestion, ExhibitionQuestionOption, ExhibitionQuestionVariant
+from exhibition.views import ExhibitionQuestionOptionFormSetMixin
+
+
+def option_formset_data(options, *, initial_forms):
+    data = {
+        "options-TOTAL_FORMS": str(len(options)),
+        "options-INITIAL_FORMS": str(initial_forms),
+        "options-MIN_NUM_FORMS": "0",
+        "options-MAX_NUM_FORMS": "1000",
+    }
+    for index, option in enumerate(options):
+        data.update(
+            {
+                f"options-{index}-id": str(option.get("id", "")),
+                f"options-{index}-answer_0": option["answer"],
+                f"options-{index}-ORDER": str(option["order"]),
+            }
+        )
+        if option.get("delete"):
+            data[f"options-{index}-DELETE"] = "on"
+    return data
+
+
+def option_formset_view(event, question, data):
+    view = ExhibitionQuestionOptionFormSetMixin()
+    request = RequestFactory().post("/", data)
+    request.event = event
+    view.request = request
+    view.object = question
+    return view
+
+
+@pytest.mark.django_db
+def test_choice_option_formset_requires_an_option(event):
+    formset = ExhibitionQuestionOptionFormSet(
+        option_formset_data([], initial_forms=0),
+        event=event,
+        prefix="options",
+        requires_option=True,
+    )
+
+    assert not formset.is_valid()
+    assert "Please provide at least one option" in formset.non_form_errors().as_text()
+
+
+@pytest.mark.django_db
+def test_choice_option_formset_saves_ordered_options(event):
+    question = ExhibitionQuestion.objects.create(
+        event=event,
+        variant=ExhibitionQuestionVariant.CHOICES,
+        question={"en": "Which option?"},
+    )
+    first = ExhibitionQuestionOption.objects.create(question=question, answer={"en": "First"}, position=0)
+    second = ExhibitionQuestionOption.objects.create(question=question, answer={"en": "Second"}, position=1)
+    view = option_formset_view(
+        event,
+        question,
+        option_formset_data(
+            [
+                {"id": second.pk, "answer": "Second", "order": 0},
+                {"id": first.pk, "answer": "First", "order": 1},
+                {"answer": "Third", "order": 2},
+            ],
+            initial_forms=2,
+        ),
+    )
+
+    assert view.option_formset.is_valid()
+    view.save_option_formset()
+
+    assert list(question.options.values_list("answer", "position")) == [
+        ({"en": "Second"}, 0),
+        ({"en": "First"}, 1),
+        ({"en": "Third"}, 2),
+    ]
+
+
+@pytest.mark.django_db
+def test_choice_option_formset_deletes_marked_options(event):
+    question = ExhibitionQuestion.objects.create(
+        event=event,
+        variant=ExhibitionQuestionVariant.SELECT,
+        question={"en": "Which option?"},
+    )
+    first = ExhibitionQuestionOption.objects.create(question=question, answer={"en": "First"}, position=0)
+    second = ExhibitionQuestionOption.objects.create(question=question, answer={"en": "Second"}, position=1)
+    view = option_formset_view(
+        event,
+        question,
+        option_formset_data(
+            [
+                {"id": first.pk, "answer": "First", "order": 0},
+                {"id": second.pk, "answer": "Second", "order": 1, "delete": True},
+            ],
+            initial_forms=2,
+        ),
+    )
+
+    assert view.option_formset.is_valid()
+    view.save_option_formset()
+
+    assert list(question.options.values_list("answer", flat=True)) == [{"en": "First"}]
+
+
+@pytest.mark.django_db
+def test_non_choice_question_clears_existing_options(event):
+    question = ExhibitionQuestion.objects.create(
+        event=event,
+        variant=ExhibitionQuestionVariant.STRING,
+        question={"en": "Short answer"},
+    )
+    ExhibitionQuestionOption.objects.create(question=question, answer={"en": "Unused"}, position=0)
+
+    view = ExhibitionQuestionOptionFormSetMixin()
+    view.object = question
+    view.save_option_formset()
+
+    assert not question.options.exists()

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -35,6 +35,67 @@ def option_formset_view(event, question, data):
     return view
 
 
+def option_formset_get_view(event, question=None):
+    view = ExhibitionQuestionOptionFormSetMixin()
+    request = RequestFactory().get("/")
+    request.event = event
+    view.request = request
+    view.object = question
+    return view
+
+
+@pytest.mark.django_db
+def test_new_question_option_formset_does_not_include_existing_question_options(event):
+    existing_question = ExhibitionQuestion.objects.create(
+        event=event,
+        variant=ExhibitionQuestionVariant.SELECT,
+        question={"en": "Existing question"},
+    )
+    ExhibitionQuestionOption.objects.create(
+        question=existing_question,
+        answer={"en": "First existing option"},
+        position=0,
+    )
+    ExhibitionQuestionOption.objects.create(
+        question=existing_question,
+        answer={"en": "Second existing option"},
+        position=1,
+    )
+
+    view = option_formset_get_view(event)
+
+    assert view.option_formset.initial_form_count() == 0
+    assert view.option_formset.total_form_count() == 0
+
+
+@pytest.mark.django_db
+def test_edit_question_option_formset_includes_only_its_own_options(event):
+    question = ExhibitionQuestion.objects.create(
+        event=event,
+        variant=ExhibitionQuestionVariant.SELECT,
+        question={"en": "Question being edited"},
+    )
+    option = ExhibitionQuestionOption.objects.create(
+        question=question,
+        answer={"en": "Its own option"},
+        position=0,
+    )
+    other_question = ExhibitionQuestion.objects.create(
+        event=event,
+        variant=ExhibitionQuestionVariant.CHOICES,
+        question={"en": "Another question"},
+    )
+    ExhibitionQuestionOption.objects.create(
+        question=other_question,
+        answer={"en": "Other question option"},
+        position=0,
+    )
+
+    view = option_formset_get_view(event, question)
+
+    assert list(view.option_formset.queryset) == [option]
+
+
 @pytest.mark.django_db
 def test_choice_option_formset_requires_an_option(event):
     formset = ExhibitionQuestionOptionFormSet(


### PR DESCRIPTION
## Summary

- replace the multiline “Options” textarea in the Call for Exhibitors form
- remove the “For choice fields, enter one option per line” helper text
- use Ticket-style individual answer-option rows with add, delete, and reorder controls
- preserve validation: choice fields require at least one option
- keep non-choice fields free of stale options

Fixes #171

## Testing

- `pytest -q` — 154 passed
- `node --check exhibition/static/exhibition/js/question-form.js`
- manually verified choice and non-choice field states, plus add/delete/reorder option controls

## Screenshots

### Before
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/904fd7c4-b03e-4c5c-8810-4e3731742fd1" />


### After

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/3e9cb25a-9703-4219-a41d-9dfd39dd9e1e" />

## Summary by Sourcery

Align exhibition choice-question option management with the Ticket-style formset experience.

New Features:
- Replace the exhibition question options textarea with individually managed answer-option rows supporting addition, deletion, and reordering.

Bug Fixes:
- Ensure choice questions require at least one non-empty answer option.
- Prevent stale answer options from remaining on non-choice questions.

Enhancements:
- Persist localized answer options and their ordering through a dedicated question-option formset.

Tests:
- Add coverage for option formset validation, isolation, ordering, creation, deletion, and cleanup.