### PR TITLE
fix: standardize exhibition tooltips

### DIFF
--- a/exhibition/static/exhibition/js/copy-key.js
+++ b/exhibition/static/exhibition/js/copy-key.js
@@ -1,6 +1,7 @@
 (function () {
-    document.addEventListener('DOMContentLoaded', function () {
-        document.querySelectorAll('.exhibitor-copy-key').forEach(function (button) {
+    function init() {
+        document.querySelectorAll('.exhibitor-copy-key:not([data-copy-key-bound])').forEach(function (button) {
+            button.setAttribute('data-copy-key-bound', 'true')
             var $button = $(button)
             var originalTitle = $button.attr('data-original-title') || button.getAttribute('title')
 
@@ -35,5 +36,12 @@
                     })
             })
         })
-    })
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init)
+    } else {
+        init()
+    }
+    document.addEventListener('eventyay:ajax-results-replaced', init)
 })()

--- a/exhibition/static/exhibition/js/message-center.js
+++ b/exhibition/static/exhibition/js/message-center.js
@@ -18,6 +18,9 @@
             .then(function (html) {
                 target.innerHTML = html;
                 target.classList.remove("email-list-loading");
+                target.dispatchEvent(
+                    new CustomEvent("eventyay:ajax-results-replaced", { bubbles: true, detail: { container: target } })
+                );
                 if (push) {
                     window.history.pushState({ emailList: true }, "", url);
                 }

--- a/exhibition/static/exhibition/js/partner-select.js
+++ b/exhibition/static/exhibition/js/partner-select.js
@@ -5,6 +5,10 @@
             return
         }
 
+        if (window.jQuery) {
+            $(scope).find('[data-toggle="tooltip"]').tooltip()
+        }
+
         var selectAll = scope.querySelector('[data-partner-select-all]')
         var countLabel = scope.querySelector('[data-partner-selected-count]')
         var downloadLink = scope.querySelector('[data-partner-download-link]')

--- a/exhibition/static/exhibition/js/proposal-actions.js
+++ b/exhibition/static/exhibition/js/proposal-actions.js
@@ -137,6 +137,7 @@
             button.className = 'btn btn-sm proposal-action-btn ' + config.cls + (config.variant ? ' ' + config.variant : '')
             button.setAttribute('data-proposal-action', action)
             button.setAttribute('data-proposal-code', code)
+            button.setAttribute('data-toggle', 'tooltip')
             if (config.label) {
                 button.title = config.label
             }
@@ -161,6 +162,9 @@
                     actionsCell.insertBefore(button, viewLink)
                 }
             })
+            if (window.jQuery) {
+                $(actionsCell).find('[data-toggle="tooltip"]').tooltip()
+            }
         }
 
         function rebuildCheckbox(row, result) {

--- a/exhibition/static/exhibition/js/tooltip-init.js
+++ b/exhibition/static/exhibition/js/tooltip-init.js
@@ -1,0 +1,14 @@
+(function () {
+    "use strict";
+
+    function initTooltips() {
+        $('[data-toggle="tooltip"]').tooltip();
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initTooltips);
+    } else {
+        initTooltips();
+    }
+    document.addEventListener('eventyay:ajax-results-replaced', initTooltips);
+})();

--- a/exhibition/templates/exhibitors/_email_outbox_body.html
+++ b/exhibition/templates/exhibitors/_email_outbox_body.html
@@ -43,7 +43,8 @@
                         <input type="checkbox" name="selected" value="{{ entry.pk }}" data-select-row>
                     </td>
                     <td>
-                        <span class="email-recipients" title="{{ entry.recipients|join:', ' }}">{{ entry.recipients|join:", " }}</span>
+                        <span class="email-recipients" title="{{ entry.recipients|join:', ' }}"
+                              data-toggle="tooltip">{{ entry.recipients|join:", " }}</span>
                         {% if entry.is_batch %}
                             <span class="label label-default">{{ entry.recipients|length }}</span>
                         {% endif %}

