### PR TITLE
fix: mark email body as required

### DIFF
--- a/exhibition/forms.py
+++ b/exhibition/forms.py
@@ -8,6 +8,7 @@ from django.db import transaction
 from django.db.models import Max
 from django.forms import inlineformset_factory
 from django.utils import timezone
+from django.utils.html import strip_tags
 from django.utils.translation import gettext_lazy as _
 from django_countries.fields import CountryField
 from eventyay.base.forms import I18nFormSet, I18nModelForm, SettingsForm
@@ -30,6 +31,7 @@ from eventyay.control.forms import ExtFileField, SplitDateTimeField
 from eventyay.helpers.countries import CachedCountries
 from eventyay.helpers.i18n import get_format_without_seconds, is_rtl
 from i18nfield.forms import I18nFormField, I18nTextInput
+from i18nfield.strings import LazyI18nString
 from phonenumber_field.formfields import PhoneNumberField
 from phonenumber_field.widgets import PhoneNumberPrefixWidget
 
@@ -1900,11 +1902,39 @@ class ExhibitionComposeForm(forms.Form):
             }
         )
 
+    def clean_body(self):
+        body = self.cleaned_data.get("body")
+        if not body:
+            raise forms.ValidationError(_("This field is required."))
+        if isinstance(body, LazyI18nString):
+            data = body.data
+            if isinstance(data, dict):
+                has_content = any(not _is_html_empty(v) for v in data.values() if v)
+                if not has_content:
+                    raise forms.ValidationError(_("This field is required."))
+            elif isinstance(data, str) and _is_html_empty(data):
+                raise forms.ValidationError(_("This field is required."))
+        elif isinstance(body, str) and _is_html_empty(body):
+            raise forms.ValidationError(_("This field is required."))
+        return body
+
     def clean_scheduled_at(self):
         scheduled_at = self.cleaned_data.get("scheduled_at")
         if scheduled_at and scheduled_at <= timezone.now():
             raise forms.ValidationError(_("The scheduled time must be in the future."))
         return scheduled_at
+
+
+def _is_html_empty(html: str) -> bool:
+    """Check whether an HTML snippet contains no substantive text or media."""
+    if not html:
+        return True
+    text = strip_tags(html).replace("\xa0", " ").replace("&nbsp;", " ").strip()
+    if text:
+        return False
+    if "<img" in html:
+        return False
+    return True
 
 
 class ExhibitionMailTemplatesForm(SettingsForm):

--- a/exhibition/forms.py
+++ b/exhibition/forms.py
@@ -1,3 +1,5 @@
+from html import unescape
+
 import dateutil.parser
 from django import forms
 from django.conf import settings as django_settings
@@ -1929,10 +1931,10 @@ def _is_html_empty(html: str) -> bool:
     """Check whether an HTML snippet contains no substantive text or media."""
     if not html:
         return True
-    text = strip_tags(html).replace("\xa0", " ").replace("&nbsp;", " ").strip()
+    text = unescape(strip_tags(html)).replace("\xa0", " ").strip()
     if text:
         return False
-    if "<img" in html:
+    if "<img" in html.lower():
         return False
     return True
 

--- a/exhibition/forms.py
+++ b/exhibition/forms.py
@@ -1819,6 +1819,18 @@ def social_link_prefixes() -> dict[str, str]:
     return {key: spec.prefix for key, spec in SOCIAL_LINK_SPECS.items()}
 
 
+def _is_html_empty(html: str) -> bool:
+    """Check whether an HTML snippet contains no substantive text or media."""
+    if not html:
+        return True
+    text = unescape(strip_tags(html)).replace("\xa0", " ").strip()
+    if text:
+        return False
+    if "<img" in html.lower():
+        return False
+    return True
+
+
 class ExhibitionEmailQueueForm(forms.ModelForm):
     """Edit a queued email's recipient / subject / body / schedule before sending."""
 
@@ -1840,6 +1852,12 @@ class ExhibitionEmailQueueForm(forms.ModelForm):
                 "Leave empty to keep this in the outbox until sent manually. Time is interpreted in the event timezone."
             ),
         }
