### PR TITLE
fix(exhibition): keep list selections across pagination

### DIFF
--- a/exhibition/static/exhibition/js/message-center.js
+++ b/exhibition/static/exhibition/js/message-center.js
@@ -18,9 +18,20 @@
 
     function selectionStore() {
         if (!store) {
-            store = window.ExhibitionSelection.create();
+            store = window.ExhibitionSelection.create({ scope: selectionTable() });
         }
         return store;
+    }
+
+    /*
+     * Every carried row is its own POST field, and Django rejects a request with
+     * more than DATA_UPLOAD_MAX_NUMBER_FIELDS of them, so the server renders how
+     * many a bulk op can take.
+     */
+    function selectionLimit() {
+        var warning = document.querySelector("[data-email-selection-limit]");
+        var limit = warning ? parseInt(warning.dataset.emailSelectionLimit, 10) : NaN;
+        return isNaN(limit) ? Infinity : limit;
     }
 
     /*
@@ -32,11 +43,8 @@
         if (!table) {
             return;
         }
-        var boxes = rowBoxes(table);
-        if (!boxes.length) {
-            return;
-        }
         var selection = selectionStore();
+        var boxes = rowBoxes(table);
         boxes.forEach(function (box) {
             box.checked = selection.has(box.value);
         });
@@ -45,14 +53,27 @@
             var onPage = boxes.filter(function (box) {
                 return box.checked;
             }).length;
-            all.checked = onPage === boxes.length;
+            all.checked = boxes.length > 0 && onPage === boxes.length;
             all.indeterminate = onPage > 0 && onPage < boxes.length;
         }
+        var total = selection.size();
         var label = document.querySelector("[data-email-selected-count]");
         if (label) {
-            var total = selection.size();
             label.textContent = total ? total + " " + (label.dataset.selectedLabel || "selected") : "";
         }
+        var warning = document.querySelector("[data-email-selection-limit]");
+        if (warning) {
+            warning.hidden = total <= selectionLimit();
+        }
+    }
+
+    // Hidden inputs a previous submit carried into the form. They outlive a
+    // blocked submit or a back/forward-cache restore, so they are always
+    // cleared before the next submit adds the current selection.
+    function dropCarried(root) {
+        Array.prototype.slice.call(root.querySelectorAll("[data-selection-carried]")).forEach(function (input) {
+            input.remove();
+        });
     }
 
     /*
@@ -115,13 +136,21 @@
             load(window.location.pathname + "?" + params, true);
             return;
         }
+        dropCarried(form);
         var submitter = event.submitter;
-        if (!submitter || submitter.name !== "op") {
+        // "Send all" and "Discard all" ignore the selection; only the
+        // selected-rows ops need it.
+        if (!submitter || submitter.name !== "op" || (submitter.value !== "send" && submitter.value !== "discard")) {
+            return;
+        }
+        var selection = selectionStore();
+        if (selection.size() > selectionLimit()) {
+            event.preventDefault();
+            refreshSelection();
             return;
         }
         // Bulk ops act on the whole cross-page selection: rows picked on other
         // pages have no checkbox here, so send them as hidden fields.
-        var selection = selectionStore();
         var onPage = {};
         rowBoxes(form).forEach(function (box) {
             onPage[box.value] = true;
@@ -134,6 +163,7 @@
             hidden.type = "hidden";
             hidden.name = "selected";
             hidden.value = id;
+            hidden.setAttribute("data-selection-carried", "");
             form.appendChild(hidden);
         });
     }
@@ -173,6 +203,17 @@
         if (container()) {
             load(window.location.href, false);
         }
+    });
+    window.addEventListener("pageshow", function (event) {
+        var target = container();
+        if (!event.persisted || !target) {
+            return;
+        }
+        // Restored from the back/forward cache: drop what the last submit
+        // carried and re-read the selection, which may have changed since.
+        dropCarried(target);
+        store = null;
+        refreshSelection();
     });
 
     function onReady() {

--- a/exhibition/static/exhibition/js/message-center.js
+++ b/exhibition/static/exhibition/js/message-center.js
@@ -1,8 +1,58 @@
 (function () {
     "use strict";
 
+    var store = null;
+
     function container() {
         return document.getElementById("email-list");
+    }
+
+    function selectionTable() {
+        var target = container();
+        return target ? target.querySelector("table") : null;
+    }
+
+    function rowBoxes(table) {
+        return Array.prototype.slice.call(table.querySelectorAll("[data-select-row]"));
+    }
+
+    function selectionStore() {
+        if (!store) {
+            store = window.ExhibitionSelection.create();
+        }
+        return store;
+    }
+
+    /*
+     * Re-tick the rows the user picked on other pages and show the total across
+     * every page, not just the rows currently rendered.
+     */
+    function refreshSelection() {
+        var table = selectionTable();
+        if (!table) {
+            return;
+        }
+        var boxes = rowBoxes(table);
+        if (!boxes.length) {
+            return;
+        }
+        var selection = selectionStore();
+        boxes.forEach(function (box) {
+            box.checked = selection.has(box.value);
+        });
+        var all = table.querySelector("[data-select-all]");
+        if (all) {
+            var onPage = boxes.filter(function (box) {
+                return box.checked;
+            }).length;
+            all.checked = onPage === boxes.length;
+            all.indeterminate = onPage > 0 && onPage < boxes.length;
+        }
+        var label = document.querySelector("[data-email-selected-count]");
+        if (label) {
+            var total = selection.size();
+            label.textContent = total ? total + " " + (label.dataset.selectedLabel || "selected") : "";
+        }
     }
 
     function load(url, push) {
@@ -18,12 +68,16 @@
             .then(function (html) {
                 target.innerHTML = html;
                 target.classList.remove("email-list-loading");
-                target.dispatchEvent(
-                    new CustomEvent("eventyay:ajax-results-replaced", { bubbles: true, detail: { container: target } })
-                );
                 if (push) {
                     window.history.pushState({ emailList: true }, "", url);
                 }
+                // Rebuild the store against the URL we actually landed on, so a
+                // filter change drops the selection but paging keeps it.
+                store = null;
+                refreshSelection();
+                target.dispatchEvent(
+                    new CustomEvent("eventyay:ajax-results-replaced", { bubbles: true, detail: { container: target } })
+                );
             })
             .catch(function () {
                 target.classList.remove("email-list-loading");
@@ -33,12 +87,37 @@
 
     function onSubmit(event) {
         var form = event.target;
-        if (!form.matches || !form.matches("#email-list form[data-ajax]")) {
+        if (!form.matches || !form.matches("#email-list form")) {
             return;
         }
-        event.preventDefault();
-        var params = new URLSearchParams(new FormData(form)).toString();
-        load(window.location.pathname + "?" + params, true);
+        if (form.matches("[data-ajax]")) {
+            var params = new URLSearchParams(new FormData(form)).toString();
+            event.preventDefault();
+            load(window.location.pathname + "?" + params, true);
+            return;
+        }
+        var submitter = event.submitter;
+        if (!submitter || submitter.name !== "op") {
+            return;
+        }
+        // Bulk ops act on the whole cross-page selection: rows picked on other
+        // pages have no checkbox here, so send them as hidden fields.
+        var selection = selectionStore();
+        var onPage = {};
+        rowBoxes(form).forEach(function (box) {
+            onPage[box.value] = true;
+        });
+        selection.ids().forEach(function (id) {
+            if (onPage[id]) {
+                return;
+            }
+            var hidden = document.createElement("input");
+            hidden.type = "hidden";
+            hidden.name = "selected";
+            hidden.value = id;
+            form.appendChild(hidden);
+        });
+        selection.clear();
     }
 
     function onClick(event) {
@@ -52,20 +131,20 @@
 
     function onChange(event) {
         var element = event.target;
+        if (!element.matches) {
+            return;
+        }
         if (element.matches("[data-select-all]")) {
-            var rows = element.closest("table").querySelectorAll("[data-select-row]");
-            rows.forEach(function (row) {
-                row.checked = element.checked;
-            });
-        } else if (element.matches("[data-select-row]")) {
             var table = element.closest("table");
-            var all = table.querySelector("[data-select-all]");
-            if (all) {
-                var boxes = Array.prototype.slice.call(table.querySelectorAll("[data-select-row]"));
-                all.checked = boxes.length > 0 && boxes.every(function (box) {
-                    return box.checked;
-                });
-            }
+            var selection = selectionStore();
+            rowBoxes(table).forEach(function (row) {
+                row.checked = element.checked;
+                selection.toggle(row.value, element.checked);
+            });
+            refreshSelection();
+        } else if (element.matches("[data-select-row]")) {
+            selectionStore().toggle(element.value, element.checked);
+            refreshSelection();
         }
     }
 
@@ -77,4 +156,10 @@
             load(window.location.href, false);
         }
     });
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", refreshSelection);
+    } else {
+        refreshSelection();
+    }
 })();