--- a/exhibition/templates/exhibitors/_email_outbox_body.html
+++ b/exhibition/templates/exhibitors/_email_outbox_body.html
@@ -64,21 +64,21 @@
                     <td class="email-actions">
                         <div class="btn-toolbar" role="toolbar">
                             <div class="btn-group" role="group">
-                                <button type="submit" class="btn btn-sm btn-primary" title="{% trans 'Send this email' %}"
+                                <button type="submit" class="btn btn-sm btn-primary" title="{% trans 'Send' %}"
                                         data-toggle="tooltip"
                                         formaction="{% url 'plugins:exhibition:email.send' organizer=request.event.organizer.slug event=request.event.slug pk=entry.pk %}">
                                     <i class="fa fa-mail-forward"></i>
                                 </button>
                             </div>
                             <div class="btn-group" role="group">
-                                <a class="btn btn-sm btn-info" title="{% trans 'Edit this email' %}"
+                                <a class="btn btn-sm btn-info" title="{% trans 'Edit' %}"
                                    data-toggle="tooltip"
                                    href="{% url 'plugins:exhibition:email.edit' organizer=request.event.organizer.slug event=request.event.slug pk=entry.pk %}">
                                     <i class="fa fa-edit"></i>
                                 </a>
                             </div>
                             <div class="btn-group" role="group">
-                                <a class="btn btn-sm btn-danger" title="{% trans 'Discard this email' %}"
+                                <a class="btn btn-sm btn-danger" title="{% trans 'Discard' %}"
                                    data-toggle="tooltip"
                                    href="{% url 'plugins:exhibition:email.delete' organizer=request.event.organizer.slug event=request.event.slug pk=entry.pk %}">
                                     <i class="fa fa-trash"></i>

--- a/exhibition/templates/exhibitors/_email_outbox_body.html
+++ b/exhibition/templates/exhibitors/_email_outbox_body.html
@@ -65,18 +65,21 @@
                         <div class="btn-toolbar" role="toolbar">
                             <div class="btn-group" role="group">
                                 <button type="submit" class="btn btn-sm btn-primary" title="{% trans 'Send this email' %}"
+                                        data-toggle="tooltip"
                                         formaction="{% url 'plugins:exhibition:email.send' organizer=request.event.organizer.slug event=request.event.slug pk=entry.pk %}">
                                     <i class="fa fa-mail-forward"></i>
                                 </button>
                             </div>
                             <div class="btn-group" role="group">
                                 <a class="btn btn-sm btn-info" title="{% trans 'Edit this email' %}"
+                                   data-toggle="tooltip"
                                    href="{% url 'plugins:exhibition:email.edit' organizer=request.event.organizer.slug event=request.event.slug pk=entry.pk %}">
                                     <i class="fa fa-edit"></i>
                                 </a>
                             </div>
                             <div class="btn-group" role="group">
                                 <a class="btn btn-sm btn-danger" title="{% trans 'Discard this email' %}"
+                                   data-toggle="tooltip"
                                    href="{% url 'plugins:exhibition:email.delete' organizer=request.event.organizer.slug event=request.event.slug pk=entry.pk %}">
                                     <i class="fa fa-trash"></i>
                                 </a>

--- a/exhibition/templates/exhibitors/_email_sent_body.html
+++ b/exhibition/templates/exhibitors/_email_sent_body.html
@@ -19,7 +19,8 @@
         {% for entry in entries %}
             <tr>
                 <td>
-                    <span class="email-recipients" title="{{ entry.recipients|join:', ' }}">{{ entry.recipients|join:", " }}</span>
+                    <span class="email-recipients" title="{{ entry.recipients|join:', ' }}"
+                          data-toggle="tooltip">{{ entry.recipients|join:", " }}</span>
                     {% if entry.is_batch %}
                         <span class="label label-default">{{ entry.recipients|length }}</span>
                     {% endif %}

