### PR TITLE
fix: make sent email subjects clickable and viewable

### DIFF
--- a/exhibition/templates/exhibitors/_email_sent_body.html
+++ b/exhibition/templates/exhibitors/_email_sent_body.html
@@ -9,36 +9,37 @@
 <div class="table-responsive">
     <table class="table table-hover">
         <thead>
-        <tr>
-            <th>{% include "exhibitors/_sort_header.html" with ajax=True field="to_email" label=label_recipient %}</th>
-            <th>{% include "exhibitors/_sort_header.html" with ajax=True field="subject" label=label_subject %}</th>
-            <th>{% include "exhibitors/_sort_header.html" with ajax=True field="sent_at" label=label_sent %}</th>
-        </tr>
+            <tr>
+                <th>{% include "exhibitors/_sort_header.html" with ajax=True field="to_email" label=label_recipient %}
+                </th>
+                <th>{% include "exhibitors/_sort_header.html" with ajax=True field="subject" label=label_subject %}</th>
+                <th>{% include "exhibitors/_sort_header.html" with ajax=True field="sent_at" label=label_sent %}</th>
+            </tr>
         </thead>
         <tbody>
-        {% for entry in entries %}
+            {% for entry in entries %}
             <tr>
                 <td>
-                    <span class="email-recipients" title="{{ entry.recipients|join:', ' }}"
-                          data-toggle="tooltip">{{ entry.recipients|join:", " }}</span>
+                    <span class="email-recipients" title="{{ entry.recipients|join:', ' }}" data-toggle="tooltip">{{
+                        entry.recipients|join:", " }}</span>
                     {% if entry.is_batch %}
-                        <span class="label label-default">{{ entry.recipients|length }}</span>
+                    <span class="label label-default">{{ entry.recipients|length }}</span>
                     {% endif %}
                 </td>
                 <td>{{ entry.subject }}</td>
                 <td class="email-created">{{ entry.sent_at }}</td>
             </tr>
-        {% empty %}
+            {% empty %}
             <tr>
                 <td colspan="3">
                     {% if filter_form.filtered %}
-                        {% trans "No emails match your search." %}
+                    {% trans "No emails match your search." %}
                     {% else %}
-                        {% trans "No emails have been sent yet." %}
+                    {% trans "No emails have been sent yet." %}
                     {% endif %}
                 </td>
             </tr>
-        {% endfor %}
+            {% endfor %}
         </tbody>
     </table>
 </div>

--- a/exhibition/templates/exhibitors/_email_sent_body.html
+++ b/exhibition/templates/exhibitors/_email_sent_body.html
@@ -9,21 +9,20 @@
 <div class="table-responsive">
     <table class="table table-hover">
         <thead>
-            <tr>
-                <th>{% include "exhibitors/_sort_header.html" with ajax=True field="to_email" label=label_recipient %}
-                </th>
-                <th>{% include "exhibitors/_sort_header.html" with ajax=True field="subject" label=label_subject %}</th>
-                <th>{% include "exhibitors/_sort_header.html" with ajax=True field="sent_at" label=label_sent %}</th>
-            </tr>
+        <tr>
+            <th>{% include "exhibitors/_sort_header.html" with ajax=True field="to_email" label=label_recipient %}</th>
+            <th>{% include "exhibitors/_sort_header.html" with ajax=True field="subject" label=label_subject %}</th>
+            <th>{% include "exhibitors/_sort_header.html" with ajax=True field="sent_at" label=label_sent %}</th>
+        </tr>
         </thead>
         <tbody>
-            {% for entry in entries %}
+        {% for entry in entries %}
             <tr>
                 <td>
-                    <span class="email-recipients" title="{{ entry.recipients|join:', ' }}" data-toggle="tooltip">{{
-                        entry.recipients|join:", " }}</span>
+                    <span class="email-recipients" title="{{ entry.recipients|join:', ' }}"
+                          data-toggle="tooltip">{{ entry.recipients|join:", " }}</span>
                     {% if entry.is_batch %}
-                    <span class="label label-default">{{ entry.recipients|length }}</span>
+                        <span class="label label-default">{{ entry.recipients|length }}</span>
                     {% endif %}
                 </td>
                 <td>