--- a/exhibition/static/exhibition/js/message-center.js
+++ b/exhibition/static/exhibition/js/message-center.js
@@ -55,6 +55,25 @@
         }
     }
 
+    /*
+     * A bulk operation that actually sent or discarded rows redirects back with
+     * ?bulk=done: those rows are gone, so the selection goes with them. Doing it
+     * here rather than at submit time means a cancelled discard confirmation, a
+     * failed request, or an op that matched nothing leaves the selection intact
+     * for the user to retry.
+     */
+    function consumeBulkResult() {
+        var params = new URLSearchParams(window.location.search);
+        if (!params.has("bulk")) {
+            return;
+        }
+        selectionStore().clear();
+        params.delete("bulk");
+        var query = params.toString();
+        window.history.replaceState({}, "", window.location.pathname + (query ? "?" + query : ""));
+        store = null;
+    }
+
     function load(url, push) {
         var target = container();
         if (!target) {
@@ -117,7 +136,6 @@
             hidden.value = id;
             form.appendChild(hidden);
         });
-        selection.clear();
     }
 
     function onClick(event) {
@@ -157,9 +175,14 @@
         }
     });
 
-    if (document.readyState === "loading") {
-        document.addEventListener("DOMContentLoaded", refreshSelection);
-    } else {
+    function onReady() {
+        consumeBulkResult();
         refreshSelection();
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", onReady);
+    } else {
+        onReady();
     }
 })();

--- a/exhibition/static/exhibition/js/message-center.js
+++ b/exhibition/static/exhibition/js/message-center.js
@@ -23,21 +23,21 @@
         return store;
     }
 
-    /*
-     * Every carried row is its own POST field, and Django rejects a request with
-     * more than DATA_UPLOAD_MAX_NUMBER_FIELDS of them, so the server renders how
-     * many a bulk op can take.
-     */
     function selectionLimit() {
         var warning = document.querySelector("[data-email-selection-limit]");
         var limit = warning ? parseInt(warning.dataset.emailSelectionLimit, 10) : NaN;
         return isNaN(limit) ? Infinity : limit;
     }
 