--- a/exhibition/templates/exhibitors/_filter_form.html
+++ b/exhibition/templates/exhibitors/_filter_form.html
@@ -15,7 +15,8 @@
             </div>
             <div class="advanced-filter-search-actions">
                 <a href="{{ request.path }}" class="btn btn-default btn-clear-filter"
-                   aria-label="{% trans 'Clear filters' %}" title="{% trans 'Clear filters' %}">
+                   aria-label="{% trans 'Clear filters' %}" title="{% trans 'Clear filters' %}"
+                   data-toggle="tooltip">
                     <span class="fa fa-eraser" aria-hidden="true"></span>
                     <span class="sr-only">{% trans "Clear filters" %}</span>
                 </a>

--- a/exhibition/templates/exhibitors/_partner_row.html
+++ b/exhibition/templates/exhibitors/_partner_row.html
@@ -36,13 +36,13 @@
     {% endif %}
     <td class="text-right flip">
         {% if "can_change_event_settings" in request.eventpermset %}
-            <a href="{% url "plugins:exhibition:edit" organizer=request.event.organizer.slug event=request.event.slug pk=e.id %}?type={{ partner_type }}" class="btn btn-default btn-sm"><i class="fa fa-edit"></i></a>
+            <a href="{% url "plugins:exhibition:edit" organizer=request.event.organizer.slug event=request.event.slug pk=e.id %}?type={{ partner_type }}" class="btn btn-default btn-sm" title="{% trans "Edit" %}" data-toggle="tooltip"><i class="fa fa-edit"></i></a>
             <button type="button" class="btn btn-default btn-sm exhibitor-copy-key" data-url="{% url "plugins:exhibition:copy_key" organizer=request.event.organizer.slug event=request.event.slug pk=e.id %}" data-copied-label="{% trans "Copied!" %}" data-failed-label="{% trans "Copy failed" %}" title="{% trans "Key" %}" data-toggle="tooltip"><i class="fa fa-copy"></i></button>
             <a href="{% url "plugins:exhibition:vouchers" organizer=request.event.organizer.slug event=request.event.slug pk=e.id %}" class="btn btn-default btn-sm" title="{% trans "Vouchers" %}" data-toggle="tooltip"><i class="fa fa-ticket"></i></a>
             <a href="{% url "plugins:exhibition:devices" organizer=request.event.organizer.slug event=request.event.slug pk=e.id %}" class="btn btn-default btn-sm" title="{% trans "Lead-scanning devices" %}" data-toggle="tooltip"><i class="fa fa-mobile"></i></a>
-            <a href="{% url "plugins:exhibition:delete" organizer=request.event.organizer.slug event=request.event.slug pk=e.id %}?type={{ partner_type }}" class="btn btn-delete btn-danger btn-sm"><i class="fa fa-trash"></i></a>
+            <a href="{% url "plugins:exhibition:delete" organizer=request.event.organizer.slug event=request.event.slug pk=e.id %}?type={{ partner_type }}" class="btn btn-delete btn-danger btn-sm" title="{% trans "Delete" %}" data-toggle="tooltip"><i class="fa fa-trash"></i></a>
             {% if reorder_enabled %}
-                <button type="button" draggable="true" class="btn btn-primary btn-sm dragsort-button" title="{% trans 'Move' %}" aria-label="{% trans 'Move' %}">
+                <button type="button" draggable="true" class="btn btn-primary btn-sm dragsort-button" title="{% trans 'Move' %}" aria-label="{% trans 'Move' %}" data-toggle="tooltip">
                     <i class="fa fa-arrows"></i>
                 </button>
             {% endif %}

--- a/exhibition/templates/exhibitors/base.html
+++ b/exhibition/templates/exhibitors/base.html
@@ -1,8 +1,14 @@
 {% extends 'pretixcontrol/base.html' %}
 {% load i18n %}
+{% load static %}
 {% load exhibition_email %}
 
 {% block title %}{{ request.event.name }} - {% trans "Exhibitors & Sponsors" %}{% endblock %}