@@ -33,17 +32,17 @@
                 </td>
                 <td class="email-created">{{ entry.sent_at }}</td>
             </tr>
-            {% empty %}
+        {% empty %}
             <tr>
                 <td colspan="3">
                     {% if filter_form.filtered %}
-                    {% trans "No emails match your search." %}
+                        {% trans "No emails match your search." %}
                     {% else %}
-                    {% trans "No emails have been sent yet." %}
+                        {% trans "No emails have been sent yet." %}
                     {% endif %}
                 </td>
             </tr>
-            {% endfor %}
+        {% endfor %}
         </tbody>
     </table>
 </div>

--- a/exhibition/templates/exhibitors/_email_sent_body.html
+++ b/exhibition/templates/exhibitors/_email_sent_body.html
@@ -26,7 +26,11 @@
                     <span class="label label-default">{{ entry.recipients|length }}</span>
                     {% endif %}
                 </td>
-                <td>{{ entry.subject }}</td>
+                <td>
+                    <a href="{% url 'plugins:exhibition:email.edit' organizer=request.event.organizer.slug event=request.event.slug pk=entry.pk %}">
+                        {{ entry.subject }}
+                    </a>
+                </td>
                 <td class="email-created">{{ entry.sent_at }}</td>
             </tr>
             {% empty %}

--- a/exhibition/templates/exhibitors/email_edit.html
+++ b/exhibition/templates/exhibitors/email_edit.html
@@ -5,42 +5,58 @@
 {% block title %}{{ request.event.name }} - {% trans "Edit email" %}{% endblock %}
 
 {% block exhibitors_header %}
-    <h1>{% trans "Preview / edit email" %}</h1>
+    <h1>
+        {% if can_edit %}
+            {% trans "Preview / edit email" %}
+        {% else %}
+            {% trans "Preview email" %}
+        {% endif %}
+    </h1>
 {% endblock %}
 
 {% block exhibitors_content %}
     <p>
-        <a class="btn btn-default" href="{% url 'plugins:exhibition:email.outbox' organizer=request.event.organizer.slug event=request.event.slug %}">
-            <i class="fa fa-arrow-left"></i> {% trans "Back to outbox" %}
-        </a>
+        {% if can_edit %}
+            <a class="btn btn-default" href="{% url 'plugins:exhibition:email.outbox' organizer=request.event.organizer.slug event=request.event.slug %}">
+                <i class="fa fa-arrow-left"></i> {% trans "Back to outbox" %}
+            </a>
+        {% else %}
+            <a class="btn btn-default" href="{% url 'plugins:exhibition:email.sent' organizer=request.event.organizer.slug event=request.event.slug %}">
+                <i class="fa fa-arrow-left"></i> {% trans "Back to sent emails" %}
+            </a>
+        {% endif %}
     </p>
 
     <form action="" method="post" class="form-horizontal">
         {% csrf_token %}
-        {% bootstrap_form_errors form %}
-        {% if email.batch %}
-            <div class="form-group">
-                <label class="col-md-3 control-label">{% trans "Recipients" %} ({{ recipients|length }})</label>
-                <div class="col-md-9">
-                    <p class="form-control-static">{{ recipients|join:", " }}</p>
+        <fieldset {% if not can_edit %}disabled{% endif %}>
+            {% bootstrap_form_errors form %}
+            {% if email.batch %}
+                <div class="form-group">
+                    <label class="col-md-3 control-label">{% trans "Recipients" %} ({{ recipients|length }})</label>
+                    <div class="col-md-9">
+                        <p class="form-control-static">{{ recipients|join:", " }}</p>
+                    </div>
+                </div>
+                <input type="hidden" name="to_email" value="{{ email.to_email }}">
+            {% else %}
+                {% bootstrap_field form.to_email layout="control" %}
+            {% endif %}
+            {% bootstrap_field form.subject layout="control" %}
+            {% bootstrap_field form.body layout="control" %}
+            {% bootstrap_field form.scheduled_at layout="control" %}
+        </fieldset>
+        {% if can_edit %}
+            <div class="form-group submit-group">
+                <div class="col-md-9 col-md-offset-3">
+                    <button type="submit" class="btn btn-default" name="_save" value="save">
+                        {% trans "Save changes" %}
+                    </button>
+                    <button type="submit" class="btn btn-primary" name="_send" value="send">
+                        <i class="fa fa-paper-plane"></i> {% trans "Save & send" %}
+                    </button>
                 </div>
             </div>