-    /*
-     * Re-tick the rows the user picked on other pages and show the total across
-     * every page, not just the rows currently rendered.
-     */
+    function selectableIds(table) {
+        return (
+            selectionStore().available() ||
+            rowBoxes(table).map(function (box) {
+                return box.value;
+            })
+        );
+    }
+
     function refreshSelection() {
         var table = selectionTable();
         if (!table) {
@@ -48,15 +48,13 @@
         boxes.forEach(function (box) {
             box.checked = selection.has(box.value);
         });
+        var total = selection.size();
         var all = table.querySelector("[data-select-all]");
         if (all) {
-            var onPage = boxes.filter(function (box) {
-                return box.checked;
-            }).length;
-            all.checked = boxes.length > 0 && onPage === boxes.length;
-            all.indeterminate = onPage > 0 && onPage < boxes.length;
+            var selectable = selectableIds(table).length;
+            all.checked = selectable > 0 && total === selectable;
+            all.indeterminate = total > 0 && total < selectable;
         }
-        var total = selection.size();
         var label = document.querySelector("[data-email-selected-count]");
         if (label) {
             label.textContent = total ? total + " " + (label.dataset.selectedLabel || "selected") : "";
@@ -67,22 +65,12 @@
         }
     }
 
-    // Hidden inputs a previous submit carried into the form. They outlive a
-    // blocked submit or a back/forward-cache restore, so they are always
-    // cleared before the next submit adds the current selection.
     function dropCarried(root) {
         Array.prototype.slice.call(root.querySelectorAll("[data-selection-carried]")).forEach(function (input) {
             input.remove();
         });
     }
 
-    /*
-     * A bulk operation that actually sent or discarded rows redirects back with
-     * ?bulk=done: those rows are gone, so the selection goes with them. Doing it
-     * here rather than at submit time means a cancelled discard confirmation, a
-     * failed request, or an op that matched nothing leaves the selection intact
-     * for the user to retry.
-     */
     function consumeBulkResult() {
         var params = new URLSearchParams(window.location.search);
         if (!params.has("bulk")) {
@@ -111,8 +99,6 @@
                 if (push) {
                     window.history.pushState({ emailList: true }, "", url);
                 }
-                // Rebuild the store against the URL we actually landed on, so a
-                // filter change drops the selection but paging keeps it.
                 store = null;
                 refreshSelection();
                 target.dispatchEvent(
@@ -138,8 +124,6 @@
         }
         dropCarried(form);
         var submitter = event.submitter;
-        // "Send all" and "Discard all" ignore the selection; only the
-        // selected-rows ops need it.
         if (!submitter || submitter.name !== "op" || (submitter.value !== "send" && submitter.value !== "discard")) {
             return;
         }
@@ -149,8 +133,6 @@
             refreshSelection();
             return;
         }
-        // Bulk ops act on the whole cross-page selection: rows picked on other
-        // pages have no checkbox here, so send them as hidden fields.
         var onPage = {};
         rowBoxes(form).forEach(function (box) {
             onPage[box.value] = true;
@@ -183,12 +165,12 @@
             return;
         }
         if (element.matches("[data-select-all]")) {
-            var table = element.closest("table");
             var selection = selectionStore();
-            rowBoxes(table).forEach(function (row) {
-                row.checked = element.checked;
-                selection.toggle(row.value, element.checked);
-            });
+            if (element.checked) {
+                selection.addAll(selectableIds(element.closest("table")));
+            } else {
+                selection.clear();
+            }
             refreshSelection();
         } else if (element.matches("[data-select-row]")) {
             selectionStore().toggle(element.value, element.checked);
@@ -209,8 +191,6 @@
         if (!event.persisted || !target) {
             return;
         }
-        // Restored from the back/forward cache: drop what the last submit
-        // carried and re-read the selection, which may have changed since.
         dropCarried(target);
         store = null;
         refreshSelection();

--- a/exhibition/static/exhibition/js/partner-select.js
+++ b/exhibition/static/exhibition/js/partner-select.js
@@ -14,7 +14,7 @@
         var downloadLink = scope.querySelector('[data-partner-download-link]')
         var selectedLabel = scope.dataset.selectedLabel || 'selected'
         var baseHref = downloadLink ? downloadLink.getAttribute('href') : null
-        var store = window.ExhibitionSelection.create()
+        var store = window.ExhibitionSelection.create({ scope: scope })
 
         function checkboxes() {
             return Array.prototype.slice.call(scope.querySelectorAll('[data-partner-checkbox]'))

--- a/exhibition/static/exhibition/js/partner-select.js
+++ b/exhibition/static/exhibition/js/partner-select.js
@@ -14,34 +14,35 @@
         var downloadLink = scope.querySelector('[data-partner-download-link]')
         var selectedLabel = scope.dataset.selectedLabel || 'selected'
         var baseHref = downloadLink ? downloadLink.getAttribute('href') : null
+        var store = window.ExhibitionSelection.create()
 
         function checkboxes() {
             return Array.prototype.slice.call(scope.querySelectorAll('[data-partner-checkbox]'))
         }
 
-        function selectedValues() {
-            return checkboxes()
-                .filter(function (box) {
-                    return box.checked
-                })
-                .map(function (box) {
-                    return box.value
-                })
+        function restoreSelection() {
+            checkboxes().forEach(function (box) {
+                box.checked = store.has(box.value)
+            })
         }
 
         function refreshSelection() {
             var boxes = checkboxes()
-            var selected = selectedValues()
+            var onPage = boxes.filter(function (box) {
+                return box.checked
+            }).length
+            // The count covers every page, not just the rows currently rendered.
+            var total = store.size()
             if (countLabel) {
-                countLabel.textContent = selected.length ? selected.length + ' ' + selectedLabel : ''
+                countLabel.textContent = total ? total + ' ' + selectedLabel : ''
             }
             if (selectAll) {
-                selectAll.checked = boxes.length > 0 && selected.length === boxes.length
-                selectAll.indeterminate = selected.length > 0 && selected.length < boxes.length
+                selectAll.checked = boxes.length > 0 && onPage === boxes.length
+                selectAll.indeterminate = onPage > 0 && onPage < boxes.length
             }
             if (downloadLink) {
-                downloadLink.classList.toggle('disabled', selected.length === 0)
-                downloadLink.setAttribute('aria-disabled', selected.length === 0 ? 'true' : 'false')
+                downloadLink.classList.toggle('disabled', total === 0)
+                downloadLink.setAttribute('aria-disabled', total === 0 ? 'true' : 'false')
             }
         }
 
@@ -49,6 +50,7 @@
             selectAll.addEventListener('change', function () {
                 checkboxes().forEach(function (box) {
                     box.checked = selectAll.checked
+                    store.toggle(box.value, selectAll.checked)
                 })
                 refreshSelection()
             })
@@ -56,6 +58,7 @@
 
         scope.addEventListener('change', function (event) {
             if (event.target.hasAttribute('data-partner-checkbox')) {
+                store.toggle(event.target.value, event.target.checked)
                 refreshSelection()
             }
         })
@@ -63,7 +66,7 @@
         if (downloadLink && baseHref) {
             downloadLink.addEventListener('click', function (event) {
                 event.preventDefault()
-                var selected = selectedValues()
+                var selected = store.ids()
                 if (!selected.length) {
                     return
                 }
@@ -76,6 +79,7 @@
             })
         }
 
+        restoreSelection()
         refreshSelection()
     }
 

--- a/exhibition/static/exhibition/js/partner-select.js
+++ b/exhibition/static/exhibition/js/partner-select.js
@@ -20,25 +20,27 @@
             return Array.prototype.slice.call(scope.querySelectorAll('[data-partner-checkbox]'))
         }
 
-        function restoreSelection() {
-            checkboxes().forEach(function (box) {
-                box.checked = store.has(box.value)
-            })
+        function selectableIds() {
+            return (
+                store.available() ||
+                checkboxes().map(function (box) {
+                    return box.value
+                })
+            )
         }
 
         function refreshSelection() {
-            var boxes = checkboxes()
-            var onPage = boxes.filter(function (box) {
-                return box.checked
-            }).length
-            // The count covers every page, not just the rows currently rendered.
+            checkboxes().forEach(function (box) {
+                box.checked = store.has(box.value)
+            })
             var total = store.size()
+            var selectable = selectableIds().length
             if (countLabel) {
                 countLabel.textContent = total ? total + ' ' + selectedLabel : ''
             }
             if (selectAll) {
-                selectAll.checked = boxes.length > 0 && onPage === boxes.length
-                selectAll.indeterminate = onPage > 0 && onPage < boxes.length
+                selectAll.checked = selectable > 0 && total === selectable
+                selectAll.indeterminate = total > 0 && total < selectable
             }
             if (downloadLink) {
                 downloadLink.classList.toggle('disabled', total === 0)
@@ -48,10 +50,11 @@
 
         if (selectAll) {
             selectAll.addEventListener('change', function () {
-                checkboxes().forEach(function (box) {
-                    box.checked = selectAll.checked
-                    store.toggle(box.value, selectAll.checked)
-                })
+                if (selectAll.checked) {
+                    store.addAll(selectableIds())
+                } else {
+                    store.clear()
+                }
                 refreshSelection()
             })
         }
@@ -70,6 +73,12 @@
                 if (!selected.length) {
                     return
                 }
+                if (selected.length === selectableIds().length) {
+                    var filtered = new URLSearchParams(window.location.search)
+                    filtered.set('download', 'yes')
+                    window.location.href = window.location.pathname + '?' + filtered.toString()
+                    return
+                }
                 var params = selected
                     .map(function (value) {
                         return 'pk=' + encodeURIComponent(value)
@@ -79,7 +88,6 @@
             })
         }
 
-        restoreSelection()
         refreshSelection()
     }
 

--- a/exhibition/static/exhibition/js/proposal-actions.js
+++ b/exhibition/static/exhibition/js/proposal-actions.js
@@ -33,7 +33,7 @@
         var bulkHint = container.querySelector('[data-proposal-bulk-hint]')
         var bulkReasons = bulkBar ? bulkBar.dataset : {}
         var selectAllAcrossPages = false
-        var store = window.ExhibitionSelection.create()
+        var store = window.ExhibitionSelection.create({ scope: container })
 
         function allResultsSelected() {
             return selectAllAcrossPages && store.size() > 0

--- a/exhibition/static/exhibition/js/proposal-actions.js
+++ b/exhibition/static/exhibition/js/proposal-actions.js
@@ -32,11 +32,20 @@
         var bulkBar = container.querySelector('.proposal-bulk-bar')
         var bulkHint = container.querySelector('[data-proposal-bulk-hint]')
         var bulkReasons = bulkBar ? bulkBar.dataset : {}
-        var selectAllAcrossPages = false
         var store = window.ExhibitionSelection.create({ scope: container })
 
+        function selectableIds() {
+            return (
+                store.available() ||
+                checkboxes().map(function (box) {
+                    return box.value
+                })
+            )
+        }
+
         function allResultsSelected() {
-            return selectAllAcrossPages && store.size() > 0
+            var selectable = selectableIds().length
+            return selectable > 0 && store.size() === selectable
         }
 
         function filterParams() {
@@ -57,27 +66,28 @@
             return Array.prototype.slice.call(container.querySelectorAll('[data-proposal-checkbox]'))
         }
 
-        // Which bulk actions a row allows travels with the selection, so a
-        // request picked on page 1 is still filtered correctly from page 3.
         function metaFor(box) {
             return {
                 actions: (box.dataset.proposalBulkActions || '').split(' ').filter(Boolean),
             }
         }
 
-        function restoreSelection() {
+        function metaLookup() {
+            var known = {}
             checkboxes().forEach(function (box) {
-                box.checked = store.has(box.value)
-                if (box.checked) {
+                known[box.value] = metaFor(box)
+            })
+            return function (code) {
+                return known[code] || null
+            }
+        }
+
+        function refreshMeta() {
+            checkboxes().forEach(function (box) {
+                if (store.has(box.value)) {
                     store.add(box.value, metaFor(box))
                 }
             })
-        }
-
-        function selectedOnPage() {
-            return checkboxes().filter(function (box) {
-                return box.checked
-            }).length
         }
 
         function eligibleFor(action) {
@@ -96,10 +106,10 @@
         }
 
         function refreshSelection() {
-            var boxes = checkboxes()
-            var onPage = selectedOnPage()
+            checkboxes().forEach(function (box) {
+                box.checked = store.has(box.value)
+            })
             var count = store.size()
-            var pageFullySelected = boxes.length > 0 && onPage === boxes.length
             var acrossPages = allResultsSelected()
             var hints = []
             bulkButtons.forEach(function (button) {
@@ -124,12 +134,11 @@
                 bulkHint.hidden = hints.length === 0
             }
             if (countLabel) {
-                var shown = acrossPages ? bulkReasons.proposalTotal : count
-                countLabel.textContent = count ? shown + ' ' + (i18n.selected || '') : ''
+                countLabel.textContent = count ? count + ' ' + (i18n.selected || '') : ''
             }
             if (selectAll) {
-                selectAll.checked = pageFullySelected
-                selectAll.indeterminate = onPage > 0 && !pageFullySelected
+                selectAll.checked = acrossPages
+                selectAll.indeterminate = count > 0 && !acrossPages
             }
         }
 
@@ -252,10 +261,8 @@
                 })
                 .then(function (payload) {
                     if (payload.ok && payload.data.ok) {
-                        // The rows have been acted on, so they leave the selection.
                         if (acrossPages) {
                             store.clear()
-                            selectAllAcrossPages = false
                         } else {
                             codes.forEach(function (code) {
                                 store.remove(code)
@@ -361,24 +368,23 @@
 
         if (selectAll) {
             selectAll.addEventListener('change', function () {
-                selectAllAcrossPages = selectAll.checked
-                checkboxes().forEach(function (box) {
-                    box.checked = selectAll.checked
-                    store.toggle(box.value, selectAll.checked, metaFor(box))
-                })
+                if (selectAll.checked) {
+                    store.addAll(selectableIds(), metaLookup())
+                } else {
+                    store.clear()
+                }
                 refreshSelection()
             })
         }
 
         container.addEventListener('change', function (event) {
             if (event.target.matches('[data-proposal-checkbox]')) {
-                selectAllAcrossPages = false
                 store.toggle(event.target.value, event.target.checked, metaFor(event.target))
                 refreshSelection()
             }
         })
 
-        restoreSelection()
+        refreshMeta()
         refreshSelection()
     }
 

--- a/exhibition/static/exhibition/js/proposal-actions.js
+++ b/exhibition/static/exhibition/js/proposal-actions.js
@@ -33,9 +33,10 @@
         var bulkHint = container.querySelector('[data-proposal-bulk-hint]')
         var bulkReasons = bulkBar ? bulkBar.dataset : {}
         var selectAllAcrossPages = false
+        var store = window.ExhibitionSelection.create()
 
         function allResultsSelected() {
-            return selectAllAcrossPages && selectedBoxes().length > 0
+            return selectAllAcrossPages && store.size() > 0
         }
 
         function filterParams() {
@@ -56,23 +57,38 @@
             return Array.prototype.slice.call(container.querySelectorAll('[data-proposal-checkbox]'))
         }
 
-        function selectedBoxes() {
-            return checkboxes().filter(function (box) {
-                return box.checked
+        // Which bulk actions a row allows travels with the selection, so a
+        // request picked on page 1 is still filtered correctly from page 3.
+        function metaFor(box) {
+            return {
+                actions: (box.dataset.proposalBulkActions || '').split(' ').filter(Boolean),
+            }
+        }
+
+        function restoreSelection() {
+            checkboxes().forEach(function (box) {
+                box.checked = store.has(box.value)
+                if (box.checked) {
+                    store.add(box.value, metaFor(box))
+                }
             })
         }
 
+        function selectedOnPage() {
+            return checkboxes().filter(function (box) {
+                return box.checked
+            }).length
+        }
+
         function eligibleFor(action) {
-            return selectedBoxes().filter(function (box) {
-                var actions = (box.dataset.proposalBulkActions || '').split(' ')
-                return actions.indexOf(action) !== -1
+            return store.ids().filter(function (code) {
+                var meta = store.meta(code)
+                return !!meta && (meta.actions || []).indexOf(action) !== -1
             })
         }
 
         function selectedCodes(action) {
-            return eligibleFor(action).map(function (box) {
-                return box.value
-            })
+            return eligibleFor(action)
         }
 
         function capitalize(word) {
@@ -81,8 +97,9 @@
 
         function refreshSelection() {
             var boxes = checkboxes()
-            var count = selectedBoxes().length
-            var pageFullySelected = boxes.length > 0 && count === boxes.length
+            var onPage = selectedOnPage()
+            var count = store.size()
+            var pageFullySelected = boxes.length > 0 && onPage === boxes.length
             var acrossPages = allResultsSelected()
             var hints = []
             bulkButtons.forEach(function (button) {
@@ -112,7 +129,7 @@
             }
             if (selectAll) {
                 selectAll.checked = pageFullySelected
-                selectAll.indeterminate = count > 0 && !pageFullySelected
+                selectAll.indeterminate = onPage > 0 && !pageFullySelected
             }
         }
 
@@ -173,6 +190,7 @@
                 return
             }
             box.checked = false
+            store.remove(box.value)
             box.setAttribute('data-proposal-bulk-actions', (result.bulk_actions || []).join(' '))
         }
 
@@ -192,7 +210,7 @@
         function setBusy(busy) {
             bulkButtons.forEach(function (button) {
                 var pending = allResultsSelected()
-                    ? selectedBoxes().length === 0
+                    ? store.size() === 0
                     : selectedCodes(button.dataset.proposalBulk).length === 0
                 button.disabled = busy || pending
             })
@@ -234,6 +252,15 @@
                 })
                 .then(function (payload) {
                     if (payload.ok && payload.data.ok) {
+                        // The rows have been acted on, so they leave the selection.
+                        if (acrossPages) {
+                            store.clear()
+                            selectAllAcrossPages = false
+                        } else {
+                            codes.forEach(function (code) {
+                                store.remove(code)
+                            })
+                        }
                         if (payload.data.reload) {
                             refreshResults(payload.data.message)
                             return
@@ -337,6 +364,7 @@
                 selectAllAcrossPages = selectAll.checked
                 checkboxes().forEach(function (box) {
                     box.checked = selectAll.checked
+                    store.toggle(box.value, selectAll.checked, metaFor(box))
                 })
                 refreshSelection()
             })
@@ -345,10 +373,12 @@
         container.addEventListener('change', function (event) {
             if (event.target.matches('[data-proposal-checkbox]')) {
                 selectAllAcrossPages = false
+                store.toggle(event.target.value, event.target.checked, metaFor(event.target))
                 refreshSelection()
             }
         })
 
+        restoreSelection()
         refreshSelection()
     }
 

--- a/exhibition/static/exhibition/js/selection-store.js
+++ b/exhibition/static/exhibition/js/selection-store.js
@@ -1,20 +1,9 @@
-/*
- * Cross-page selection for the paginated exhibition lists.
- *
- * Checkbox state used to live only in the DOM, so paginating a list threw the
- * selection away. This keeps it in sessionStorage instead, keyed by the list's
- * path, so it survives pagination, sorting and page-size changes while still
- * resetting when the filters change or the list is left.
- */
 ;(function () {
     'use strict'
 
     var PREFIX = 'exhibition:selection:'
-
-    // Query parameters that move you around a result set without changing it.
-    // Everything else counts as a filter, and changing a filter drops the
-    // selection because the user is now looking at a different list.
     var VOLATILE_PARAMS = ['page', 'page_size', 'ordering']
+    var LAST_PATH_KEY = PREFIX + 'last-path'
 
     function openStorage() {
         try {
@@ -24,7 +13,6 @@
             storage.removeItem(probe)
             return storage
         } catch (err) {
-            // Private mode or blocked storage: fall back to per-page selection.
             return null
         }
     }
@@ -49,7 +37,7 @@
         try {
             storage.setItem(PREFIX + key, JSON.stringify(state))
         } catch (err) {
-            // Quota exhausted: the selection just stops persisting.
+            return
         }
     }
 
@@ -65,20 +53,6 @@
         return pairs.sort().join('&')
     }
 
-    var LAST_PATH_KEY = PREFIX + 'last-path'
-
-    /*
-     * True when this page load continues browsing the same list, i.e. a
-     * pagination or sort click, a reload, or a step back to another page of it.
-     * Arriving from anywhere else -- the dashboard, another list -- means the
-     * list was left, so the stored selection is dropped.
-     *
-     * document.referrer cannot answer this: the control panel ships
-     * <meta name="referrer" content="origin">, so it never carries a path.
-     * Instead every exhibition page records its own path as it loads (this
-     * module is pulled in from exhibitors/base.html), and the previous value is
-     * where the user just came from.
-     */
     function continuesSameList() {
         if (!storage) {
             return false
@@ -86,8 +60,6 @@
         var current = window.location.pathname
         try {
             var previous = storage.getItem(LAST_PATH_KEY)
-            // A bulk-action confirmation belongs to the list that opened it, so it
-            // leaves the marker untouched: cancelling returns you to your selection.
             if (!document.querySelector('[data-selection-passthrough]')) {
                 storage.setItem(LAST_PATH_KEY, current)
             }
@@ -97,13 +69,9 @@
         }
     }
 
-    // Evaluated once per page load; init() may run again after an AJAX refresh
-    // and must not re-drop a selection the user is still building.
     var continued = continuesSameList()
     var started = {}
 
-    // Ids the list still contains, from the data-selection-ids attribute the
-    // server renders; null when the element does not carry one.
     function presentIds(element) {
         if (!element || !element.hasAttribute('data-selection-ids')) {
             return null
@@ -111,11 +79,6 @@
         return element.getAttribute('data-selection-ids').split(' ').filter(Boolean)
     }
 
-    /*
-     * options.scope: element carrying data-selection-ids. Stored ids missing from
-     * it were deleted or acted on since they were picked, so they are dropped
-     * rather than inflating the count with rows the server would ignore.
-     */
     function create(options) {
         var settings = options || {}
         var key = settings.key || window.location.pathname
@@ -160,6 +123,12 @@
                 state.items[id] = meta || {}
                 persist()
             },
+            addAll: function (ids, metaFor) {
+                ids.forEach(function (id) {
+                    state.items[id] = (metaFor ? metaFor(id) : null) || state.items[id] || {}
+                })
+                persist()
+            },
             remove: function (id) {
                 delete state.items[id]
                 persist()
@@ -174,6 +143,9 @@
             },
             ids: function () {
                 return Object.keys(state.items)
+            },
+            available: function () {
+                return present ? present.slice() : null
             },
             size: function () {
                 return Object.keys(state.items).length

--- a/exhibition/static/exhibition/js/selection-store.js
+++ b/exhibition/static/exhibition/js/selection-store.js
@@ -102,6 +102,20 @@
     var continued = continuesSameList()
     var started = {}
 
+    // Ids the list still contains, from the data-selection-ids attribute the
+    // server renders; null when the element does not carry one.
+    function presentIds(element) {
+        if (!element || !element.hasAttribute('data-selection-ids')) {
+            return null
+        }
+        return element.getAttribute('data-selection-ids').split(' ').filter(Boolean)
+    }
+
+    /*
+     * options.scope: element carrying data-selection-ids. Stored ids missing from
+     * it were deleted or acted on since they were picked, so they are dropped
+     * rather than inflating the count with rows the server would ignore.
+     */
     function create(options) {
         var settings = options || {}
         var key = settings.key || window.location.pathname
@@ -116,6 +130,18 @@
         }
         if (!state || state.signature !== signature || !state.items) {
             state = { signature: signature, items: {} }
+        }
+        var present = presentIds(settings.scope)
+        if (present) {
+            var keep = {}
+            present.forEach(function (id) {
+                keep[id] = true
+            })
+            Object.keys(state.items).forEach(function (id) {
+                if (!keep[id]) {
+                    delete state.items[id]
+                }
+            })
         }
         write(key, state)
 

--- a/exhibition/static/exhibition/js/selection-store.js
+++ b/exhibition/static/exhibition/js/selection-store.js
@@ -86,7 +86,11 @@
         var current = window.location.pathname
         try {
             var previous = storage.getItem(LAST_PATH_KEY)
-            storage.setItem(LAST_PATH_KEY, current)
+            // A bulk-action confirmation belongs to the list that opened it, so it
+            // leaves the marker untouched: cancelling returns you to your selection.
+            if (!document.querySelector('[data-selection-passthrough]')) {
+                storage.setItem(LAST_PATH_KEY, current)
+            }
             return previous === current
         } catch (err) {
             return false

--- a/exhibition/static/exhibition/js/selection-store.js
+++ b/exhibition/static/exhibition/js/selection-store.js
@@ -1,0 +1,159 @@
+/*
+ * Cross-page selection for the paginated exhibition lists.
+ *
+ * Checkbox state used to live only in the DOM, so paginating a list threw the
+ * selection away. This keeps it in sessionStorage instead, keyed by the list's
+ * path, so it survives pagination, sorting and page-size changes while still
+ * resetting when the filters change or the list is left.
+ */
+;(function () {
+    'use strict'
+
+    var PREFIX = 'exhibition:selection:'
+
+    // Query parameters that move you around a result set without changing it.
+    // Everything else counts as a filter, and changing a filter drops the
+    // selection because the user is now looking at a different list.
+    var VOLATILE_PARAMS = ['page', 'page_size', 'ordering']
+
+    function openStorage() {
+        try {
+            var storage = window.sessionStorage
+            var probe = '__exhibition_selection_probe__'
+            storage.setItem(probe, '1')
+            storage.removeItem(probe)
+            return storage
+        } catch (err) {
+            // Private mode or blocked storage: fall back to per-page selection.
+            return null
+        }
+    }
+
+    var storage = openStorage()
+
+    function read(key) {
+        if (!storage) {
+            return null
+        }
+        try {
+            return JSON.parse(storage.getItem(PREFIX + key))
+        } catch (err) {
+            return null
+        }
+    }
+
+    function write(key, state) {
+        if (!storage) {
+            return
+        }
+        try {
+            storage.setItem(PREFIX + key, JSON.stringify(state))
+        } catch (err) {
+            // Quota exhausted: the selection just stops persisting.
+        }
+    }
+
+    function signatureFrom(search) {
+        var params = new URLSearchParams(search || '')
+        VOLATILE_PARAMS.forEach(function (name) {
+            params.delete(name)
+        })
+        var pairs = []
+        params.forEach(function (value, name) {
+            pairs.push(name + '=' + value)
+        })
+        return pairs.sort().join('&')
+    }
+
+    var LAST_PATH_KEY = PREFIX + 'last-path'
+
+    /*
+     * True when this page load continues browsing the same list, i.e. a
+     * pagination or sort click, a reload, or a step back to another page of it.
+     * Arriving from anywhere else -- the dashboard, another list -- means the
+     * list was left, so the stored selection is dropped.
+     *
+     * document.referrer cannot answer this: the control panel ships
+     * <meta name="referrer" content="origin">, so it never carries a path.
+     * Instead every exhibition page records its own path as it loads (this
+     * module is pulled in from exhibitors/base.html), and the previous value is
+     * where the user just came from.
+     */
+    function continuesSameList() {
+        if (!storage) {
+            return false
+        }
+        var current = window.location.pathname
+        try {
+            var previous = storage.getItem(LAST_PATH_KEY)
+            storage.setItem(LAST_PATH_KEY, current)
+            return previous === current
+        } catch (err) {
+            return false
+        }
+    }
+
+    // Evaluated once per page load; init() may run again after an AJAX refresh
+    // and must not re-drop a selection the user is still building.
+    var continued = continuesSameList()
+    var started = {}
+
+    function create(options) {
+        var settings = options || {}
+        var key = settings.key || window.location.pathname
+        var signature = signatureFrom(window.location.search)
+        var state = read(key)
+
+        if (!started[key]) {
+            started[key] = true
+            if (!continued) {
+                state = null
+            }
+        }
+        if (!state || state.signature !== signature || !state.items) {
+            state = { signature: signature, items: {} }
+        }
+        write(key, state)
+
+        function persist() {
+            write(key, state)
+        }
+
+        return {
+            has: function (id) {
+                return Object.prototype.hasOwnProperty.call(state.items, id)
+            },
+            meta: function (id) {
+                return state.items[id] || null
+            },
+            add: function (id, meta) {
+                state.items[id] = meta || {}
+                persist()
+            },
+            remove: function (id) {
+                delete state.items[id]
+                persist()
+            },
+            toggle: function (id, selected, meta) {
+                if (selected) {
+                    state.items[id] = meta || state.items[id] || {}
+                } else {
+                    delete state.items[id]
+                }
+                persist()
+            },
+            ids: function () {
+                return Object.keys(state.items)
+            },
+            size: function () {
+                return Object.keys(state.items).length
+            },
+            clear: function () {
+                state.items = {}
+                persist()
+            },
+        }
+    }
+
+    window.ExhibitionSelection = { create: create, signatureFrom: signatureFrom }
+})()

--- a/exhibition/templates/exhibitors/_email_outbox_body.html
+++ b/exhibition/templates/exhibitors/_email_outbox_body.html
@@ -25,9 +25,16 @@
             <span class="text-muted" data-email-selected-count
                   data-selected-label="{% trans "selected" %}"></span>
         </div>
+        {% if selection_limit %}
+            <p class="text-danger" data-email-selection-limit="{{ selection_limit }}" hidden>
+                {% blocktrans trimmed with limit=selection_limit %}
+                    At most {{ limit }} emails can be sent or discarded at once. Deselect some, or use "Send all" or "Discard all".
+                {% endblocktrans %}
+            </p>
+        {% endif %}
     {% endif %}
     <div class="table-responsive">
-        <table class="table table-hover">
+        <table class="table table-hover" data-selection-ids="{{ selectable_ids|join:' ' }}">
             <thead>
             <tr>
                 <th class="email-select"><input type="checkbox" data-select-all></th>
@@ -42,7 +49,8 @@
             {% for entry in entries %}
                 <tr>
                     <td class="email-select">
-                        <input type="checkbox" name="selected" value="{{ entry.pk }}" data-select-row>
+                        {# The selection is kept in sessionStorage, so ticking a row is not an unsaved change for are-you-sure. #}
+                        <input type="checkbox" name="selected" value="{{ entry.pk }}" data-select-row data-ays-ignore="true">
                     </td>
                     <td>
                         <span class="email-recipients" title="{{ entry.recipients|join:', ' }}"

--- a/exhibition/templates/exhibitors/_email_outbox_body.html
+++ b/exhibition/templates/exhibitors/_email_outbox_body.html
@@ -22,6 +22,8 @@
             <button type="submit" class="btn btn-danger btn-sm" name="op" value="discard_all">
                 {% trans "Discard all" %}
             </button>
+            <span class="text-muted" data-email-selected-count
+                  data-selected-label="{% trans "selected" %}"></span>
         </div>
     {% endif %}
     <div class="table-responsive">

--- a/exhibition/templates/exhibitors/_email_outbox_body.html
+++ b/exhibition/templates/exhibitors/_email_outbox_body.html
@@ -49,7 +49,6 @@
             {% for entry in entries %}
                 <tr>
                     <td class="email-select">
-                        {# The selection is kept in sessionStorage, so ticking a row is not an unsaved change for are-you-sure. #}
                         <input type="checkbox" name="selected" value="{{ entry.pk }}" data-select-row data-ays-ignore="true">
                     </td>
                     <td>

--- a/exhibition/templates/exhibitors/base.html
+++ b/exhibition/templates/exhibitors/base.html
@@ -7,6 +7,7 @@
 
 {% block custom_header %}
     {{ block.super }}
+    <script defer src="{% static 'exhibition/js/selection-store.js' %}"></script>
     <script defer src="{% static 'exhibition/js/tooltip-init.js' %}"></script>
 {% endblock %}
 

--- a/exhibition/templates/exhibitors/email_bulk_discard.html
+++ b/exhibition/templates/exhibitors/email_bulk_discard.html
@@ -8,6 +8,8 @@
 {% endblock %}
 
 {% block exhibitors_content %}
+    {# Part of the list's own flow: cancelling must not drop the list selection. #}
+    <span data-selection-passthrough hidden></span>
     <form action="{% url 'plugins:exhibition:email.bulk' organizer=request.event.organizer.slug event=request.event.slug %}" method="post">
         {% csrf_token %}
         <input type="hidden" name="op" value="{% if scope == 'all' %}discard_all{% else %}discard{% endif %}">

--- a/exhibition/templates/exhibitors/email_bulk_discard.html
+++ b/exhibition/templates/exhibitors/email_bulk_discard.html
@@ -8,7 +8,6 @@
 {% endblock %}
 
 {% block exhibitors_content %}
-    {# Part of the list's own flow: cancelling must not drop the list selection. #}
     <span data-selection-passthrough hidden></span>
     <form action="{% url 'plugins:exhibition:email.bulk' organizer=request.event.organizer.slug event=request.event.slug %}" method="post">
         {% csrf_token %}

--- a/exhibition/templates/exhibitors/exhibitor_info.html
+++ b/exhibition/templates/exhibitors/exhibitor_info.html
@@ -45,7 +45,8 @@
             {% endif %}
         </div>
     {% else %}
-        <div data-partner-select-scope data-selected-label="{% trans "selected" %}">
+        <div data-partner-select-scope data-selected-label="{% trans "selected" %}"
+             data-selection-ids="{{ selectable_ids|join:' ' }}">
         {% if send_vouchers_url %}
             <form id="partner-send-vouchers" action="{{ send_vouchers_url }}{% if query_string %}?{{ query_string }}{% endif %}" method="post">
                 {% csrf_token %}

--- a/exhibition/templates/exhibitors/proposal_list.html
+++ b/exhibition/templates/exhibitors/proposal_list.html
@@ -30,7 +30,6 @@
              data-proposal-list>
             {% if can_manage %}
                 <div class="proposal-bulk-bar"
-                     data-proposal-total="{{ page_obj.paginator.count }}"
                      data-proposal-reason-none="{% trans 'Select at least one request.' %}"
                      data-proposal-reason-approve="{% trans 'None of the selected requests can be approved.' %}"
                      data-proposal-reason-reject="{% trans 'None of the selected requests can be rejected.' %}"

--- a/exhibition/templates/exhibitors/proposal_list.html
+++ b/exhibition/templates/exhibitors/proposal_list.html
@@ -26,6 +26,7 @@
         <div class="proposal-action-feedback" data-proposal-feedback></div>
         <div class="table-responsive"
              data-proposal-actions-url="{% url 'plugins:exhibition:proposal.actions' organizer=request.event.organizer.slug event=request.event.slug %}"
+             data-selection-ids="{{ selectable_ids|join:' ' }}"
              data-proposal-list>
             {% if can_manage %}
                 <div class="proposal-bulk-bar"

--- a/exhibition/templates/exhibitors/voucher_bulk_send.html
+++ b/exhibition/templates/exhibitors/voucher_bulk_send.html
@@ -8,7 +8,6 @@
 {% endblock %}
 
 {% block exhibitors_content %}
-    {# Part of the list's own flow: cancelling must not drop the list selection. #}
     <span data-selection-passthrough hidden></span>
     <form action="?{{ query_string }}" method="post">
         {% csrf_token %}

--- a/exhibition/templates/exhibitors/voucher_bulk_send.html
+++ b/exhibition/templates/exhibitors/voucher_bulk_send.html
@@ -8,6 +8,8 @@
 {% endblock %}
 
 {% block exhibitors_content %}
+    {# Part of the list's own flow: cancelling must not drop the list selection. #}
+    <span data-selection-passthrough hidden></span>
     <form action="?{{ query_string }}" method="post">
         {% csrf_token %}
         <input type="hidden" name="confirmed" value="1">

--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -2751,14 +2751,24 @@ class EmailBulkActionView(EventPermissionRequiredMixin, View):
         batches = [batch for batch in base.filter(pk__in=selected).values_list("batch", flat=True) if batch]
         return base.filter(Q(pk__in=selected) | Q(batch__in=batches))
 
+    def outbox_redirect(self, request, done=False):
+        """Back to the outbox. ``?bulk=done`` tells the page its selection was consumed.
+
+        Only set it once rows have actually been sent or discarded, so a cancelled
+        confirmation or a request that did nothing leaves the selection to retry.
+        """
+        response = redirect("plugins:exhibition:email.outbox", **event_kwargs(request.event))
+        if done:
+            response["Location"] += "?bulk=done"
+        return response
+
     def post(self, request, *args, **kwargs):
         op = request.POST.get("op", "")
         action = "send" if op.startswith("send") else "discard" if op.startswith("discard") else None
         scope = "all" if op.endswith("_all") else "selected"
-        outbox_url = redirect("plugins:exhibition:email.outbox", **event_kwargs(request.event))
 
         if action is None:
-            return outbox_url
+            return self.outbox_redirect(request)
 
         rows = self.target_rows(request, scope)
 
@@ -2775,7 +2785,7 @@ class EmailBulkActionView(EventPermissionRequiredMixin, View):
                 )
             else:
                 messages.info(request, _("No emails were selected."))
-            return outbox_url
+            return self.outbox_redirect(request, done=bool(count))
 
         if request.POST.get("confirmed"):
             count = rows.count()
@@ -2788,12 +2798,12 @@ class EmailBulkActionView(EventPermissionRequiredMixin, View):
                 )
             else:
                 messages.info(request, _("No emails were selected."))
-            return outbox_url
+            return self.outbox_redirect(request, done=bool(count))
 
         count = rows.count()
         if not count:
             messages.info(request, _("No emails were selected."))
-            return outbox_url
+            return self.outbox_redirect(request)
         return render(
             request,
             "exhibitors/email_bulk_discard.html",

--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -192,9 +192,6 @@ class PublicCallEnabledMixin:
 class FilteredListMixin(PaginationMixin):
     """Wires a control-panel FilterForm and pagination into a ListView."""
 
-    # Field whose values back the list's row checkboxes. Lists that set it expose
-    # every value still in the filtered result as ``selectable_ids``, so the
-    # cross-page selection can drop rows removed since they were picked.
     selection_field = None
 
     def build_filter_form(self):

--- a/exhibition/views.py
+++ b/exhibition/views.py
@@ -2,6 +2,7 @@ import io
 import json
 
 from defusedcsv import csv
+from django.conf import settings as django_settings
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.exceptions import PermissionDenied
@@ -191,6 +192,11 @@ class PublicCallEnabledMixin:
 class FilteredListMixin(PaginationMixin):
     """Wires a control-panel FilterForm and pagination into a ListView."""
 
+    # Field whose values back the list's row checkboxes. Lists that set it expose
+    # every value still in the filtered result as ``selectable_ids``, so the
+    # cross-page selection can drop rows removed since they were picked.
+    selection_field = None
+
     def build_filter_form(self):
         raise NotImplementedError
 
@@ -208,6 +214,8 @@ class FilteredListMixin(PaginationMixin):
         context["filter_form"] = self.filter_form
         context["advanced_filters_open"] = advanced_filters_open_from_get(self.filter_form)
         context["advanced_filter_count"] = advanced_filter_count(self.filter_form)
+        if self.selection_field:
+            context["selectable_ids"] = list(self.object_list.order_by().values_list(self.selection_field, flat=True))
         return context
 
 
@@ -500,6 +508,7 @@ class ExhibitorListView(EventPermissionRequiredMixin, FilteredListMixin, ListVie
     permission = ("can_change_event_settings", "can_view_orders")
     template_name = "exhibitors/exhibitor_info.html"
     context_object_name = "exhibitors"
+    selection_field = "pk"
     partner_type = None
 
     def build_filter_form(self):
@@ -1302,6 +1311,7 @@ class ProposalListView(EventPermissionRequiredMixin, FilteredListMixin, ListView
     permission = ("can_change_event_settings", "can_change_exhibition_proposals", "is_exhibition_reviewer")
     template_name = "exhibitors/proposal_list.html"
     context_object_name = "proposals"
+    selection_field = "code"
 
     @cached_property
     def hide_applicant_emails(self):
@@ -2579,6 +2589,17 @@ class EmailListMixin(FilteredListMixin):
         return [self.template_name]
 
 
+def bulk_email_selection_limit():
+    """Most rows a bulk email request can carry, or ``None`` when Django sets no cap.
+
+    Each selected row is its own POST field, and Django rejects a request with
+    more than ``DATA_UPLOAD_MAX_NUMBER_FIELDS`` of them. The discard confirmation
+    re-posts the selection alongside the CSRF token, ``op`` and ``confirmed``.
+    """
+    limit = django_settings.DATA_UPLOAD_MAX_NUMBER_FIELDS
+    return None if limit is None else limit - 3
+
+
 class EmailOutboxListView(EmailListMixin, EventPermissionRequiredMixin, ListView):
     """Unsent queued emails awaiting organiser review."""
 
@@ -2587,9 +2608,15 @@ class EmailOutboxListView(EmailListMixin, EventPermissionRequiredMixin, ListView
     template_name = "exhibitors/email_outbox.html"
     partial_template_name = "exhibitors/_email_outbox_body.html"
     date_field = "created"
+    selection_field = "pk"
 
     def base_queryset(self):
         return ExhibitionEmailQueue.objects.filter(event=self.request.event, sent_at__isnull=True)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["selection_limit"] = bulk_email_selection_limit()
+        return context
 
 
 class EmailSentListView(EmailListMixin, EventPermissionRequiredMixin, ListView):

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -740,7 +740,6 @@ def test_outbox_lists_every_selectable_row_not_just_the_current_page(mail_event)
     context = _outbox_context(mail_event, page_size=1)
 
     assert len(context["entries"]) == 1
-    # A batch is one row, keyed by its lowest pk, just like its checkbox.
     assert sorted(context["selectable_ids"]) == sorted([min(row.pk for row in batch), single.pk])
 
 

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -1,5 +1,6 @@
 import json
 from datetime import timedelta
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -28,6 +29,7 @@ from exhibition.models import (
 from exhibition.views import (
     EmailComposeView,
     EmailDeleteView,
+    EmailOutboxListView,
     EmailSendView,
     EmailTemplatePreviewView,
     group_email_entries,
@@ -712,6 +714,43 @@ def test_delete_view_discards_whole_batch(mail_event):
 
     with scopes_disabled():
         assert ExhibitionEmailQueue.objects.filter(event=mail_event).count() == 0
+
+
+def _outbox_context(event, **params):
+    request = RequestFactory().get("/outbox", params)
+    request.event = event
+    request.user = None
+    request.session = {}
+    request.resolver_match = SimpleNamespace(url_name="email.outbox")
+    view = EmailOutboxListView()
+    view.setup(request)
+    with scopes_disabled():
+        view.object_list = view.get_queryset()
+        return view.get_context_data()
+
+
+@pytest.mark.django_db
+def test_outbox_lists_every_selectable_row_not_just_the_current_page(mail_event):
+    p1 = _proposal(mail_event, "One", ExhibitionProposalState.ACCEPTED, email="one@example.com")
+    p2 = _proposal(mail_event, "Two", ExhibitionProposalState.ACCEPTED, email="two@example.com")
+    with scopes_disabled():
+        batch = mail_helpers.queue_compose_emails(mail_event, [p1, p2], "Hi", "Body")
+        single = mail_helpers.queue_proposal_email(mail_event, p1, mail_helpers.PROPOSAL_ACCEPTED)
+
+    context = _outbox_context(mail_event, page_size=1)
+
+    assert len(context["entries"]) == 1
+    # A batch is one row, keyed by its lowest pk, just like its checkbox.
+    assert sorted(context["selectable_ids"]) == sorted([min(row.pk for row in batch), single.pk])
+
+
+@pytest.mark.django_db
+def test_outbox_caps_the_selection_below_the_post_field_limit(mail_event, settings):
+    settings.DATA_UPLOAD_MAX_NUMBER_FIELDS = 50
+    assert _outbox_context(mail_event)["selection_limit"] == 47
+
+    settings.DATA_UPLOAD_MAX_NUMBER_FIELDS = None
+    assert _outbox_context(mail_event)["selection_limit"] is None
 
 
 PLAIN_BODY = "First paragraph.\n\nSecond paragraph.\nSame paragraph, new line."


### PR DESCRIPTION
Checkbox state lived only in the DOM, so moving to another page of any paginated exhibition list threw the selection away: the count reset, the ticks were gone on return, and bulk actions only ever saw the visible page.

Add a shared sessionStorage-backed selection store, keyed by the list's path, and wire the three paginated lists (partners, message center outbox, exhibition requests) to it. Selections now survive pagination, sorting and page-size changes; the count reflects the total across pages; and bulk actions operate on the whole selection -- the outbox sends off-page picks as hidden fields, and proposals carry each row's permitted bulk actions along with it so eligibility still works from another page.

The selection is dropped when a filter changes or the list is left. The control panel sets <meta name="referrer" content="origin">, so document.referrer cannot identify the previous page; instead the store is loaded from exhibitors/base.html on every exhibition page and each page records its own path, making the previous value the page the user came from.

Fixes #220

[Screencast From 2026-09-09 23-55-22.webm](https://github.com/user-attachments/assets/aaefa807-4949-4955-98d6-9b00eb259d6b)

## Summary by Sourcery

Keep exhibition list selections across pagination and apply bulk operations to the complete selection.

New Features:
- Preserve selections across pagination, sorting, and page-size changes in partner, email outbox, and exhibition request lists.
- Enable bulk actions and downloads to operate on selections spanning multiple pages, including action eligibility for off-page exhibition requests.

Bug Fixes:
- Prevent paginated list selections from being lost when navigating between pages.

Enhancements:
- Clear selections when filters change or the user leaves the associated list, while retaining them through supported confirmation flows.
- Display aggregate selection counts and enforce the email outbox bulk submission limit.

Tests:
- Add coverage for exposing all selectable outbox rows across pagination and calculating the bulk selection limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Selections persist across pagination, sorting, reloads, and page-size changes.
  * Bulk actions and downloads include selected items from across all pages.
  * Selection counts show the total number of selected items.
  * Selections reset when filters or lists change, while stale items are removed automatically.
  * Email outbox selections display a selected-count indicator and selection-limit warning.
  * Cancelling bulk-action flows preserves the current selection.
  * Selections clear after completed email bulk actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->