+
+{% block custom_header %}
+    {{ block.super }}
+    <script defer src="{% static 'exhibition/js/tooltip-init.js' %}"></script>
+{% endblock %}
 
 {% block nav %}
   <li>

--- a/exhibition/templates/exhibitors/call_questions.html
+++ b/exhibition/templates/exhibitors/call_questions.html
@@ -70,13 +70,13 @@
                             <td class="text-center">{{ field.answer_count }}</td>
                             <td class="text-right">
                                 {% if field.is_custom %}
-                                    <a class="btn btn-default btn-sm" href="{% url 'plugins:exhibition:call.questions.edit' organizer=request.event.organizer.slug event=request.event.slug pk=field.pk %}" title="{% trans 'Edit' %}"><i class="fa fa-edit"></i></a>
-                                    <a class="btn btn-delete btn-danger btn-sm" href="{% url 'plugins:exhibition:call.questions.delete' organizer=request.event.organizer.slug event=request.event.slug pk=field.pk %}" title="{% trans 'Delete' %}"><i class="fa fa-trash"></i></a>
+                                    <a class="btn btn-default btn-sm" href="{% url 'plugins:exhibition:call.questions.edit' organizer=request.event.organizer.slug event=request.event.slug pk=field.pk %}" title="{% trans 'Edit' %}" data-toggle="tooltip"><i class="fa fa-edit"></i></a>
+                                    <a class="btn btn-delete btn-danger btn-sm" href="{% url 'plugins:exhibition:call.questions.delete' organizer=request.event.organizer.slug event=request.event.slug pk=field.pk %}" title="{% trans 'Delete' %}" data-toggle="tooltip"><i class="fa fa-trash"></i></a>
                                 {% else %}
-                                    <a class="btn btn-default btn-sm" href="{% url 'plugins:exhibition:call.fields.edit' organizer=request.event.organizer.slug event=request.event.slug key=field.dragsort_id %}" title="{% trans 'Edit' %}"><i class="fa fa-edit"></i></a>
-                                    <a class="btn btn-delete btn-danger btn-sm" href="{% url 'plugins:exhibition:call.fields.reset' organizer=request.event.organizer.slug event=request.event.slug key=field.dragsort_id %}" title="{% trans 'Reset to default' %}"><i class="fa fa-trash"></i></a>
+                                    <a class="btn btn-default btn-sm" href="{% url 'plugins:exhibition:call.fields.edit' organizer=request.event.organizer.slug event=request.event.slug key=field.dragsort_id %}" title="{% trans 'Edit' %}" data-toggle="tooltip"><i class="fa fa-edit"></i></a>
+                                    <a class="btn btn-delete btn-danger btn-sm" href="{% url 'plugins:exhibition:call.fields.reset' organizer=request.event.organizer.slug event=request.event.slug key=field.dragsort_id %}" title="{% trans 'Reset to default' %}" data-toggle="tooltip"><i class="fa fa-trash"></i></a>
                                 {% endif %}
-                                <button type="button" draggable="true" class="btn btn-primary btn-sm dragsort-button" title="{% trans 'Move field' %}" aria-label="{% trans 'Move field' %}">
+                                <button type="button" draggable="true" class="btn btn-primary btn-sm dragsort-button" title="{% trans 'Move field' %}" aria-label="{% trans 'Move field' %}" data-toggle="tooltip">
                                     <i class="fa fa-arrows"></i>
                                 </button>
                             </td>

--- a/exhibition/templates/exhibitors/email_templates.html
+++ b/exhibition/templates/exhibitors/email_templates.html
@@ -78,7 +78,7 @@
                             <strong>{{ panel.label }}</strong>
                             <span class="pull-right">
                                 <a href="{% url 'plugins:exhibition:email.custom_templates.delete' organizer=request.event.organizer.slug event=request.event.slug pk=panel.pk %}"