-            <input type="hidden" name="to_email" value="{{ email.to_email }}">
-        {% else %}
-            {% bootstrap_field form.to_email layout="control" %}
         {% endif %}
-        {% bootstrap_field form.subject layout="control" %}
-        {% bootstrap_field form.body layout="control" %}
-        {% bootstrap_field form.scheduled_at layout="control" %}
-        <div class="form-group submit-group">
-            <div class="col-md-9 col-md-offset-3">
-                <button type="submit" class="btn btn-default" name="_save" value="save">
-                    {% trans "Save changes" %}
-                </button>
-                <button type="submit" class="btn btn-primary" name="_send" value="send">
-                    <i class="fa fa-paper-plane"></i> {% trans "Save & send" %}
-                </button>
-            </div>
-        </div>
     </form>
 {% endblock %}

--- a/exhibition/templates/exhibitors/email_edit.html
+++ b/exhibition/templates/exhibitors/email_edit.html
@@ -29,8 +29,33 @@
 
     <form action="" method="post" class="form-horizontal">
         {% csrf_token %}
-        <fieldset {% if not can_edit %}disabled{% endif %}>
-            {% bootstrap_form_errors form %}
+        {% bootstrap_form_errors form %}
+        {% if not can_edit %}
+            <div class="form-group">
+                <label class="col-md-3 control-label">{% trans "Recipients" %} ({{ recipients|length }})</label>
+                <div class="col-md-9">
+                    <p class="form-control-static">{{ recipients|join:", " }}</p>
+                </div>
+            </div>
+            <div class="form-group">
+                <label class="col-md-3 control-label">{% trans "Subject" %}</label>
+                <div class="col-md-9">
+                    <p class="form-control-static">{{ email.subject }}</p>
+                </div>
+            </div>
+            <div class="form-group">
+                <label class="col-md-3 control-label">{% trans "Message" %}</label>
+                <div class="col-md-9">
+                    <p class="form-control-static" style="white-space: pre-wrap;">{{ email.body }}</p>
+                </div>
+            </div>
+            <div class="form-group">
+                <label class="col-md-3 control-label">{% trans "Sent at" %}</label>
+                <div class="col-md-9">
+                    <p class="form-control-static">{{ email.sent_at }}</p>
+                </div>
+            </div>
+        {% else %}
             {% if email.batch %}
                 <div class="form-group">
                     <label class="col-md-3 control-label">{% trans "Recipients" %} ({{ recipients|length }})</label>
@@ -45,8 +70,6 @@
             {% bootstrap_field form.subject layout="control" %}
             {% bootstrap_field form.body layout="control" %}
             {% bootstrap_field form.scheduled_at layout="control" %}
-        </fieldset>
-        {% if can_edit %}
             <div class="form-group submit-group">
                 <div class="col-md-9 col-md-offset-3">
                     <button type="submit" class="btn btn-default" name="_save" value="save">

--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -2367,6 +2367,7 @@ class EmailEditView(EventPermissionRequiredMixin, UpdateView):
 
     @transaction.atomic
     def post(self, request, *args, **kwargs):
+        # Lock the email row and its batch siblings to ensure atomic updates and prevent race conditions
         self._locked_object = self.get_queryset().select_for_update().get(pk=self.kwargs.get(self.pk_url_kwarg))
         if self._locked_object.sent_at is not None:
             raise PermissionDenied("Cannot edit an email that has already been sent.")

--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -2360,11 +2360,18 @@ class EmailEditView(EventPermissionRequiredMixin, UpdateView):
             context["recipients"] = [self.object.to_email]
         return context
 
+    def get_object(self, queryset=None):
+        if getattr(self, "_locked_object", None) is not None:
+            return self._locked_object
+        return super().get_object(queryset)
+
     @transaction.atomic
     def post(self, request, *args, **kwargs):
-        self.object = self.get_queryset().select_for_update().get(pk=self.kwargs.get(self.pk_url_kwarg))
-        if self.object.sent_at is not None:
+        self._locked_object = self.get_queryset().select_for_update().get(pk=self.kwargs.get(self.pk_url_kwarg))
+        if self._locked_object.sent_at is not None:
             raise PermissionDenied("Cannot edit an email that has already been sent.")
