### PR TITLE
fix: Add form_invalid error message to exhibition forms

### DIFF
--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -776,6 +776,7 @@ class ProposalLinkFormsetMixin:
         return context
 
     def form_invalid(self, form):
+        messages.error(self.request, _("We could not save your changes. See below for details."))
         return self.render_to_response(self.get_context_data(form=form))
 
     def save_link_formsets(self):
@@ -1091,6 +1092,7 @@ class ExhibitorLinkFormsetMixin:
         return context
 
     def form_invalid(self, form):
+        messages.error(self.request, _("We could not save your changes. See below for details."))
         return self.render_to_response(self.get_context_data(form=form))
 
     def save_link_formsets(self):
@@ -1776,6 +1778,10 @@ class ExhibitionDefaultFieldEditView(DefaultFieldMixin, FormView):
         messages.success(self.request, _("Your changes have been saved."))
         return redirect(self.get_success_url())
 
+    def form_invalid(self, form):
+        messages.error(self.request, _("We could not save your changes. See below for details."))
+        return super().form_invalid(form)
+
 
 class ExhibitionDefaultFieldResetView(DefaultFieldMixin, TemplateView):
     template_name = "exhibitors/call_default_field_reset.html"
@@ -2211,6 +2217,9 @@ class EmailComposeView(EventPermissionRequiredMixin, FormView):
         )
         return redirect("plugins:exhibition:email.outbox", **event_kwargs(event))
 
+    def form_invalid(self, form):
+        messages.error(self.request, _("We could not save your changes. See below for details."))
+        return super().form_invalid(form)
 
 def group_email_entries(emails):
     """Collapse rows that share a compose batch into one entry per message."""

--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -1,7 +1,6 @@
 import io
 import json
 
-# pyrefly: ignore [missing-import]
 from defusedcsv import csv
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin

--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -1,6 +1,7 @@
 import io
 import json
 
+# pyrefly: ignore [missing-import]
 from defusedcsv import csv
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
@@ -416,6 +417,8 @@ class SettingsView(EventPermissionRequiredMixin, ListView):
                 messages.success(self.request, _("Sponsor group added."))
                 return redirect(self.get_settings_url("sponsors"))
 
+            messages.error(self.request, _("We could not save your changes. See below for details."))
+            self.object_list = self.get_queryset()
             return self.render_to_response(
                 self.get_context_data(
                     add_group_form=form,
@@ -437,6 +440,8 @@ class SettingsView(EventPermissionRequiredMixin, ListView):
                 messages.success(self.request, _("Sponsor group updated."))
                 return redirect(self.get_settings_url("sponsors"))
 
+            messages.error(self.request, _("We could not save your changes. See below for details."))
+            self.object_list = self.get_queryset()
             return self.render_to_response(
                 self.get_context_data(
                     edit_group_forms={group.pk: form},
@@ -1664,6 +1669,10 @@ class ExhibitionQuestionCreateView(EventPermissionRequiredMixin, CreateView):
         )
         return response
 
+    def form_invalid(self, form):
+        messages.error(self.request, _("We could not save your changes. See below for details."))
+        return super().form_invalid(form)
+
     def get_success_url(self):
         return reverse(
             "plugins:exhibition:call.questions",
@@ -2221,6 +2230,7 @@ class EmailComposeView(EventPermissionRequiredMixin, FormView):
         messages.error(self.request, _("We could not save your changes. See below for details."))
         return super().form_invalid(form)
 
+
 def group_email_entries(emails):
     """Collapse rows that share a compose batch into one entry per message."""
     entries = []
@@ -2675,6 +2685,10 @@ class CustomEmailTemplateCreateView(EventPermissionRequiredMixin, CreateView):
         form.instance.event = self.request.event
         messages.success(self.request, _("Custom template has been created."))
         return super().form_valid(form)
+
+    def form_invalid(self, form):
+        messages.error(self.request, _("We could not save your changes. See below for details."))
+        return super().form_invalid(form)
 
     def get_success_url(self):
         return reverse("plugins:exhibition:email.templates", kwargs=event_kwargs(self.request.event))


### PR DESCRIPTION
Closes #188. 

Adds `messages.error` calls to `form_invalid` methods in exhibition views (Exhibitor, Proposal, and Email compose forms) to display the standard error banner when a required field is missed. This ensures UI consistency with the rest of the eventyay platform.

## Summary by Sourcery

Bug Fixes:
- Display the standard error banner when exhibition forms fail validation, including exhibitor, proposal, email composition, and template forms.

https://github.com/user-attachments/assets/5ec43023-44b6-43cb-99a6-706a7ee3d435