-                                   class="btn btn-sm btn-danger" title="{% trans 'Discard this template' %}">
+                                   class="btn btn-sm btn-danger" title="{% trans 'Discard this template' %}" data-toggle="tooltip">
                                     <i class="fa fa-trash"></i>
                                 </a>
                                 <i class="fa fa-angle-down collapse-indicator"></i>

--- a/exhibition/templates/exhibitors/proposal_list.html
+++ b/exhibition/templates/exhibitors/proposal_list.html
@@ -107,34 +107,35 @@
                                 <a class="proposal-edited-dot"
                                    href="{% url 'plugins:exhibition:proposal.detail' organizer=request.event.organizer.slug event=request.event.slug code=proposal.code %}#post-acceptance-changes"
                                    title="{{ edited_hint }}"
-                                   aria-label="{{ edited_hint }}"></a>
+                                   aria-label="{{ edited_hint }}"
+                                   data-toggle="tooltip"></a>
                             {% endif %}
                         </td>
                         <td>{{ proposal.updated|date:"SHORT_DATETIME_FORMAT" }}</td>
                         <td class="text-right proposal-row-actions" data-proposal-actions-cell>
                             {% if can_manage %}
                                 {% if "approve" in proposal.review_actions %}
-                                    <button type="button" class="btn btn-success btn-sm proposal-action-btn proposal-action-approve" data-proposal-action="approve" data-proposal-code="{{ proposal.code }}" title="{% trans 'Approve' %}">
+                                    <button type="button" class="btn btn-success btn-sm proposal-action-btn proposal-action-approve" data-proposal-action="approve" data-proposal-code="{{ proposal.code }}" title="{% trans 'Approve' %}" data-toggle="tooltip">
                                         <i class="fa fa-check"></i>
                                     </button>
                                 {% endif %}
                                 {% if "reject" in proposal.review_actions %}
-                                    <button type="button" class="btn btn-danger btn-sm proposal-action-btn proposal-action-reject" data-proposal-action="reject" data-proposal-code="{{ proposal.code }}" title="{% trans 'Reject' %}">
+                                    <button type="button" class="btn btn-danger btn-sm proposal-action-btn proposal-action-reject" data-proposal-action="reject" data-proposal-code="{{ proposal.code }}" title="{% trans 'Reject' %}" data-toggle="tooltip">
                                         <i class="fa fa-times"></i>
                                     </button>
                                 {% endif %}
                                 {% if "withdraw" in proposal.review_actions %}
-                                    <button type="button" class="btn btn-sm proposal-action-btn proposal-action-withdraw" data-proposal-action="withdraw" data-proposal-code="{{ proposal.code }}" title="{% trans 'Withdraw' %}">
+                                    <button type="button" class="btn btn-sm proposal-action-btn proposal-action-withdraw" data-proposal-action="withdraw" data-proposal-code="{{ proposal.code }}" title="{% trans 'Withdraw' %}" data-toggle="tooltip">
                                         <i class="fa fa-undo"></i>
                                     </button>
                                 {% endif %}
                                 {% if "reopen" in proposal.review_actions %}
-                                    <button type="button" class="btn btn-sm proposal-action-btn proposal-action-reopen" data-proposal-action="reopen" data-proposal-code="{{ proposal.code }}" title="{% trans 'Reopen for review' %}">
+                                    <button type="button" class="btn btn-sm proposal-action-btn proposal-action-reopen" data-proposal-action="reopen" data-proposal-code="{{ proposal.code }}" title="{% trans 'Reopen for review' %}" data-toggle="tooltip">
                                         <i class="fa fa-inbox"></i>
                                     </button>
                                 {% endif %}
                             {% endif %}
-                            <a class="btn btn-default btn-sm" href="{% url 'plugins:exhibition:proposal.detail' organizer=request.event.organizer.slug event=request.event.slug code=proposal.code %}" title="{% trans 'View' %}">
+                            <a class="btn btn-default btn-sm" href="{% url 'plugins:exhibition:proposal.detail' organizer=request.event.organizer.slug event=request.event.slug code=proposal.code %}" title="{% trans 'View' %}" data-toggle="tooltip">
                                 <i class="fa fa-eye"></i>
                             </a>
                         </td>

