### PR TITLE
fix: make sent email subjects clickable and viewable

### DIFF
--- a/exhibition/templates/exhibitors/_email_sent_body.html
+++ b/exhibition/templates/exhibitors/_email_sent_body.html
@@ -25,7 +25,11 @@
                         <span class="label label-default">{{ entry.recipients|length }}</span>
                     {% endif %}
                 </td>
-                <td>{{ entry.subject }}</td>
+                <td>
+                    <a href="{% url 'plugins:exhibition:email.edit' organizer=request.event.organizer.slug event=request.event.slug pk=entry.pk %}">
+                        {{ entry.subject }}
+                    </a>
+                </td>
                 <td class="email-created">{{ entry.sent_at }}</td>
             </tr>
         {% empty %}

--- a/exhibition/templates/exhibitors/email_edit.html
+++ b/exhibition/templates/exhibitors/email_edit.html
@@ -5,42 +5,58 @@
 {% block title %}{{ request.event.name }} - {% trans "Edit email" %}{% endblock %}
 
 {% block exhibitors_header %}
-    <h1>{% trans "Preview / edit email" %}</h1>
+    <h1>
+        {% if can_edit %}
+            {% trans "Preview / edit email" %}
+        {% else %}
+            {% trans "Preview email" %}
+        {% endif %}
+    </h1>
 {% endblock %}
 
 {% block exhibitors_content %}
     <p>
-        <a class="btn btn-default" href="{% url 'plugins:exhibition:email.outbox' organizer=request.event.organizer.slug event=request.event.slug %}">
-            <i class="fa fa-arrow-left"></i> {% trans "Back to outbox" %}
-        </a>
+        {% if can_edit %}
+            <a class="btn btn-default" href="{% url 'plugins:exhibition:email.outbox' organizer=request.event.organizer.slug event=request.event.slug %}">
+                <i class="fa fa-arrow-left"></i> {% trans "Back to outbox" %}
+            </a>
+        {% else %}
+            <a class="btn btn-default" href="{% url 'plugins:exhibition:email.sent' organizer=request.event.organizer.slug event=request.event.slug %}">
+                <i class="fa fa-arrow-left"></i> {% trans "Back to sent emails" %}
+            </a>
+        {% endif %}
     </p>
 
     <form action="" method="post" class="form-horizontal">
         {% csrf_token %}
-        {% bootstrap_form_errors form %}
-        {% if email.batch %}
-            <div class="form-group">
-                <label class="col-md-3 control-label">{% trans "Recipients" %} ({{ recipients|length }})</label>
-                <div class="col-md-9">
-                    <p class="form-control-static">{{ recipients|join:", " }}</p>
+        <fieldset {% if not can_edit %}disabled{% endif %}>
+            {% bootstrap_form_errors form %}
+            {% if email.batch %}
+                <div class="form-group">
+                    <label class="col-md-3 control-label">{% trans "Recipients" %} ({{ recipients|length }})</label>
+                    <div class="col-md-9">
+                        <p class="form-control-static">{{ recipients|join:", " }}</p>
+                    </div>
+                </div>
+                <input type="hidden" name="to_email" value="{{ email.to_email }}">
+            {% else %}
+                {% bootstrap_field form.to_email layout="control" %}
+            {% endif %}
+            {% bootstrap_field form.subject layout="control" %}
+            {% bootstrap_field form.body layout="control" %}
+            {% bootstrap_field form.scheduled_at layout="control" %}
+        </fieldset>
+        {% if can_edit %}
+            <div class="form-group submit-group">
+                <div class="col-md-9 col-md-offset-3">
+                    <button type="submit" class="btn btn-default" name="_save" value="save">
+                        {% trans "Save changes" %}
+                    </button>
+                    <button type="submit" class="btn btn-primary" name="_send" value="send">
+                        <i class="fa fa-paper-plane"></i> {% trans "Save & send" %}
+                    </button>
                 </div>
             </div>
-            <input type="hidden" name="to_email" value="{{ email.to_email }}">
-        {% else %}
-            {% bootstrap_field form.to_email layout="control" %}
         {% endif %}
-        {% bootstrap_field form.subject layout="control" %}
-        {% bootstrap_field form.body layout="control" %}
-        {% bootstrap_field form.scheduled_at layout="control" %}
-        <div class="form-group submit-group">
-            <div class="col-md-9 col-md-offset-3">
-                <button type="submit" class="btn btn-default" name="_save" value="save">
-                    {% trans "Save changes" %}
-                </button>
-                <button type="submit" class="btn btn-primary" name="_send" value="send">
-                    <i class="fa fa-paper-plane"></i> {% trans "Save & send" %}
-                </button>
-            </div>
-        </div>
     </form>
 {% endblock %}

--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -2339,7 +2339,7 @@ class EmailEditView(EventPermissionRequiredMixin, UpdateView):
     context_object_name = "email"
 
     def get_queryset(self):
-        return ExhibitionEmailQueue.objects.filter(event=self.request.event, sent_at__isnull=True)
+        return ExhibitionEmailQueue.objects.filter(event=self.request.event)
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
@@ -2347,17 +2347,22 @@ class EmailEditView(EventPermissionRequiredMixin, UpdateView):
         return kwargs
 
     def batch_queryset(self):
-        return ExhibitionEmailQueue.objects.filter(
-            event=self.request.event, batch=self.object.batch, sent_at__isnull=True
-        )
+        return ExhibitionEmailQueue.objects.filter(event=self.request.event, batch=self.object.batch)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        context["can_edit"] = self.object.sent_at is None
         if self.object.batch:
             context["recipients"] = list(self.batch_queryset().values_list("to_email", flat=True))
         else:
             context["recipients"] = [self.object.to_email]
         return context
+
+    def post(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        if self.object.sent_at is not None:
+            raise PermissionDenied("Cannot edit an email that has already been sent.")
+        return super().post(request, *args, **kwargs)
 
     def reschedule(self, rows, scheduled_at):
         from .tasks import send_scheduled_email


### PR DESCRIPTION
Fixes #193

**Summary**
This PR updates the Sent emails view so that the subject of each email is clickable, taking the user to a detailed preview page. The preview page reuses the `EmailEditView` but intelligently renders all inputs as read-only and removes the save/send actions for already sent emails.

**Root Cause**
Previously, the `_email_sent_body.html` template rendered the subject as plain text, preventing organizers from viewing the full content of past emails. Furthermore, the existing `EmailEditView` strictly filtered out sent emails (returning 404) and lacked logic for read-only rendering, making it impossible to reuse directly.

**Changes Made**
- In `exhibition/views.py`, updated `EmailEditView`'s `get_queryset` and `batch_queryset` to allow retrieval of sent emails.
- In `exhibition/views.py`, injected `can_edit` into the context of `EmailEditView` and overrode the `post` method to raise `PermissionDenied` for sent emails.
- In `_email_sent_body.html`, wrapped the subject field in a link routing to `plugins:exhibition:email.edit`.
- In `email_edit.html`, added conditional logic using `can_edit` to wrap the form in a disabled fieldset, hide submit buttons, and appropriately update the header and "back" link for sent emails.

## Summary by Sourcery

Enable organizers to open sent emails from the sent list and view their contents without editing or resending them.

New Features:
- Make subjects in the sent emails list link to a detailed email preview.

Bug Fixes:
- Allow sent emails to be viewed through the existing email page while preventing modifications to them.

Enhancements:
- Reuse the email editing view for read-only sent email previews with appropriate navigation and controls.