### PR TITLE
fix: match search/clear button sizes and align exhibitor form fields #170

### DIFF
--- a/exhibition/static/exhibition/css/exhibitors-add.css
+++ b/exhibition/static/exhibition/css/exhibitors-add.css
@@ -62,7 +62,11 @@
 }
 
 .partner-link-actions {
-    margin-top: 10px;
+    margin-top: 0;
+}
+
+.form-horizontal .radio:first-child {
+    margin-top: -5px;
 }
 
 .partner-link-add {

--- a/exhibition/static/exhibition/css/exhibitors-add.css
+++ b/exhibition/static/exhibition/css/exhibitors-add.css
@@ -65,7 +65,7 @@
     margin-top: 0;
 }
 
-.form-horizontal .radio:first-child {
+#lead-scanning-section .radio:first-child {
     margin-top: -5px;
 }
 

--- a/exhibition/static/exhibition/css/exhibitors-public-list.css
+++ b/exhibition/static/exhibition/css/exhibitors-public-list.css
@@ -30,6 +30,7 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    gap: 6px;
     min-width: 110px;
     height: 34px;
     box-sizing: border-box;

--- a/exhibition/static/exhibition/css/exhibitors-public-list.css
+++ b/exhibition/static/exhibition/css/exhibitors-public-list.css
@@ -27,6 +27,12 @@
 .exhibition-public-filter-submit,
 .exhibition-public-filter-reset {
     flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 110px;
+    height: 34px;
+    box-sizing: border-box;
 }
 
 .exhibition-public-grid {

--- a/exhibition/static/exhibition/css/exhibitors-public-list.css
+++ b/exhibition/static/exhibition/css/exhibitors-public-list.css
@@ -34,6 +34,16 @@
     min-width: 110px;
     height: 34px;
     box-sizing: border-box;
+    padding: 0 12px;
+    margin: 0;
+    font-family: inherit;
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 1;
+    text-align: center;
+    vertical-align: middle;
+    border-width: 1px;
+    border-style: solid;
 }
 
 .exhibition-public-grid {

--- a/exhibition/templates/exhibitors/_filter_form.html
+++ b/exhibition/templates/exhibitors/_filter_form.html
@@ -15,9 +15,9 @@
             </div>
             <div class="advanced-filter-search-actions">
                 <a href="{{ request.path }}" class="btn btn-default btn-clear-filter"
-                   aria-label="{% trans 'Clear filters' %}" title="{% trans 'Clear filters' %}">
+                   aria-label="{% trans 'Clear' %}" title="{% trans 'Clear' %}">
                     <span class="fa fa-eraser" aria-hidden="true"></span>
-                    <span class="sr-only">{% trans "Clear filters" %}</span>
+                    {% trans "Clear" %}
                 </a>
                 {% if filter_form.advanced_fields %}
                     <button type="button"

--- a/exhibition/templates/exhibitors/public_list.html
+++ b/exhibition/templates/exhibitors/public_list.html
@@ -29,7 +29,7 @@
                     {% trans "Search" %}
                 </button>
                 <a href="{{ request.path }}" class="btn btn-default exhibition-public-filter-reset">
-                    {% trans "Reset" %}
+                    {% trans "Clear" %}
                 </a>
             </form>
             {% if exhibitors %}


### PR DESCRIPTION
Supersedes #173 (which got closed while I was still addressing feedback).

Addresses both parts of #170:

**Part 1 (button size/rename/font):**
Renamed "Reset" to "Clear" on the public Exhibition tab's search bar,
and pinned font-size, font-weight, line-height, padding, and
border-width identically between the `<button>` (Search) and `<a>`
(Clear) elements, so there's no gap regardless of browser/theme
defaults.

**Part 2 (fieldset alignment):**
Fixed three specific misalignments on the Add/Edit Exhibitor form:
- Social Media and Extra Links: removed an unnecessary top margin on
  the "Add link" button.
- Lead scanning behavior: nudged the radio group up to align with its
  label.

 
<img width="1841" height="347" alt="1" src="https://github.com/user-attachments/assets/3897e9e1-c31b-404e-b787-110eb9736659" />

<img width="892" height="526" alt="2" src="https://github.com/user-attachments/assets/a6c44fd3-30bc-463c-a5b7-adf4d3380624" />

<img width="1295" height="112" alt="3" src="https://github.com/user-attachments/assets/efe73bcd-1331-471c-9950-d87546a58bf8" />

## Summary by Sourcery

Standardize exhibition filter controls and correct exhibitor form field alignment.

Bug Fixes:
- Align the public exhibition search and clear controls with consistent sizing and typography across browsers and themes.
- Correct Add/Edit Exhibitor form alignment for link actions and lead-scanning options.

Enhancements:
- Rename public exhibition filter action from “Reset” to “Clear” and simplify clear-filter accessibility text.