--- a/exhibition/templates/exhibitors/settings.html
+++ b/exhibition/templates/exhibitors/settings.html
@@ -238,7 +238,9 @@
                                                 type="button"
                                                 class="btn btn-default btn-sm sponsor-group-edit-toggle"
                                                 data-group-editor-toggle="group-editor-{{ group.pk }}"
-                                                aria-expanded="{% if expanded_group_pk == group.pk %}true{% else %}false{% endif %}">
+                                                aria-expanded="{% if expanded_group_pk == group.pk %}true{% else %}false{% endif %}"
+                                                title="{% trans 'Edit sponsor group' %}"
+                                                data-toggle="tooltip">
                                                 <i class="fa fa-angle-down"></i>
                                             </button>
                                             <form action="" method="post" class="sponsor-group-delete-form">

--- a/exhibition/templates/exhibitors/settings.html
+++ b/exhibition/templates/exhibitors/settings.html
@@ -246,9 +246,9 @@
                                                 <input type="hidden" name="tab" value="sponsors">
                                                 <input type="hidden" name="action" value="delete_group">
                                                 <input type="hidden" name="group_id" value="{{ group.pk }}">
-                                                <button type="submit" class="btn btn-delete btn-danger btn-sm"><i class="fa fa-trash"></i></button>
+                                                <button type="submit" class="btn btn-delete btn-danger btn-sm" title="{% trans 'Delete' %}" data-toggle="tooltip"><i class="fa fa-trash"></i></button>
                                             </form>
-                                            <button type="button" class="btn btn-primary btn-sm sponsor-group-drag-handle" data-group-drag-handle aria-label="{% trans 'Reorder sponsor group' %}" title="{% trans 'Reorder sponsor group' %}">
+                                            <button type="button" class="btn btn-primary btn-sm sponsor-group-drag-handle" data-group-drag-handle aria-label="{% trans 'Reorder sponsor group' %}" title="{% trans 'Reorder sponsor group' %}" data-toggle="tooltip">
                                                 <i class="fa fa-arrows"></i>
                                             </button>
                                         </div>

--- a/exhibition/templates/exhibitors/vouchers.html
+++ b/exhibition/templates/exhibitors/vouchers.html
@@ -54,7 +54,7 @@
                                     <input type="hidden" name="voucher" value="{{ link.pk }}">
                                     {% if link.voucher.redeemed %}
                                         <span data-toggle="tooltip" title="{% trans "Already redeemed" %}">
-                                            <button type="button" class="btn btn-delete btn-danger btn-sm" disabled style="pointer-events: none;">
+                                            <button type="button" class="btn btn-delete btn-danger btn-sm" disabled>
                                                 <i class="fa fa-trash"></i>
                                             </button>
                                         </span>

--- a/exhibition/templates/exhibitors/vouchers.html
+++ b/exhibition/templates/exhibitors/vouchers.html
@@ -53,7 +53,7 @@
                                     <input type="hidden" name="action" value="delete">
                                     <input type="hidden" name="voucher" value="{{ link.pk }}">
                                     <button type="submit" class="btn btn-delete btn-danger btn-sm"
-                                            {% if link.voucher.redeemed %}disabled title="{% trans "Already redeemed" %}"{% endif %}>
+                                            {% if link.voucher.redeemed %}disabled title="{% trans "Already redeemed" %}" data-toggle="tooltip"{% else %}title="{% trans "Delete" %}" data-toggle="tooltip"{% endif %}>
                                         <i class="fa fa-trash"></i>
                                     </button>
                                 </form>

--- a/exhibition/templates/exhibitors/vouchers.html
+++ b/exhibition/templates/exhibitors/vouchers.html
@@ -52,10 +52,17 @@
                                     {% csrf_token %}
                                     <input type="hidden" name="action" value="delete">
                                     <input type="hidden" name="voucher" value="{{ link.pk }}">