+        if self._locked_object.batch:
+            list(self.batch_queryset().select_for_update())
         return super().post(request, *args, **kwargs)
 
     def reschedule(self, rows, scheduled_at):

--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -2368,7 +2368,9 @@ class EmailEditView(EventPermissionRequiredMixin, UpdateView):
     @transaction.atomic
     def post(self, request, *args, **kwargs):
         # Lock the email row and its batch siblings to ensure atomic updates and prevent race conditions
-        self._locked_object = self.get_queryset().select_for_update().get(pk=self.kwargs.get(self.pk_url_kwarg))
+        self._locked_object = get_object_or_404(
+            self.get_queryset().select_for_update(), pk=self.kwargs.get(self.pk_url_kwarg)
+        )
         if self._locked_object.sent_at is not None:
             raise PermissionDenied("Cannot edit an email that has already been sent.")
         if self._locked_object.batch:

--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -2339,7 +2339,7 @@ class EmailEditView(EventPermissionRequiredMixin, UpdateView):
     context_object_name = "email"
 
     def get_queryset(self):
-        return ExhibitionEmailQueue.objects.filter(event=self.request.event, sent_at__isnull=True)
+        return ExhibitionEmailQueue.objects.filter(event=self.request.event)
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
@@ -2348,16 +2348,24 @@ class EmailEditView(EventPermissionRequiredMixin, UpdateView):
 
     def batch_queryset(self):
         return ExhibitionEmailQueue.objects.filter(
-            event=self.request.event, batch=self.object.batch, sent_at__isnull=True
+            event=self.request.event, batch=self.object.batch, sent_at__isnull=self.object.sent_at is None
         )
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        context["can_edit"] = self.object.sent_at is None
         if self.object.batch:
             context["recipients"] = list(self.batch_queryset().values_list("to_email", flat=True))
         else:
             context["recipients"] = [self.object.to_email]
         return context
+
+    @transaction.atomic
+    def post(self, request, *args, **kwargs):
+        self.object = self.get_queryset().select_for_update().get(pk=self.kwargs.get(self.pk_url_kwarg))
+        if self.object.sent_at is not None:
+            raise PermissionDenied("Cannot edit an email that has already been sent.")
+        return super().post(request, *args, **kwargs)
 
     def reschedule(self, rows, scheduled_at):
         from .tasks import send_scheduled_email


### PR DESCRIPTION
Fixes #193

**Summary**
This PR updates the Sent emails view so that the subject of each email is clickable, taking the user to a detailed preview page. The preview page reuses the `EmailEditView` but intelligently renders all inputs as read-only and removes the save/send actions for already sent emails.

**Root Cause**
Previously, the `_email_sent_body.html` template rendered the subject as plain text, preventing organizers from viewing the full content of past emails. Furthermore, the existing `EmailEditView` strictly filtered out sent emails (returning 404) and lacked logic for read-only rendering, making it impossible to reuse directly.

**Changes Made**
- In `exhibition/views.py`, updated `EmailEditView`'s `get_queryset` and `batch_queryset` to allow retrieval of sent emails, correctly filtering batches by sent state to prevent accidental update of sent emails.
- In `exhibition/views.py`, injected `can_edit` into the context of `EmailEditView` and overrode the `post` method using `transaction.atomic` and `select_for_update()` to prevent race conditions when editing emails.
- In `_email_sent_body.html`, wrapped the subject field in a link routing to `plugins:exhibition:email.edit`.
- In `email_edit.html`, added conditional logic using `can_edit` to wrap the form in a disabled fieldset, hide submit buttons, and appropriately update the header and "back" link for sent emails.

## Summary by Sourcery

Enable organizers to open sent emails from the sent-mail list and safely view their full contents without permitting changes.

New Features:
- Make sent email subjects link to a detailed preview of the email contents.

Bug Fixes:
- Prevent sent emails from being edited or modified while allowing them to be viewed.

Enhancements:
- Reuse the email editing view for read-only previews of sent emails and provide appropriate navigation and display states.
- Ensure email edits and batched email updates are handled atomically to avoid race conditions.