### PR TITLE
fix(exhibition): show exhibitor banners complete instead of cropped

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,29 @@ Features
 - Support notes and tags for scanned leads.
 - Provide REST API endpoints for exhibitor data and lead scanning workflows.
 
+Image dimensions
+----------------
+
+Exhibitor header images (banners) are shown complete, never cropped. Every
+public surface -- the exhibitor list card and the detail page hero -- reserves
+the same box:
+
+============  ==================
+Property      Value
+============  ==================
+Aspect ratio  3:1 (wide)
+Recommended   1500 x 500 pixels
+============  ==================
+
+An image that does not match 3:1 is neither rejected nor cropped. It is scaled
+to fit inside the box and centred, with the surrounding area filled by a plain
+background, so the layout stays intact whatever is uploaded.
+
+The ratio is defined as the ``--exhibition-banner-ratio`` CSS custom property
+in ``exhibition/static/exhibition/css/exhibitors-public-list.css`` and
+``exhibitors-public-detail.css``. Change it in both places to move every
+surface together.
+
 Repository branches
 -------------------
 

--- a/exhibition/forms.py
+++ b/exhibition/forms.py
@@ -312,6 +312,11 @@ class ExhibitorInfoForm(ExhibitionQuestionFieldsMixin, I18nModelForm):
                 "Lets this exhibitor sign in to the lead scanning app and scan attendees at their booth. "
                 "Turn this off to block scanning entirely."
             ),
+            "header_image": _(
+                "Shown as the banner on the public exhibitor page and list card. "
+                "Use a wide 3:1 image, for example 1500 x 500 pixels. Other shapes are "
+                "shown complete on a plain background rather than being cropped."
+            ),
         }
 
     PROFILE_SETTING_FIELD_MAP = {
@@ -1085,6 +1090,13 @@ class ExhibitionProposalForm(ExhibitionQuestionFieldsMixin, I18nModelForm):
             "url": _("Organization website"),
             "booth_name": _("Preferred booth name"),
             "notes": _("Message to the organizers"),
+        }
+        help_texts = {
+            "header_image": _(
+                "Shown as the banner on the public exhibitor page and list card. "
+                "Use a wide 3:1 image, for example 1500 x 500 pixels. Other shapes are "
+                "shown complete on a plain background rather than being cropped."
+            ),
         }
         widgets = {
             "notes": forms.Textarea(attrs={"rows": 4}),

--- a/exhibition/static/exhibition/css/exhibitors-public-detail.css
+++ b/exhibition/static/exhibition/css/exhibitors-public-detail.css
@@ -1,3 +1,11 @@
+/* Banner (header image) aspect ratio.
+   Exhibitor banners are shown complete rather than cropped, so every surface
+   reserves the same 3:1 box and letterboxes anything that does not match.
+   Recommended upload: 1500 x 500 px. Documented in README.rst. */
+:root {
+    --exhibition-banner-ratio: 3 / 1;
+}
+
 .exhibition-detail-page {
     margin-top: 32px;
 }
@@ -39,7 +47,7 @@
 }
 
 .exhibition-detail-hero {
-    height: 420px;
+    aspect-ratio: var(--exhibition-banner-ratio);
     background: #edf2f7;
     overflow: hidden;
     border-radius: 16px;
@@ -49,7 +57,7 @@
     width: 100%;
     height: 100%;
     display: block;
-    object-fit: cover;
+    object-fit: contain;
     object-position: center;
 }
 
@@ -349,10 +357,6 @@
 
     .exhibition-detail-nav .btn {
         width: 100%;
-    }
-
-    .exhibition-detail-hero {
-        height: 240px;
     }
 
     .exhibition-detail-content {

--- a/exhibition/static/exhibition/css/exhibitors-public-list.css
+++ b/exhibition/static/exhibition/css/exhibitors-public-list.css
@@ -1,3 +1,11 @@
+/* Banner (header image) aspect ratio.
+   Exhibitor banners are shown complete rather than cropped, so every surface
+   reserves the same 3:1 box and letterboxes anything that does not match.
+   Recommended upload: 1500 x 500 px. Documented in README.rst. */
+:root {
+    --exhibition-banner-ratio: 3 / 1;
+}
+
 .exhibition-public-page {
     margin-top: 32px;
 }
@@ -74,7 +82,7 @@
 
 .exhibition-public-card-image {
     background: var(--color-grey-lightest, #f8f9fa);
-    height: 180px;
+    aspect-ratio: var(--exhibition-banner-ratio);
     overflow: hidden;
 }
 
@@ -82,7 +90,7 @@
     width: 100%;
     height: 100%;
     display: block;
-    object-fit: cover;
+    object-fit: contain;
     object-position: center;
 }
 


### PR DESCRIPTION
The public list card and the detail hero both put the header image in a fixed-height box with object-fit: cover, so the browser filled the box by cutting the image down. The two boxes were not even the same shape -- 220px tall cards against a 420px hero -- so an organizer lost different parts of their banner on each surface, and had no way to see the whole thing outside the edit form preview.

Give both surfaces the same 3:1 box via aspect-ratio and switch them to object-fit: contain, so the banner is scaled to fit and shown in full. The ratio lives in the --exhibition-banner-ratio custom property, and the narrow-viewport rules no longer override the height, so every surface and screen size frames a banner identically.

An image that is not 3:1 is scaled to fit and centred against the existing plain background rather than cropped or stretched, so an unexpected shape letterboxes instead of breaking the layout.

Document the ratio in README.rst and state it on the upload field itself, so the expected size is visible at the point where the file is chosen.

Fixes #219

## Summary by Sourcery

Show complete exhibitor banners consistently across public listing and detail views.

Bug Fixes:
- Display exhibitor banners fully on public detail pages by fitting images within a consistent 3:1 frame instead of cropping them.

Enhancements:
- Standardize exhibitor banner presentation across viewport sizes with a shared aspect ratio and centered handling for non-3:1 images.

Documentation:
- Document the recommended 3:1 exhibitor banner dimensions in the README and upload form guidance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exhibitor and proposal forms now provide guidance for header images, including the recommended 3:1 banner ratio and non-cropping behavior.
  * Voucher configuration now supports selecting event pool tags, including separate sponsor voucher pools.
  * Public exhibitor banners display within a consistent 3:1 layout, preserving the full image with centered scaling and background space when needed.
  * List cards continue displaying banners as cropped thumbnails to fill their card layout.
* **Documentation**
  * Added detailed guidance on banner dimensions and display behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->