+
+    def clean_body(self):
+        body = self.cleaned_data.get("body")
+        if not body or _is_html_empty(body):
+            raise forms.ValidationError(_("This field is required."))
+        return body
 
     def clean_scheduled_at(self):
         scheduled_at = self.cleaned_data.get("scheduled_at")
@@ -1925,18 +1943,6 @@ class ExhibitionComposeForm(forms.Form):
         if scheduled_at and scheduled_at <= timezone.now():
             raise forms.ValidationError(_("The scheduled time must be in the future."))
         return scheduled_at
-
-
-def _is_html_empty(html: str) -> bool:
-    """Check whether an HTML snippet contains no substantive text or media."""
-    if not html:
-        return True
-    text = unescape(strip_tags(html)).replace("\xa0", " ").strip()
-    if text:
-        return False
-    if "<img" in html.lower():
-        return False
-    return True
 
 
 class ExhibitionMailTemplatesForm(SettingsForm):

--- a/exhibition/templates/exhibitors/email_compose.html
+++ b/exhibition/templates/exhibitors/email_compose.html
@@ -46,9 +46,9 @@
         <fieldset>
             <legend>{% trans "Message" %}</legend>
             {% bootstrap_field form.subject layout="control" %}
-            <div class="form-group" data-email-preview-wrapper
+            <div class="form-group{% if form.body.errors %} has-error{% endif %}" data-email-preview-wrapper
                  data-email-preview-url="{% url 'plugins:exhibition:email.templates.preview' organizer=request.event.organizer.slug event=request.event.slug %}?role=compose">
-                <label class="col-md-3 control-label">{{ form.body.label }}</label>
+                <label class="col-md-3 control-label"><span class="label-text">{{ form.body.label }}<span aria-hidden="true" class="required-indicator text-danger"> *</span><span class="sr-only">, {% trans "required" context "form" %}</span></span></label>
                 <div class="col-md-9">
                     <ul class="nav nav-tabs" role="tablist">
                         <li role="presentation" class="active">

