### PR TITLE
fix(exhibition): make sent email subject clickable to preview (#193)

### DIFF
--- a/exhibition/templates/exhibitors/_email_sent_body.html
+++ b/exhibition/templates/exhibitors/_email_sent_body.html
@@ -25,7 +25,11 @@
                         <span class="label label-default">{{ entry.recipients|length }}</span>
                     {% endif %}
                 </td>
-                <td>{{ entry.subject }}</td>
+                <td>
+                    <a href="{% url 'plugins:exhibition:email.preview' organizer=request.event.organizer.slug event=request.event.slug pk=entry.pk %}">
+                        {{ entry.subject }}
+                    </a>
+                </td>
                 <td class="email-created">{{ entry.sent_at }}</td>
             </tr>
         {% empty %}

--- a/exhibition/templates/exhibitors/email_preview.html
+++ b/exhibition/templates/exhibitors/email_preview.html
@@ -1,0 +1,48 @@
+{% extends "exhibitors/base.html" %}
+{% load i18n %}
+{% load bootstrap3 %}
+{% load rich_text %}
+
+{% block title %}{{ request.event.name }} - {% trans "Preview email" %}{% endblock %}
+
+{% block exhibitors_header %}
+    <h1>{% trans "Preview email" %}</h1>
+{% endblock %}
+
+{% block exhibitors_content %}
+    <p>
+        <a class="btn btn-default" href="{% url 'plugins:exhibition:email.sent' organizer=request.event.organizer.slug event=request.event.slug %}">
+            <i class="fa fa-arrow-left"></i> {% trans "Back to sent emails" %}
+        </a>
+    </p>
+
+    <div class="form-horizontal">
+        {% if email.batch %}
+            <div class="form-group">
+                <label class="col-md-3 control-label">{% trans "Recipients" %} ({{ recipients|length }})</label>
+                <div class="col-md-9">
+                    <p class="form-control-static">{{ recipients|join:", " }}</p>
+                </div>
+            </div>
+        {% else %}
+            <div class="form-group">
+                <label class="col-md-3 control-label">{% trans "Recipient" %}</label>
+                <div class="col-md-9">
+                    <p class="form-control-static">{{ email.to_email }}</p>
+                </div>
+            </div>
+        {% endif %}
+        <div class="form-group">
+            <label class="col-md-3 control-label">{% trans "Subject" %}</label>
+            <div class="col-md-9">
+                <p class="form-control-static">{{ email.subject }}</p>
+            </div>
+        </div>
+        <div class="form-group">
+            <label class="col-md-3 control-label">{% trans "Message" %}</label>
+            <div class="col-md-9">
+                <div class="form-control-static" style="background-color: #f9f9f9; padding: 10px; border: 1px solid #ccc; border-radius: 4px;">{{ email.body|rich_text }}</div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/exhibition/urls.py
+++ b/exhibition/urls.py
@@ -21,6 +21,7 @@ from .views import (
     EmailDeleteView,
     EmailEditView,
     EmailOutboxListView,
+    EmailPreviewView,
     EmailSendView,
     EmailSentListView,
     EmailTemplatePreviewView,
@@ -303,6 +304,11 @@ urlpatterns = [
         "exhibitors/event/<orgslug:organizer>/<slug:event>/emails/custom-templates/<int:pk>/delete",
         CustomEmailTemplateDeleteView.as_view(),
         name="email.custom_templates.delete",
+    ),
+    path(
+        "exhibitors/event/<orgslug:organizer>/<slug:event>/emails/<int:pk>/preview",
+        EmailPreviewView.as_view(),
+        name="email.preview",
     ),
     path(
         "exhibitors/event/<orgslug:organizer>/<slug:event>/emails/<int:pk>/edit",

--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -2571,6 +2571,31 @@ class EmailEditView(EventPermissionRequiredMixin, UpdateView):
         return reverse("plugins:exhibition:email.outbox", kwargs=event_kwargs(self.request.event))
 
 
+class EmailPreviewView(EventPermissionRequiredMixin, DetailView):
+    """Preview a queued (sent) email."""
+
+    model = ExhibitionEmailQueue
+    permission = EMAIL_MANAGE_PERMISSION
+    template_name = "exhibitors/email_preview.html"
+    context_object_name = "email"
+
+    def get_queryset(self):
+        return ExhibitionEmailQueue.objects.filter(event=self.request.event, sent_at__isnull=False)
+
+    def batch_queryset(self):
+        return ExhibitionEmailQueue.objects.filter(
+            event=self.request.event, batch=self.object.batch, sent_at__isnull=False
+        )
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        if self.object.batch:
+            context["recipients"] = list(self.batch_queryset().values_list("to_email", flat=True))
+        else:
+            context["recipients"] = [self.object.to_email]
+        return context
+
+
 class EmailSendView(EventPermissionRequiredMixin, View):
     """Send a queued email (or the whole batch it belongs to)."""
 


### PR DESCRIPTION
Fixes #193

**Changes:**
- Makes the email Subject in Sent emails clickable.
- Clicking the subject opens a 'Preview' view showing the details of the sent email in a readable format.

**Note:**
While working on this PR, I noticed that the email option was missing from the exhibitor detail form (\forms.py\ and \models.py\). I will raise this issue as a separate bug and submit a separate PR to fix it.

Screenshots:

Sent email list page:
<img width="1279" height="542" alt="Screenshot 2026-09-05 165622" src="https://github.com/user-attachments/assets/a5815f32-0140-490e-88fb-ab5d3883fe88" />

Preview email page:
<img width="1277" height="602" alt="Screenshot 2026-09-05 165536" src="https://github.com/user-attachments/assets/27eda442-f496-4641-afaa-5c29bef20d98" />