-                                    <button type="submit" class="btn btn-delete btn-danger btn-sm"
-                                            {% if link.voucher.redeemed %}disabled title="{% trans "Already redeemed" %}" data-toggle="tooltip"{% else %}title="{% trans "Delete" %}" data-toggle="tooltip"{% endif %}>
-                                        <i class="fa fa-trash"></i>
-                                    </button>
+                                    {% if link.voucher.redeemed %}
+                                        <span data-toggle="tooltip" title="{% trans "Already redeemed" %}">
+                                            <button type="button" class="btn btn-delete btn-danger btn-sm" disabled style="pointer-events: none;">
+                                                <i class="fa fa-trash"></i>
+                                            </button>
+                                        </span>
+                                    {% else %}
+                                        <button type="submit" class="btn btn-delete btn-danger btn-sm" title="{% trans "Delete" %}" data-toggle="tooltip">
+                                            <i class="fa fa-trash"></i>
+                                        </button>
+                                    {% endif %}
                                 </form>
                             </td>
                         </tr>


### PR DESCRIPTION
## Description

Closes #184

Standardizes action and control button tooltips across the Exhibition plugin by using the Bootstrap tooltip convention consistently.

This also fixes the existing issue where Bootstrap tooltips disappear after AJAX-based list filtering or search.

## Changes Made

### 1. Fix tooltip initialization after AJAX updates

* Added a shared `tooltip-init.js` module to initialize Bootstrap tooltips on page load.
* Re-initializes tooltips when `eventyay:ajax-results-replaced` is triggered after AJAX results are replaced.
* Added the shared initializer to the Exhibition base template.
* Updated the message center to dispatch the AJAX results replacement event.
* Ensured dynamically generated proposal action buttons receive Bootstrap tooltips.
* Updated partner select and copy-key behavior so tooltip functionality continues to work after list refreshes.

### 2. Standardize tooltips across Exhibition lists

Added Bootstrap tooltips and missing `title` attributes to action/control buttons across the Exhibition plugin, including:

* Exhibitor and Sponsor lists

  * Edit
  * Delete
  * Move

* Exhibition Requests

  * Approve
  * Reject
  * Withdraw
  * Reopen
  * View
  * Edited indicator

* Exhibitor Form Fields

  * Edit
  * Delete
  * Reset to default
  * Move

* Email Outbox

  * Send
  * Edit
  * Discard

* Email Templates

  * Discard custom template

* Vouchers

  * Delete

* Sponsor Settings

  * Delete sponsor group
  * Move

All tooltips follow the existing Bootstrap convention used throughout eventyay.

##Screenshots 

<img width="1458" height="731" alt="Screenshot 2026-08-28 at 10 29 28 PM" src="https://github.com/user-attachments/assets/01f15044-473f-4b6f-b5e1-40343f8a0ddb" />

<img width="1424" height="740" alt="Screenshot 2026-08-28 at 10 29 39 PM" src="https://github.com/user-attachments/assets/4b64ceca-e828-4d11-9e38-004c26a050af" />


## Verification

* Verified that the updated action buttons use Bootstrap tooltips instead of browser-native tooltips.
* Verified that missing tooltips were added to relevant icon-only actions.
* Tested tooltip behavior after AJAX-based filtering/search.
* Confirmed that tooltips are re-initialized after AJAX results are replaced.
* Ran `git diff --check` to check for whitespace errors.
* Confirmed the working tree is clean after committing the changes.

## Summary by Sourcery

Standardize Exhibition tooltips and keep them functional across page loads, AJAX updates, and dynamic list interactions.

Bug Fixes:
- Restore Bootstrap tooltips after AJAX-filtered or dynamically replaced Exhibition content.

Enhancements:
- Standardize Bootstrap tooltips and labels across Exhibition action and control buttons, including dynamically generated proposal actions.