--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -1703,8 +1703,7 @@ class ExhibitionQuestionOptionFormSetMixin:
         ordered_forms = self.option_formset.ordered_forms + [
             option_form
             for option_form in self.option_formset.extra_forms
-            if option_form not in self.option_formset.ordered_forms
-            and option_form not in deleted_forms
+            if option_form not in self.option_formset.ordered_forms and option_form not in deleted_forms
         ]
         option_forms = [
             option_form

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -11,7 +11,11 @@ from django_scopes import scopes_disabled
 from eventyay.base.models.auth import User
 
 from exhibition import mail as mail_helpers
-from exhibition.forms import ExhibitionComposeForm, ExhibitionMailTemplatesForm
+from exhibition.forms import (
+    ExhibitionComposeForm,
+    ExhibitionEmailQueueForm,
+    ExhibitionMailTemplatesForm,
+)
 from exhibition.models import (
     ExhibitionEmailQueue,
     ExhibitionProposal,
@@ -484,6 +488,52 @@ def test_compose_form_accepts_valid_body(mail_event, valid_body):
         data={
             "states": [ExhibitionProposalState.ACCEPTED],
             **_compose_data(mail_event, subject="Hi", body=valid_body),
+        },
+        event=mail_event,
+    )
+    assert form.is_valid(), form.errors
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "empty_body",
+    [
+        "",
+        "<p></p>",
+        "<p><br></p>",
+        "<p>&nbsp;</p>",
+        "<p>&#160;</p>",
+        "<p>&#xA0;</p>",
+    ],
+)
+def test_email_queue_edit_form_rejects_empty_html_body(mail_event, empty_body):
+    form = ExhibitionEmailQueueForm(
+        data={
+            "to_email": "test@example.com",
+            "subject": "Update",
+            "body": empty_body,
+        },
+        event=mail_event,
+    )
+    assert not form.is_valid()
+    assert "body" in form.errors
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "valid_body",
+    [
+        '<img src="https://example.com/logo.png">',
+        '<IMG SRC="https://example.com/logo.png">',
+        "<p>Hello world</p>",
+    ],
+)
+def test_email_queue_edit_form_accepts_valid_body(mail_event, valid_body):
+    form = ExhibitionEmailQueueForm(
+        data={
+            "to_email": "test@example.com",
+            "subject": "Update",
+            "body": valid_body,
         },
         event=mail_event,
     )

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -447,6 +447,21 @@ def test_compose_form_requires_subject_and_body(mail_event):
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize("empty_body", ["", "<p></p>", "<p><br></p>", "<p>&nbsp;</p>"])
+def test_compose_form_rejects_empty_html_body(mail_event, empty_body):
+    form = ExhibitionComposeForm(
+        data={
+            "states": [ExhibitionProposalState.ACCEPTED],
+            **_compose_data(mail_event, subject="Hi", body=empty_body),
+        },
+        event=mail_event,
+    )
+    assert not form.is_valid()
+    assert "body" in form.errors
+
+
+
+@pytest.mark.django_db
 def test_compose_view_saves_to_outbox(mail_event):
     _proposal(mail_event, "Acme", ExhibitionProposalState.ACCEPTED, email="a@example.com")
     form = ExhibitionComposeForm(

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -447,7 +447,17 @@ def test_compose_form_requires_subject_and_body(mail_event):
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("empty_body", ["", "<p></p>", "<p><br></p>", "<p>&nbsp;</p>"])
+@pytest.mark.parametrize(
+    "empty_body",
+    [
+        "",
+        "<p></p>",
+        "<p><br></p>",
+        "<p>&nbsp;</p>",
+        "<p>&#160;</p>",
+        "<p>&#xA0;</p>",
+    ],
+)
 def test_compose_form_rejects_empty_html_body(mail_event, empty_body):
     form = ExhibitionComposeForm(
         data={
@@ -459,6 +469,25 @@ def test_compose_form_rejects_empty_html_body(mail_event, empty_body):
     assert not form.is_valid()
     assert "body" in form.errors
 
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "valid_body",
+    [
+        '<img src="https://example.com/logo.png">',
+        '<IMG SRC="https://example.com/logo.png">',
+        "<p>Hello world</p>",
+    ],
+)
+def test_compose_form_accepts_valid_body(mail_event, valid_body):
+    form = ExhibitionComposeForm(
+        data={
+            "states": [ExhibitionProposalState.ACCEPTED],
+            **_compose_data(mail_event, subject="Hi", body=valid_body),
+        },
+        event=mail_event,
+    )
+    assert form.is_valid(), form.errors
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Fixes issue #187 — Mark Email Body Required

### 1. Required Asterisk UI (`email_compose.html`)

* Rendered the required asterisk using `<span class="required-indicator text-danger"> *</span>` inside `<span class="label-text">`, ensuring it is styled red to match `subject` and other required fields.
* Added `{% if form.body.errors %} has-error{% endif %}` to the containing `.form-group` so validation errors highlight the label, tabs, and border in red, consistent with the `subject` field.

### 2. Validation When Body Is Cleared (`forms.py`)

* Implemented `clean_body()` and an `_is_html_empty()` helper on `ExhibitionComposeForm`.
* When the rich-text editor is cleared and leaves empty HTML wrappers such as `<p></p>`, `<p><br></p>`, or `<p>&nbsp;</p>`, `clean_body()` detects the content as empty and raises `ValidationError(_("This field is required."))`.
* This prevents users from saving or sending an email with an effectively empty body.

### 3. Tests Added (`test_email.py`)

* Added `test_compose_form_rejects_empty_html_body` to verify that `ExhibitionComposeForm` rejects empty email bodies for the following variants:

  * `""`
  * `"<p></p>"`
  * `"<p><br></p>"`
  * `"<p>&nbsp;</p>"`

### 4. Screenshots 

<img width="1435" height="712" alt="Screenshot 2026-08-31 at 12 21 19 AM" src="https://github.com/user-attachments/assets/9e779522-3f71-4955-b5b1-5f1877fd643d" />

<img width="1431" height="711" alt="Screenshot 2026-08-31 at 12 21 32 AM" src="https://github.com/user-attachments/assets/701a4582-895a-4419-8927-46ce42d6a46c" />

## Summary by Sourcery

Require meaningful email body content and provide consistent required-field validation feedback in the email workflows.

Bug Fixes:
- Require substantive content in composed and queued email bodies, rejecting empty rich-text HTML while allowing text and images.
- Highlight email body validation errors and mark the field as required in the compose interface.

Tests:
- Add coverage for empty and valid HTML bodies in compose and queued email forms.