### PR TITLE
feat: preview modal for image upload

### DIFF
--- a/exhibition/static/exhibition/css/exhibitors-add.css
+++ b/exhibition/static/exhibition/css/exhibitors-add.css
@@ -36,10 +36,6 @@
     background-color: #ddd;
 }
 
-/* Mirrors .form-image-preview from core's common/css/_forms.css, which the control and
-   presale bases do not load: transparency checkerboard behind the thumbnail.
-   Shadows are spelled out rather than using core's --shadow-* variables, because
-   common/css/_variables.css is loaded on the control base but not the presale one. */
 .exhibition-image-preview {
     background-size: 21px 21px;
     background-position:
@@ -91,8 +87,6 @@
     max-width: 420px;
 }
 
-/* Mirrors core's #lightbox-dialog (common/includes/modals.html + _pretalx.css), which is
-   only wired up on the pretalx-side bases. */
 dialog.exhibition-image-dialog {
     border: none;
     padding: 0;
@@ -139,8 +133,33 @@ dialog.exhibition-image-dialog .exhibition-image-dialog-close {
     cursor: pointer;
     color: rgb(0 0 0 / 0.7);
     font-size: 20px;
-    border: none;
+    line-height: 1;
+    padding: 4px 8px;
+    border: 0;
+    border-radius: 0;
     background: transparent;
+    box-shadow: none;
+    appearance: none;
+}
+
+dialog.exhibition-image-dialog .exhibition-image-dialog-close:hover,
+dialog.exhibition-image-dialog .exhibition-image-dialog-close:active {
+    color: rgb(0 0 0 / 0.9);
+    border: 0;
+    background: transparent;
+    box-shadow: none;
+}
+
+dialog.exhibition-image-dialog .exhibition-image-dialog-close:focus {
+    outline: none;
+    border: 0;
+    background: transparent;
+    box-shadow: none;
+}
+
+dialog.exhibition-image-dialog .exhibition-image-dialog-close:focus-visible {
+    outline: 2px solid rgb(0 0 0 / 0.4);
+    outline-offset: 2px;
 }
 
 .partner-link-formset {

--- a/exhibition/static/exhibition/css/exhibitors-add.css
+++ b/exhibition/static/exhibition/css/exhibitors-add.css
@@ -88,11 +88,16 @@
 }
 
 dialog.exhibition-image-dialog {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    margin: 0;
     border: none;
     padding: 0;
     background: transparent;
-    max-width: none;
-    max-height: none;
+    max-width: 90vw;
+    max-height: 90vh;
     overflow: visible;
 }
 
@@ -115,11 +120,12 @@ dialog.exhibition-image-dialog figure {
 }
 
 dialog.exhibition-image-dialog img {
+    display: block;
     object-fit: contain;
-    max-height: 80vh;
+    max-height: 70vh;
     max-width: 80vw;
-    height: 100%;
-    width: 100%;
+    height: auto;
+    width: auto;
 }
 
 dialog.exhibition-image-dialog figcaption {

--- a/exhibition/static/exhibition/css/exhibitors-add.css
+++ b/exhibition/static/exhibition/css/exhibitors-add.css
@@ -122,8 +122,8 @@ dialog.exhibition-image-dialog figure {
 dialog.exhibition-image-dialog img {
     display: block;
     object-fit: contain;
-    max-height: 70vh;
-    max-width: 80vw;
+    max-width: min(80vw, 720px);
+    max-height: min(70vh, 540px);
     height: auto;
     width: auto;
 }

--- a/exhibition/static/exhibition/css/exhibitors-add.css
+++ b/exhibition/static/exhibition/css/exhibitors-add.css
@@ -36,21 +36,111 @@
     background-color: #ddd;
 }
 
-.partner-image-preview {
-    object-fit: contain;
-    object-position: center;
-    background: #f8f8f8;
+/* Mirrors .form-image-preview from core's common/css/_forms.css, which the control and
+   presale bases do not load: transparency checkerboard behind the thumbnail.
+   Shadows are spelled out rather than using core's --shadow-* variables, because
+   common/css/_variables.css is loaded on the control base but not the presale one. */
+.exhibition-image-preview {
+    background-size: 21px 21px;
+    background-position:
+        0 0,
+        10px 10px;
+    background-image:
+        linear-gradient(
+            45deg,
+            #efefef 25%,
+            rgb(239 239 239 / 0) 25%,
+            rgb(239 239 239 / 0) 75%,
+            #efefef 75%,
+            #efefef
+        ),
+        linear-gradient(
+            45deg,
+            #efefef 25%,
+            rgb(239 239 239 / 0) 25%,
+            rgb(239 239 239 / 0) 75%,
+            #efefef 75%,
+            #efefef
+        );
+    border-radius: 6px;
+    display: inline-block;
+    max-width: 100%;
+}
+
+.exhibition-image-preview img {
+    border-radius: 6px;
+    max-width: 100%;
+    height: auto;
+    box-shadow:
+        0 1px 3px rgb(0 0 0 / 0.12),
+        0 1px 2px rgb(0 0 0 / 0.24);
+}
+
+.exhibition-image-preview a:hover img,
+.exhibition-image-preview a:focus img {
+    box-shadow:
+        0 2px 5px rgb(0 0 0 / 0.25),
+        0 3px 5px rgb(0 0 0 / 0.22);
 }
 
 .partner-image-preview-logo {
-    width: 180px;
-    height: 180px;
+    max-width: 180px;
 }
 
 .partner-image-preview-header {
-    width: 420px;
-    height: 180px;
-    max-width: 100%;
+    max-width: 420px;
+}
+
+/* Mirrors core's #lightbox-dialog (common/includes/modals.html + _pretalx.css), which is
+   only wired up on the pretalx-side bases. */
+dialog.exhibition-image-dialog {
+    border: none;
+    padding: 0;
+    background: transparent;
+    max-width: none;
+    max-height: none;
+    overflow: visible;
+}
+
+dialog.exhibition-image-dialog::backdrop {
+    background: rgb(0 0 0 / 0.5);
+}
+
+dialog.exhibition-image-dialog .modal-card-content {
+    position: relative;
+    padding: 20px;
+    background: #fff;
+    border-radius: 6px;
+    box-shadow:
+        0 0 10px rgb(0 0 0 / 0.5),
+        0 1px 2px rgb(0 0 0 / 0.24);
+}
+
+dialog.exhibition-image-dialog figure {
+    margin: 0;
+}
+
+dialog.exhibition-image-dialog img {
+    object-fit: contain;
+    max-height: 80vh;
+    max-width: 80vw;
+    height: 100%;
+    width: 100%;
+}
+
+dialog.exhibition-image-dialog figcaption {
+    margin-top: 8px;
+}
+
+dialog.exhibition-image-dialog .exhibition-image-dialog-close {
+    position: absolute;
+    top: -4px;
+    right: 0;
+    cursor: pointer;
+    color: rgb(0 0 0 / 0.7);
+    font-size: 20px;
+    border: none;
+    background: transparent;
 }
 
 .partner-link-formset {

--- a/exhibition/static/exhibition/css/exhibitors-add.css
+++ b/exhibition/static/exhibition/css/exhibitors-add.css
@@ -45,16 +45,16 @@
         linear-gradient(
             45deg,
             #efefef 25%,
-            rgb(239 239 239 / 0) 25%,
-            rgb(239 239 239 / 0) 75%,
+            transparent 25%,
+            transparent 75%,
             #efefef 75%,
             #efefef
         ),
         linear-gradient(
             45deg,
             #efefef 25%,
-            rgb(239 239 239 / 0) 25%,
-            rgb(239 239 239 / 0) 75%,
+            transparent 25%,
+            transparent 75%,
             #efefef 75%,
             #efefef
         );
@@ -68,15 +68,15 @@
     max-width: 100%;
     height: auto;
     box-shadow:
-        0 1px 3px rgb(0 0 0 / 0.12),
-        0 1px 2px rgb(0 0 0 / 0.24);
+        0 1px 3px rgba(0, 0, 0, 0.12),
+        0 1px 2px rgba(0, 0, 0, 0.24);
 }
 
 .exhibition-image-preview a:hover img,
 .exhibition-image-preview a:focus img {
     box-shadow:
-        0 2px 5px rgb(0 0 0 / 0.25),
-        0 3px 5px rgb(0 0 0 / 0.22);
+        0 2px 5px rgba(0, 0, 0, 0.25),
+        0 3px 5px rgba(0, 0, 0, 0.22);
 }
 
 .partner-image-preview-logo {
@@ -97,7 +97,7 @@ dialog.exhibition-image-dialog {
 }
 
 dialog.exhibition-image-dialog::backdrop {
-    background: rgb(0 0 0 / 0.5);
+    background: rgba(0, 0, 0, 0.5);
 }
 
 dialog.exhibition-image-dialog .modal-card-content {
@@ -106,8 +106,8 @@ dialog.exhibition-image-dialog .modal-card-content {
     background: #fff;
     border-radius: 6px;
     box-shadow:
-        0 0 10px rgb(0 0 0 / 0.5),
-        0 1px 2px rgb(0 0 0 / 0.24);
+        0 0 10px rgba(0, 0, 0, 0.5),
+        0 1px 2px rgba(0, 0, 0, 0.24);
 }
 
 dialog.exhibition-image-dialog figure {
@@ -131,7 +131,7 @@ dialog.exhibition-image-dialog .exhibition-image-dialog-close {
     top: -4px;
     right: 0;
     cursor: pointer;
-    color: rgb(0 0 0 / 0.7);
+    color: rgba(0, 0, 0, 0.7);
     font-size: 20px;
     line-height: 1;
     padding: 4px 8px;
@@ -144,7 +144,7 @@ dialog.exhibition-image-dialog .exhibition-image-dialog-close {
 
 dialog.exhibition-image-dialog .exhibition-image-dialog-close:hover,
 dialog.exhibition-image-dialog .exhibition-image-dialog-close:active {
-    color: rgb(0 0 0 / 0.9);
+    color: rgba(0, 0, 0, 0.9);
     border: 0;
     background: transparent;
     box-shadow: none;
@@ -158,7 +158,7 @@ dialog.exhibition-image-dialog .exhibition-image-dialog-close:focus {
 }
 
 dialog.exhibition-image-dialog .exhibition-image-dialog-close:focus-visible {
-    outline: 2px solid rgb(0 0 0 / 0.4);
+    outline: 2px solid rgba(0, 0, 0, 0.4);
     outline-offset: 2px;
 }
 

--- a/exhibition/static/exhibition/js/exhibitors-add.js
+++ b/exhibition/static/exhibition/js/exhibitors-add.js
@@ -5,77 +5,7 @@
         element.style.display = visible ? '' : 'none'
     }
 
-    var imageDialog = null
-
-    function buildImageDialog() {
-        var dialog = document.createElement('dialog')
-        dialog.className = 'exhibition-image-dialog'
-        dialog.setAttribute('role', 'alertdialog')
-        dialog.innerHTML =
-            '<div class="modal-card">' +
-            '<div class="modal-card-content">' +
-            '<figure class="text-center text-muted">' +
-            '<img alt="">' +
-            '<figcaption></figcaption>' +
-            '</figure>' +
-            '<button type="button" class="btn btn-default btn-xs exhibition-image-dialog-close">' +
-            '<i class="fa fa-times"></i>' +
-            '</button>' +
-            '</div>' +
-            '</div>'
-
-        function close() {
-            if (dialog.open) {
-                dialog.close()
-            }
-            dialog.querySelector('img').removeAttribute('src')
-        }
-
-        dialog.addEventListener('click', close)
-        dialog.querySelector('.modal-card-content').addEventListener('click', function (event) {
-            event.stopPropagation()
-        })
-        dialog.querySelector('.exhibition-image-dialog-close').addEventListener('click', close)
-        dialog.addEventListener('cancel', function () {
-            dialog.querySelector('img').removeAttribute('src')
-        })
-        document.body.appendChild(dialog)
-        return dialog
-    }
-
-    function openImageDialog(url, label) {
-        if (!url) return
-        if (!imageDialog) {
-            imageDialog = buildImageDialog()
-        }
-        imageDialog.querySelector('img').src = url
-        imageDialog.querySelector('img').alt = label || ''
-        imageDialog.querySelector('figcaption').textContent = label || ''
-        if (!imageDialog.open) {
-            imageDialog.showModal()
-        }
-    }
-
-    function initImageDialogTriggers() {
-        document.addEventListener('click', function (event) {
-            if (event.button !== 0 || event.ctrlKey || event.metaKey || event.shiftKey || event.altKey) {
-                return
-            }
-            if (!event.target || typeof event.target.closest !== 'function') {
-                return
-            }
-            var link = event.target.closest('.exhibition-image-preview a[data-image-preview-link]')
-            if (!link || !link.getAttribute('href')) {
-                return
-            }
-            event.preventDefault()
-            var image = link.querySelector('img')
-            openImageDialog(link.href, image ? image.alt : '')
-        })
-    }
-
     document.addEventListener('DOMContentLoaded', function () {
-        initImageDialogTriggers()
         var previewObjectUrls = new WeakMap()
         var sponsorCheckbox = document.getElementById('id_is_sponsor')
         var sponsorGroupWrapper = document.getElementById('sponsor-group-wrapper')

--- a/exhibition/static/exhibition/js/exhibitors-add.js
+++ b/exhibition/static/exhibition/js/exhibitors-add.js
@@ -5,7 +5,77 @@
         element.style.display = visible ? '' : 'none'
     }
 
+    var imageDialog = null
+
+    function buildImageDialog() {
+        var dialog = document.createElement('dialog')
+        dialog.className = 'exhibition-image-dialog'
+        dialog.setAttribute('role', 'alertdialog')
+        dialog.innerHTML =
+            '<div class="modal-card">' +
+            '<div class="modal-card-content">' +
+            '<figure class="text-center text-muted">' +
+            '<img alt="">' +
+            '<figcaption></figcaption>' +
+            '</figure>' +
+            '<button type="button" class="btn btn-default btn-xs exhibition-image-dialog-close">' +
+            '<i class="fa fa-times"></i>' +
+            '</button>' +
+            '</div>' +
+            '</div>'
+
+        function close() {
+            if (dialog.open) {
+                dialog.close()
+            }
+            dialog.querySelector('img').removeAttribute('src')
+        }
+
+        dialog.addEventListener('click', close)
+        dialog.querySelector('.modal-card-content').addEventListener('click', function (event) {
+            event.stopPropagation()
+        })
+        dialog.querySelector('.exhibition-image-dialog-close').addEventListener('click', close)
+        dialog.addEventListener('cancel', function () {
+            dialog.querySelector('img').removeAttribute('src')
+        })
+        document.body.appendChild(dialog)
+        return dialog
+    }
+
+    function openImageDialog(url, label) {
+        if (!url) return
+        if (!imageDialog) {
+            imageDialog = buildImageDialog()
+        }
+        imageDialog.querySelector('img').src = url
+        imageDialog.querySelector('img').alt = label || ''
+        imageDialog.querySelector('figcaption').textContent = label || ''
+        if (!imageDialog.open) {
+            imageDialog.showModal()
+        }
+    }
+
+    function initImageDialogTriggers() {
+        document.addEventListener('click', function (event) {
+            if (event.button !== 0 || event.ctrlKey || event.metaKey || event.shiftKey || event.altKey) {
+                return
+            }
+            if (!event.target || typeof event.target.closest !== 'function') {
+                return
+            }
+            var link = event.target.closest('.exhibition-image-preview a[data-image-preview-link]')
+            if (!link || !link.getAttribute('href')) {
+                return
+            }
+            event.preventDefault()
+            var image = link.querySelector('img')
+            openImageDialog(link.href, image ? image.alt : '')
+        })
+    }
+
     document.addEventListener('DOMContentLoaded', function () {
+        initImageDialogTriggers()
         var previewObjectUrls = new WeakMap()
         var sponsorCheckbox = document.getElementById('id_is_sponsor')
         var sponsorGroupWrapper = document.getElementById('sponsor-group-wrapper')

--- a/exhibition/static/exhibition/js/image-preview-dialog.js
+++ b/exhibition/static/exhibition/js/image-preview-dialog.js
@@ -1,0 +1,63 @@
+(function () {
+    var TRIGGER_SELECTOR = '.exhibition-image-preview a[data-image-preview-link]'
+
+    function init() {
+        var dialog = document.getElementById('exhibition-image-dialog')
+        if (!dialog || typeof dialog.showModal !== 'function') {
+            return
+        }
+
+        var image = dialog.querySelector('[data-image-dialog-image]')
+        var caption = dialog.querySelector('[data-image-dialog-caption]')
+        var content = dialog.querySelector('.modal-card-content')
+
+        function close() {
+            if (dialog.open) {
+                dialog.close()
+            }
+        }
+
+        function open(link) {
+            var thumbnail = link.querySelector('img')
+            var label = thumbnail ? thumbnail.alt : ''
+            image.src = link.href
+            image.alt = label
+            caption.textContent = label
+            if (!dialog.open) {
+                dialog.showModal()
+                dialog.focus()
+            }
+        }
+
+        dialog.addEventListener('click', close)
+        dialog.addEventListener('close', function () {
+            image.removeAttribute('src')
+        })
+        content.addEventListener('click', function (event) {
+            event.stopPropagation()
+        })
+        dialog.querySelector('[data-image-dialog-close]').addEventListener('click', close)
+
+        document.addEventListener('click', function (event) {
+            if (event.button !== 0 || event.ctrlKey || event.metaKey || event.shiftKey || event.altKey) {
+                return
+            }
+            var target = event.target
+            if (!target || typeof target.closest !== 'function') {
+                return
+            }
+            var link = target.closest(TRIGGER_SELECTOR)
+            if (!link || !link.getAttribute('href')) {
+                return
+            }
+            event.preventDefault()
+            open(link)
+        })
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init)
+    } else {
+        init()
+    }
+})()

--- a/exhibition/static/exhibition/js/image-preview-dialog.js
+++ b/exhibition/static/exhibition/js/image-preview-dialog.js
@@ -1,17 +1,14 @@
 (function () {
     var TRIGGER_SELECTOR = '.exhibition-image-preview a[data-image-preview-link]'
 
-    function scrollToTop() {
-        var prefersReducedMotion =
-            typeof window.matchMedia === 'function' &&
-            window.matchMedia('(prefers-reduced-motion: reduce)').matches
-        window.scrollTo({ top: 0, left: 0, behavior: prefersReducedMotion ? 'auto' : 'smooth' })
-    }
-
     function init() {
         var dialog = document.getElementById('exhibition-image-dialog')
         if (!dialog || typeof dialog.showModal !== 'function') {
             return
+        }
+
+        if (dialog.parentNode !== document.body) {
+            document.body.appendChild(dialog)
         }
 
         var image = dialog.querySelector('[data-image-dialog-image]')
@@ -30,11 +27,15 @@
             image.src = link.href
             image.alt = label
             caption.textContent = label
-            if (!dialog.open) {
-                scrollToTop()
-                dialog.showModal()
-                dialog.focus()
+            if (dialog.open) {
+                return
             }
+
+            var scrollX = window.scrollX
+            var scrollY = window.scrollY
+            dialog.showModal()
+            dialog.focus({ preventScroll: true })
+            window.scrollTo({ top: scrollY, left: scrollX, behavior: 'instant' })
         }
 
         dialog.addEventListener('click', close)

--- a/exhibition/static/exhibition/js/image-preview-dialog.js
+++ b/exhibition/static/exhibition/js/image-preview-dialog.js
@@ -1,6 +1,13 @@
 (function () {
     var TRIGGER_SELECTOR = '.exhibition-image-preview a[data-image-preview-link]'
 
+    function scrollToTop() {
+        var prefersReducedMotion =
+            typeof window.matchMedia === 'function' &&
+            window.matchMedia('(prefers-reduced-motion: reduce)').matches
+        window.scrollTo({ top: 0, left: 0, behavior: prefersReducedMotion ? 'auto' : 'smooth' })
+    }
+
     function init() {
         var dialog = document.getElementById('exhibition-image-dialog')
         if (!dialog || typeof dialog.showModal !== 'function') {
@@ -24,6 +31,7 @@
             image.alt = label
             caption.textContent = label
             if (!dialog.open) {
+                scrollToTop()
                 dialog.showModal()
                 dialog.focus()
             }

--- a/exhibition/templates/exhibitors/_image_preview_dialog.html
+++ b/exhibition/templates/exhibitors/_image_preview_dialog.html
@@ -1,0 +1,16 @@
+{% load i18n %}
+<dialog id="exhibition-image-dialog" class="exhibition-image-dialog" role="alertdialog" tabindex="-1"
+        aria-labelledby="exhibition-image-dialog-label">
+    <div class="modal-card">
+        <div class="modal-card-content">
+            <figure class="text-center text-muted">
+                <img alt="" data-image-dialog-image>
+                <figcaption id="exhibition-image-dialog-label" data-image-dialog-caption></figcaption>
+            </figure>
+            <button type="button" class="exhibition-image-dialog-close" data-image-dialog-close
+                    aria-label="{% trans 'Close preview' %}" title="{% trans 'Close preview' %}">
+                <i class="fa fa-times" aria-hidden="true"></i>
+            </button>
+        </div>
+    </div>
+</dialog>

--- a/exhibition/templates/exhibitors/_image_preview_dialog.html
+++ b/exhibition/templates/exhibitors/_image_preview_dialog.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<dialog id="exhibition-image-dialog" class="exhibition-image-dialog" role="alertdialog" tabindex="-1"
+<dialog id="exhibition-image-dialog" class="exhibition-image-dialog" role="dialog" tabindex="-1"
         aria-labelledby="exhibition-image-dialog-label">
     <div class="modal-card">
         <div class="modal-card-content">

--- a/exhibition/templates/exhibitors/add.html
+++ b/exhibition/templates/exhibitors/add.html
@@ -156,9 +156,11 @@
                     <div class="form-group" data-image-preview hidden>
                         <label class="col-md-3 control-label">{% trans "Logo preview" %}</label>
                         <div class="col-md-9">
-                            <a class="thumbnailed-file-link" data-image-preview-link href="" hidden>
-                                <img loading="lazy" data-image-preview-image class="img-responsive img-thumbnail partner-image-preview partner-image-preview-logo" alt="{% trans 'Logo preview' %}" hidden>
-                            </a>
+                            <div class="exhibition-image-preview partner-image-preview-logo">
+                                <a data-image-preview-link href="" hidden>
+                                    <img loading="lazy" data-image-preview-image alt="{% trans 'Logo preview' %}" hidden>
+                                </a>
+                            </div>
                             <p class="help-block text-danger" data-image-preview-error hidden>{% trans "We could not load this image preview." %}</p>
                         </div>
                     </div>
@@ -174,9 +176,11 @@
                     <div class="form-group" data-image-preview hidden>
                         <label class="col-md-3 control-label">{% trans "Header image preview" %}</label>
                         <div class="col-md-9">
-                            <a class="thumbnailed-file-link" data-image-preview-link href="" hidden>
-                                <img loading="lazy" data-image-preview-image class="img-responsive img-thumbnail partner-image-preview partner-image-preview-header" alt="{% trans 'Header image preview' %}" hidden>
-                            </a>
+                            <div class="exhibition-image-preview partner-image-preview-header">
+                                <a data-image-preview-link href="" hidden>
+                                    <img loading="lazy" data-image-preview-image alt="{% trans 'Header image preview' %}" hidden>
+                                </a>
+                            </div>
                             <p class="help-block text-danger" data-image-preview-error hidden>{% trans "We could not load this image preview." %}</p>
                         </div>
                     </div>

--- a/exhibition/templates/exhibitors/add.html
+++ b/exhibition/templates/exhibitors/add.html
@@ -156,7 +156,7 @@
                     <div class="form-group" data-image-preview hidden>
                         <label class="col-md-3 control-label">{% trans "Logo preview" %}</label>
                         <div class="col-md-9">
-                            <a data-image-preview-link href="" target="_blank" rel="noopener noreferrer" hidden>
+                            <a class="thumbnailed-file-link" data-image-preview-link href="" hidden>
                                 <img loading="lazy" data-image-preview-image class="img-responsive img-thumbnail partner-image-preview partner-image-preview-logo" alt="{% trans 'Logo preview' %}" hidden>
                             </a>
                             <p class="help-block text-danger" data-image-preview-error hidden>{% trans "We could not load this image preview." %}</p>
@@ -174,7 +174,7 @@
                     <div class="form-group" data-image-preview hidden>
                         <label class="col-md-3 control-label">{% trans "Header image preview" %}</label>
                         <div class="col-md-9">
-                            <a data-image-preview-link href="" target="_blank" rel="noopener noreferrer" hidden>
+                            <a class="thumbnailed-file-link" data-image-preview-link href="" hidden>
                                 <img loading="lazy" data-image-preview-image class="img-responsive img-thumbnail partner-image-preview partner-image-preview-header" alt="{% trans 'Header image preview' %}" hidden>
                             </a>
                             <p class="help-block text-danger" data-image-preview-error hidden>{% trans "We could not load this image preview." %}</p>

--- a/exhibition/templates/exhibitors/add.html
+++ b/exhibition/templates/exhibitors/add.html
@@ -268,5 +268,7 @@
         {% include "pretixcontrol/includes/logs.html" with obj=object %}
     </div>
 {% endif %}
+{% include "exhibitors/_image_preview_dialog.html" %}
 <script type="text/javascript" src="{% static 'exhibition/js/exhibitors-add.js' %}"></script>
+<script type="text/javascript" src="{% static 'exhibition/js/image-preview-dialog.js' %}"></script>
 {% endblock %}

--- a/exhibition/templates/exhibitors/add.html
+++ b/exhibition/templates/exhibitors/add.html
@@ -157,7 +157,7 @@
                         <label class="col-md-3 control-label">{% trans "Logo preview" %}</label>
                         <div class="col-md-9">
                             <div class="exhibition-image-preview partner-image-preview-logo">
-                                <a data-image-preview-link href="" hidden>
+                                <a data-image-preview-link href="" target="_blank" rel="noopener noreferrer" hidden>
                                     <img loading="lazy" data-image-preview-image alt="{% trans 'Logo preview' %}" hidden>
                                 </a>
                             </div>
@@ -177,7 +177,7 @@
                         <label class="col-md-3 control-label">{% trans "Header image preview" %}</label>
                         <div class="col-md-9">
                             <div class="exhibition-image-preview partner-image-preview-header">
-                                <a data-image-preview-link href="" hidden>
+                                <a data-image-preview-link href="" target="_blank" rel="noopener noreferrer" hidden>
                                     <img loading="lazy" data-image-preview-image alt="{% trans 'Header image preview' %}" hidden>
                                 </a>
                             </div>

--- a/exhibition/templates/exhibitors/public_proposal_form.html
+++ b/exhibition/templates/exhibitors/public_proposal_form.html
@@ -135,7 +135,7 @@
                         <label class="col-md-3 control-label">{% trans "Logo preview" %}</label>
                         <div class="col-md-9">
                             <div class="exhibition-image-preview partner-image-preview-logo">
-                                <a data-image-preview-link href="" hidden>
+                                <a data-image-preview-link href="" target="_blank" rel="noopener noreferrer" hidden>
                                     <img loading="lazy" data-image-preview-image alt="{% trans 'Logo preview' %}" hidden>
                                 </a>
                             </div>
@@ -155,7 +155,7 @@
                         <label class="col-md-3 control-label">{% trans "Header image preview" %}</label>
                         <div class="col-md-9">
                             <div class="exhibition-image-preview partner-image-preview-header">
-                                <a data-image-preview-link href="" hidden>
+                                <a data-image-preview-link href="" target="_blank" rel="noopener noreferrer" hidden>
                                     <img loading="lazy" data-image-preview-image alt="{% trans 'Header image preview' %}" hidden>
                                 </a>
                             </div>

--- a/exhibition/templates/exhibitors/public_proposal_form.html
+++ b/exhibition/templates/exhibitors/public_proposal_form.html
@@ -134,7 +134,7 @@
                     <div class="form-group" data-image-preview hidden>
                         <label class="col-md-3 control-label">{% trans "Logo preview" %}</label>
                         <div class="col-md-9">
-                            <a data-image-preview-link href="" target="_blank" rel="noopener noreferrer" hidden>
+                            <a class="thumbnailed-file-link" data-image-preview-link href="" hidden>
                                 <img loading="lazy" data-image-preview-image class="img-responsive img-thumbnail partner-image-preview partner-image-preview-logo" alt="{% trans 'Logo preview' %}" hidden>
                             </a>
                             <p class="help-block text-danger" data-image-preview-error hidden>{% trans "We could not load this image preview." %}</p>
@@ -152,7 +152,7 @@
                     <div class="form-group" data-image-preview hidden>
                         <label class="col-md-3 control-label">{% trans "Header image preview" %}</label>
                         <div class="col-md-9">
-                            <a data-image-preview-link href="" target="_blank" rel="noopener noreferrer" hidden>
+                            <a class="thumbnailed-file-link" data-image-preview-link href="" hidden>
                                 <img loading="lazy" data-image-preview-image class="img-responsive img-thumbnail partner-image-preview partner-image-preview-header" alt="{% trans 'Header image preview' %}" hidden>
                             </a>
                             <p class="help-block text-danger" data-image-preview-error hidden>{% trans "We could not load this image preview." %}</p>

--- a/exhibition/templates/exhibitors/public_proposal_form.html
+++ b/exhibition/templates/exhibitors/public_proposal_form.html
@@ -202,7 +202,9 @@
             </div>
         {% endif %}
     </form>
+    {% include "exhibitors/_image_preview_dialog.html" %}
     {% if can_edit %}
         <script type="text/javascript" src="{% static 'exhibition/js/exhibitors-add.js' %}"></script>
     {% endif %}
+    <script type="text/javascript" src="{% static 'exhibition/js/image-preview-dialog.js' %}"></script>
 {% endblock %}

--- a/exhibition/templates/exhibitors/public_proposal_form.html
+++ b/exhibition/templates/exhibitors/public_proposal_form.html
@@ -134,9 +134,11 @@
                     <div class="form-group" data-image-preview hidden>
                         <label class="col-md-3 control-label">{% trans "Logo preview" %}</label>
                         <div class="col-md-9">
-                            <a class="thumbnailed-file-link" data-image-preview-link href="" hidden>
-                                <img loading="lazy" data-image-preview-image class="img-responsive img-thumbnail partner-image-preview partner-image-preview-logo" alt="{% trans 'Logo preview' %}" hidden>
-                            </a>
+                            <div class="exhibition-image-preview partner-image-preview-logo">
+                                <a data-image-preview-link href="" hidden>
+                                    <img loading="lazy" data-image-preview-image alt="{% trans 'Logo preview' %}" hidden>
+                                </a>
+                            </div>
                             <p class="help-block text-danger" data-image-preview-error hidden>{% trans "We could not load this image preview." %}</p>
                         </div>
                     </div>
@@ -152,9 +154,11 @@
                     <div class="form-group" data-image-preview hidden>
                         <label class="col-md-3 control-label">{% trans "Header image preview" %}</label>
                         <div class="col-md-9">
-                            <a class="thumbnailed-file-link" data-image-preview-link href="" hidden>
-                                <img loading="lazy" data-image-preview-image class="img-responsive img-thumbnail partner-image-preview partner-image-preview-header" alt="{% trans 'Header image preview' %}" hidden>
-                            </a>
+                            <div class="exhibition-image-preview partner-image-preview-header">
+                                <a data-image-preview-link href="" hidden>
+                                    <img loading="lazy" data-image-preview-image alt="{% trans 'Header image preview' %}" hidden>
+                                </a>
+                            </div>
                             <p class="help-block text-danger" data-image-preview-error hidden>{% trans "We could not load this image preview." %}</p>
                         </div>
                     </div>


### PR DESCRIPTION
fixes #161

<img width="671" height="473" alt="image" src="https://github.com/user-attachments/assets/672807de-2b74-44f0-9c0b-97e6d9fd52c9" />


<img width="1493" height="720" alt="image" src="https://github.com/user-attachments/assets/1eb260b6-8db5-4c32-95ff-c50e24011f41" />

## Summary by Sourcery

Add responsive modal previews for uploaded exhibition images.

New Features:
- Add an image preview modal for uploaded exhibition logos and header images, with captions and accessible close controls.

Enhancements:
- Improve image preview presentation with responsive sizing, checkerboard transparency backgrounds, and visual hover and focus states.
- Use the shared preview modal across exhibitor and public proposal forms while preserving the existing inline previews.