### PR TITLE
Remove obsolete exhibitor login settings

### DIFF
--- a/exhibition/templates/exhibitors/settings.html
+++ b/exhibition/templates/exhibitors/settings.html
@@ -175,16 +175,6 @@
                     </div>
                 </fieldset>
 
-                <fieldset>
-                    <legend>{% trans "Exhibitor login" %}</legend>
-                    <p>
-                        {% trans "The access-code email sent to exhibitors is now edited together with the plugin's other email templates." %}
-                        <a href="{% url 'plugins:exhibition:email.templates' organizer=request.event.organizer.slug event=request.event.slug %}">
-                            {% trans "Edit email templates" %}
-                        </a>
-                    </p>
-                </fieldset>
-
                 <div class="form-group submit-group">
                     <div class="col-md-9 col-md-offset-3">
                         <button type="submit" class="btn btn-primary btn-save">


### PR DESCRIPTION
PR description

Removes the obsolete “Exhibitor login” section from the exhibition settings page, as the login template is now managed through the Message Centre.

Related issue: #158 — Task 2 only.
<img width="1912" height="469" alt="Screenshot 2026-09-01 193732" src="https://github.com/user-attachments/assets/13649ba6-0a2c-4c0b-a07c-86451386d278" />

## Summary by Sourcery

Enhancements:
- Remove the obsolete Exhibitor login section from the exhibition settings page now that login email templates are managed in the Message Centre.