### PR TITLE
Regenerate translation catalogs from current source strings

### DIFF
--- a/exhibition/locale/ar/LC_MESSAGES/django.po
+++ b/exhibition/locale/ar/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-29 10:33+0000\n"
+"POT-Creation-Date: 2026-09-11 11:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,595 +19,531 @@ msgstr ""
 "Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 "
 "&& n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
 
-#: exhibition/apps.py:14 exhibition/apps.py:17 exhibition/signals.py:157
-#: exhibition/templates/exhibitors/public_list.html:6
-#: exhibition/templates/exhibitors/public_list.html:14
-#: exhibition/templates/exhibitors/public_list.html:16
+#: apps.py:14 apps.py:17 signals.py:163 templates/exhibitors/public_list.html:6
+#: templates/exhibitors/public_list.html:14
+#: templates/exhibitors/public_list.html:16
 msgid "Exhibition"
 msgstr ""
 
-#: exhibition/apps.py:19
+#: apps.py:19
 msgid "This plugin enables to add and control exhibitors in eventyay"
 msgstr ""
 
-#: exhibition/filters.py:9
+#: filters.py:9
 msgid "Any"
 msgstr ""
 
-#: exhibition/filters.py:10
+#: filters.py:10
 msgid "Enabled"
 msgstr ""
 
-#: exhibition/filters.py:11 exhibition/templates/exhibitors/dashboard.html:127
+#: filters.py:11 templates/exhibitors/dashboard.html:127
 msgid "Disabled"
 msgstr ""
 
-#: exhibition/filters.py:15
+#: filters.py:15
 msgid "All types"
 msgstr ""
 
-#: exhibition/filters.py:16
+#: filters.py:16
 msgid "Exhibitor only"
 msgstr ""
 
-#: exhibition/filters.py:17
+#: filters.py:17
 msgid "Sponsor only"
 msgstr ""
 
-#: exhibition/filters.py:18 exhibition/templates/exhibitors/dashboard.html:89
-#: exhibition/templates/exhibitors/proposal_detail.html:95
-#: exhibition/templates/exhibitors/proposal_list.html:95
+#: filters.py:18 templates/exhibitors/dashboard.html:89
+#: templates/exhibitors/proposal_detail.html:95
+#: templates/exhibitors/proposal_list.html:95
 msgid "Exhibitor and sponsor"
 msgstr ""
 
-#: exhibition/filters.py:80 exhibition/filters.py:81
+#: filters.py:80 filters.py:81
 msgid "Search requests…"
 msgstr ""
 
-#: exhibition/filters.py:81
+#: filters.py:81
 msgid "Search requests"
 msgstr ""
 
-#: exhibition/filters.py:85 exhibition/templates/exhibitors/dashboard.html:75
-#: exhibition/templates/exhibitors/proposal_detail.html:85
-#: exhibition/templates/exhibitors/proposal_list.html:21
-#: exhibition/templates/exhibitors/public_proposal_list.html:12
+#: filters.py:85 templates/exhibitors/dashboard.html:75
+#: templates/exhibitors/proposal_detail.html:85
+#: templates/exhibitors/proposal_list.html:21
+#: templates/exhibitors/public_proposal_list.html:12
 msgid "State"
 msgstr ""
 
-#: exhibition/filters.py:86
+#: filters.py:86
 msgid "All states"
 msgstr ""
 
-#: exhibition/filters.py:90 exhibition/templates/exhibitors/dashboard.html:74
-#: exhibition/templates/exhibitors/proposal_detail.html:91
-#: exhibition/templates/exhibitors/proposal_list.html:62
+#: filters.py:90 templates/exhibitors/dashboard.html:74
+#: templates/exhibitors/proposal_detail.html:91
+#: templates/exhibitors/proposal_list.html:62
 msgid "Type"
 msgstr ""
 
-#: exhibition/filters.py:99 exhibition/filters.py:102
+#: filters.py:99 filters.py:102
 msgid "Search by name…"
 msgstr ""
 
-#: exhibition/filters.py:103
+#: filters.py:103
 msgid "Search requests by name"
 msgstr ""
 
-#: exhibition/filters.py:132 exhibition/filters.py:133
+#: filters.py:132 filters.py:133
 msgid "Search organizations…"
 msgstr ""
 
-#: exhibition/filters.py:133
+#: filters.py:133
 msgid "Search organizations"
 msgstr ""
 
-#: exhibition/filters.py:137
+#: filters.py:137
 msgid "Visibility"
 msgstr ""
 
-#: exhibition/filters.py:139
+#: filters.py:139
 msgid "All organizations"
 msgstr ""
 
-#: exhibition/filters.py:140 exhibition/forms.py:1512
-#: exhibition/templates/exhibitors/call_questions.html:30
+#: filters.py:140 forms.py:1553 templates/exhibitors/call_questions.html:30
 msgid "Active"
 msgstr ""
 
-#: exhibition/filters.py:141
+#: filters.py:141
 msgid "Inactive"
 msgstr ""
 
-#: exhibition/filters.py:146 exhibition/filters.py:207 exhibition/forms.py:207
-#: exhibition/forms.py:1410 exhibition/forms.py:1841
+#: filters.py:146 filters.py:207 forms.py:212 forms.py:1411 forms.py:1888
 msgid "Sponsor group"
 msgstr ""
 
-#: exhibition/filters.py:149 exhibition/filters.py:210
+#: filters.py:149 filters.py:210
 msgid "All groups"
 msgstr ""
 
-#: exhibition/filters.py:152 exhibition/templates/exhibitors/add.html:222
+#: filters.py:152 templates/exhibitors/add.html:226
 msgid "Lead scanning"
 msgstr ""
 
-#: exhibition/filters.py:157
+#: filters.py:157
 msgid "Lead access"
 msgstr ""
 
-#: exhibition/filters.py:162
+#: filters.py:162
 msgid "Voucher access"
 msgstr ""
 
-#: exhibition/filters.py:202 exhibition/filters.py:203
+#: filters.py:202 filters.py:203
 msgid "Search exhibitors…"
 msgstr ""
 
-#: exhibition/filters.py:203
+#: filters.py:203
 msgid "Search exhibitors"
 msgstr ""
 
-#: exhibition/filters.py:240 exhibition/filters.py:241
+#: filters.py:240 filters.py:241
 msgid "Search emails…"
 msgstr ""
 
-#: exhibition/filters.py:241
+#: filters.py:241
 msgid "Search emails"
 msgstr ""
 
-#: exhibition/forms.py:67
+#: forms.py:72
 #, python-format
 msgid "Times are in the event timezone: %(tz)s."
 msgstr ""
 
-#: exhibition/forms.py:128 exhibition/forms.py:139 exhibition/forms.py:933
-#: exhibition/forms.py:944
+#: forms.py:133 forms.py:144 forms.py:934 forms.py:945
 msgid "— No selection —"
 msgstr ""
 
-#: exhibition/forms.py:211
+#: forms.py:216
 msgid "Can view voucher redemptions"
 msgstr ""
 
-#: exhibition/forms.py:213 exhibition/forms.py:397
+#: forms.py:218 forms.py:402
 msgid ""
 "Lets this exhibitor or sponsor retrieve the attendees who redeemed vouchers "
 "issued to them. Separate from lead scanning, which covers attendees scanned "
 "at the booth."
 msgstr ""
 
-#: exhibition/forms.py:219
+#: forms.py:224
 msgid "Can view and export collected leads"
 msgstr ""
 
-#: exhibition/forms.py:221
+#: forms.py:226
 msgid ""
 "Lets this exhibitor retrieve the full list of leads they have already "
 "scanned. Turn this off to let them keep scanning without seeing the "
 "collected attendee data."
 msgstr ""
 
-#: exhibition/forms.py:226
+#: forms.py:231
 msgid "Lead scanning behavior"
 msgstr ""
 
-#: exhibition/forms.py:231
+#: forms.py:236
 msgid ""
 "Every attendee is one lead, even when scanned from multiple devices. Notes "
 "and ratings are shared between devices."
 msgstr ""
 
-#: exhibition/forms.py:238
+#: forms.py:243
 msgid ""
 "Every attendee is a new lead when scanned from a new device. Notes and "
 "ratings are specific to the device."
 msgstr ""
 
-#: exhibition/forms.py:251
+#: forms.py:256
 msgid "Comment"
 msgstr ""
 
-#: exhibition/forms.py:253
+#: forms.py:258
 msgid ""
 "The text entered in this field will not be visible to the user and is "
 "available for your convenience."
 msgstr ""
 
-#: exhibition/forms.py:258 exhibition/forms.py:1427 exhibition/views.py:505
+#: forms.py:263 forms.py:1428 views.py:544
 msgid "Booth ID"
 msgstr ""
 
-#: exhibition/forms.py:291 exhibition/forms.py:1027 exhibition/forms.py:1076
-#: exhibition/models.py:130
+#: forms.py:296 forms.py:1028 forms.py:1077 models.py:130
 msgid "Organization name"
 msgstr ""
 
-#: exhibition/forms.py:292 exhibition/forms.py:1030 exhibition/forms.py:1077
-#: exhibition/models.py:136
+#: forms.py:297 forms.py:1031 forms.py:1078 models.py:136
 msgid "Organization description"
 msgstr ""
 
-#: exhibition/forms.py:293 exhibition/forms.py:1078
+#: forms.py:298 forms.py:1079
 msgid "E-mail"
 msgstr ""
 
-#: exhibition/forms.py:294 exhibition/forms.py:1079 exhibition/models.py:139
+#: forms.py:299 forms.py:1080 models.py:139
 msgid "Contact page URL"
 msgstr ""
 
-#: exhibition/forms.py:295 exhibition/forms.py:1080 exhibition/models.py:140
+#: forms.py:300 forms.py:1081 models.py:140
 msgid "Promotional video URL"
 msgstr ""
 
-#: exhibition/forms.py:296 exhibition/forms.py:1081 exhibition/models.py:141
+#: forms.py:301 forms.py:1082 models.py:141
 msgid "Promotional slides"
 msgstr ""
 
-#: exhibition/forms.py:297 exhibition/forms.py:1082 exhibition/models.py:142
-#: exhibition/models.py:520
-#: exhibition/templates/exhibitors/proposal_detail.html:111
+#: forms.py:302 forms.py:1083 models.py:142 models.py:568
+#: templates/exhibitors/proposal_detail.html:111
 msgid "Logo"
 msgstr ""
 
-#: exhibition/forms.py:298 exhibition/forms.py:1083 exhibition/models.py:145
-#: exhibition/templates/exhibitors/proposal_detail.html:113
+#: forms.py:303 forms.py:1084 models.py:145
+#: templates/exhibitors/proposal_detail.html:113
 msgid "Header image"
 msgstr ""
 
-#: exhibition/forms.py:299 exhibition/forms.py:1084 exhibition/models.py:138
+#: forms.py:304 forms.py:1085 models.py:138
 msgid "Organization website"
 msgstr ""
 
-#: exhibition/forms.py:300
+#: forms.py:305
 msgid "Mark this partner as an exhibitor"
 msgstr ""
 
-#: exhibition/forms.py:301
+#: forms.py:306
 msgid "Mark this partner as an event sponsor"
 msgstr ""
 
-#: exhibition/forms.py:302 exhibition/forms.py:1036 exhibition/forms.py:1085
-#: exhibition/models.py:148 exhibition/models.py:522
+#: forms.py:307 forms.py:1037 forms.py:1086 models.py:148 models.py:570
 msgid "Preferred booth name"
 msgstr ""
 
-#: exhibition/forms.py:303
+#: forms.py:308
 msgid "Can scan attendee badges"
 msgstr ""
 
-#: exhibition/forms.py:307
+#: forms.py:312
 msgid ""
 "Lets this exhibitor sign in to the lead scanning app and scan attendees at "
 "their booth. Turn this off to block scanning entirely."
 msgstr ""
 
-#: exhibition/forms.py:348 exhibition/forms.py:1441
+#: forms.py:353 forms.py:1442
 msgid "No sponsor group"
 msgstr ""
 
-#: exhibition/forms.py:385
+#: forms.py:390
 msgid ""
 "Lets this exhibitor retrieve the attendees who redeemed vouchers issued to "
 "them. Separate from lead scanning, which covers attendees scanned at the "
 "booth."
 msgstr ""
 
-#: exhibition/forms.py:389
+#: forms.py:394
 msgid ""
 "Lets this sponsor retrieve the attendees who redeemed vouchers issued to "
 "them. Separate from lead scanning, which covers attendees scanned at the "
 "booth."
 msgstr ""
 
-#: exhibition/forms.py:393
+#: forms.py:398
 msgid ""
 "Lets this exhibitor and sponsor retrieve the attendees who redeemed vouchers "
 "issued to them. Separate from lead scanning, which covers attendees scanned "
 "at the booth."
 msgstr ""
 
-#: exhibition/forms.py:466 exhibition/forms.py:553 exhibition/forms.py:1361
-#: exhibition/forms.py:1375
+#: forms.py:471 forms.py:558 forms.py:1362 forms.py:1376 forms.py:1855
+#: forms.py:1924 forms.py:1930 forms.py:1932 forms.py:1934
 msgid "This field is required."
 msgstr ""
 
-#: exhibition/forms.py:511 exhibition/forms.py:516
+#: forms.py:516 forms.py:521
 msgid "Slides upload must be a PDF file."
 msgstr ""
 
-#: exhibition/forms.py:540
+#: forms.py:545
 msgid "A partner must be marked as an exhibitor, a sponsor, or both."
 msgstr ""
 
-#: exhibition/forms.py:615
+#: forms.py:620
 msgid "Devices to add"
 msgstr ""
 
-#: exhibition/forms.py:617
+#: forms.py:622
 msgid ""
 "How many new devices to provision now, in addition to any already listed "
 "above. Each device gets its own single-use setup token and QR code."
 msgstr ""
 
-#: exhibition/forms.py:627
-msgid "Select a product…"
+#: forms.py:635
+msgid "Vouchers to take from the pool"
 msgstr ""
 
-#: exhibition/forms.py:628
-msgid "Ticket product"
+#: forms.py:636
+msgid ""
+"Set to 0 to email the codes this partner already has without taking any more."
 msgstr ""
 
-#: exhibition/forms.py:629
-msgid "The product a redeemed voucher applies to."
-msgstr ""
-
-#: exhibition/forms.py:635
-msgid "Number of vouchers"
-msgstr ""
-
-#: exhibition/forms.py:640
-msgid "Maximum usages per voucher"
-msgstr ""
-
-#: exhibition/forms.py:645 exhibition/templates/exhibitors/vouchers.html:33
-#: exhibition/views.py:1995
-msgid "Price effect"
-msgstr ""
-
-#: exhibition/forms.py:651 exhibition/views.py:1996
-msgid "Value"
-msgstr ""
-
-#: exhibition/forms.py:652
-msgid "Amount or percentage, depending on the selected price effect."
-msgstr ""
-
-#: exhibition/forms.py:657 exhibition/templates/exhibitors/vouchers.html:35
-#: exhibition/views.py:1997
-msgid "Valid until"
-msgstr ""
-
-#: exhibition/forms.py:673
-msgid "Enter a value for the selected price effect."
-msgstr ""
-
-#: exhibition/forms.py:678 exhibition/models.py:295
-#: exhibition/templates/exhibitors/settings.html:205
+#: forms.py:647 models.py:326 templates/exhibitors/settings.html:289
 msgid "Level"
 msgstr ""
 
-#: exhibition/forms.py:685 exhibition/models.py:294
+#: forms.py:654 models.py:325
 msgid "Group name"
 msgstr ""
 
-#: exhibition/forms.py:718
+#: forms.py:677 models.py:225
+msgid "Exhibitor voucher pool"
+msgstr ""
+
+#: forms.py:678 models.py:232
+msgid "Sponsor voucher pool"
+msgstr ""
+
+#: forms.py:698
+msgid "— No pool selected —"
+msgstr ""
+
+#: forms.py:699
+msgid "— Use the exhibitor pool —"
+msgstr ""
+
+#: forms.py:719
 msgid "Enable call"
 msgstr ""
 
-#: exhibition/forms.py:719
+#: forms.py:720
 msgid "Hide call page after the deadline"
 msgstr ""
 
-#: exhibition/forms.py:720
+#: forms.py:721
 msgid "Make this call private (accessible only via a secret link)"
 msgstr ""
 
-#: exhibition/forms.py:724
+#: forms.py:725
 msgid ""
 "Turn the call on. Keep it enabled for private calls too, otherwise the "
 "secret link stops working."
 msgstr ""
 
-#: exhibition/forms.py:727
+#: forms.py:728
 msgid ""
 "The call page is not linked anywhere public and can only be opened with the "
 "secret link shown below."
 msgstr ""
 
-#: exhibition/forms.py:868
+#: forms.py:869
 msgid "Your answer"
 msgstr ""
 
-#: exhibition/forms.py:1024 exhibition/models.py:563
-#: exhibition/templates/exhibitors/proposal_detail.html:88
+#: forms.py:1025 models.py:611 templates/exhibitors/proposal_detail.html:88
 msgid "Language"
 msgstr ""
 
-#: exhibition/forms.py:1025
+#: forms.py:1026
 msgid "The language you are filling in this form with."
 msgstr ""
 
-#: exhibition/forms.py:1086 exhibition/models.py:151 exhibition/models.py:523
-#: exhibition/models.py:602
+#: forms.py:1087 models.py:151 models.py:571 models.py:650
 msgid "Message to the organizers"
 msgstr ""
 
-#: exhibition/forms.py:1149
+#: forms.py:1150
 msgid ""
 "The organization name is locked after acceptance. Contact the organizers to "
 "change it."
 msgstr ""
 
-#: exhibition/forms.py:1425
+#: forms.py:1426
 msgid "Approve as exhibitor"
 msgstr ""
 
-#: exhibition/forms.py:1426
+#: forms.py:1427
 msgid "Approve as sponsor"
 msgstr ""
 
-#: exhibition/forms.py:1428 exhibition/models.py:352 exhibition/models.py:596
-#: exhibition/models.py:966 exhibition/views.py:505
+#: forms.py:1429 models.py:383 models.py:644 models.py:1014 views.py:544
 msgid "Booth name"
 msgstr ""
 
-#: exhibition/forms.py:1429 exhibition/forms.py:1459 exhibition/models.py:607
+#: forms.py:1430 forms.py:1460 models.py:655
 msgid "Internal review notes"
 msgstr ""
 
-#: exhibition/forms.py:1470
+#: forms.py:1471
 msgid "Field label"
 msgstr ""
 
-#: exhibition/forms.py:1475 exhibition/forms.py:1510
+#: forms.py:1476 forms.py:1551
 msgid "Help text"
 msgstr ""
 
-#: exhibition/forms.py:1476
+#: forms.py:1477
 msgid "Shown below the field on the exhibitor form."
 msgstr ""
 
-#: exhibition/forms.py:1483
+#: forms.py:1484
 #, python-format
 msgid "Leave empty to use the default: %(label)s"
 msgstr ""
 
-#: exhibition/forms.py:1492
-msgid "Options"
-msgstr ""
-
-#: exhibition/forms.py:1493
-msgid "For choice fields, enter one option per line."
-msgstr ""
-
-#: exhibition/forms.py:1508
-msgid "Field type"
-msgstr ""
-
-#: exhibition/forms.py:1509 exhibition/models.py:878
-msgid "Custom question"
-msgstr ""
-
-#: exhibition/forms.py:1511
-#: exhibition/templates/exhibitors/call_questions.html:31
-#: exhibition/templates/exhibitors/call_questions.html:63
-msgid "Required"
-msgstr ""
-
-#: exhibition/forms.py:1535
+#: forms.py:1523
 msgid "Please provide at least one option for this question type."
 msgstr ""
 
-#: exhibition/forms.py:1576 exhibition/forms.py:1665
+#: forms.py:1549
+msgid "Field type"
+msgstr ""
+
+#: forms.py:1550 models.py:926
+msgid "Custom question"
+msgstr ""
+
+#: forms.py:1552 templates/exhibitors/call_questions.html:31
+#: templates/exhibitors/call_questions.html:63
+msgid "Required"
+msgstr ""
+
+#: forms.py:1583 forms.py:1672
 msgid "Choose social platform"
 msgstr ""
 
-#: exhibition/forms.py:1578 exhibition/forms.py:1667
+#: forms.py:1585 forms.py:1674
 msgid "Social platform"
 msgstr ""
 
-#: exhibition/forms.py:1582 exhibition/forms.py:1671
+#: forms.py:1589 forms.py:1678
 msgid "Profile or path"
 msgstr ""
 
-#: exhibition/forms.py:1596 exhibition/forms.py:1685
+#: forms.py:1603 forms.py:1692
 msgid "Profile, handle, or full URL"
 msgstr ""
 
-#: exhibition/forms.py:1616 exhibition/forms.py:1705
+#: forms.py:1623 forms.py:1712
 msgid "Please enter a profile, handle, or URL or remove this row."
 msgstr ""
 
-#: exhibition/forms.py:1622 exhibition/forms.py:1711
+#: forms.py:1629 forms.py:1718
 msgid "Please choose a social platform."
 msgstr ""
 
-#: exhibition/forms.py:1626 exhibition/forms.py:1715
+#: forms.py:1633 forms.py:1722
 msgid "Please enter a profile, handle, or URL."
 msgstr ""
 
-#: exhibition/forms.py:1648 exhibition/forms.py:1737
+#: forms.py:1655 forms.py:1744
 msgid "Link label"
 msgstr ""
 
-#: exhibition/forms.py:1654 exhibition/forms.py:1743
+#: forms.py:1661 forms.py:1750
 msgid "https://example.com"
 msgstr ""
 
-#: exhibition/forms.py:1807
+#: forms.py:1848
 msgid ""
 "Leave empty to keep this in the outbox until sent manually. Time is "
 "interpreted in the event timezone."
 msgstr ""
 
-#: exhibition/forms.py:1814 exhibition/forms.py:1877
+#: forms.py:1861 forms.py:1940
 msgid "The scheduled time must be in the future."
 msgstr ""
 
-#: exhibition/forms.py:1822
+#: forms.py:1869
 msgid "Exhibitors and sponsors"
 msgstr ""
 
-#: exhibition/forms.py:1823
+#: forms.py:1870
 msgid "Exhibitors only"
 msgstr ""
 
-#: exhibition/forms.py:1824
+#: forms.py:1871
 msgid "Sponsors only"
 msgstr ""
 
-#: exhibition/forms.py:1828
+#: forms.py:1875
 msgid "Application state"
 msgstr ""
 
-#: exhibition/forms.py:1836
+#: forms.py:1883
 msgid "Partner type"
 msgstr ""
 
-#: exhibition/forms.py:1844
+#: forms.py:1891
 msgid "Any sponsor group"
 msgstr ""
 
-#: exhibition/forms.py:1846 exhibition/models.py:1035 exhibition/models.py:1089
-#: exhibition/templates/exhibitors/_email_outbox_body.html:6
-#: exhibition/templates/exhibitors/_email_sent_body.html:6
+#: forms.py:1893 forms.py:1953 models.py:1084 models.py:1146
+#: templates/exhibitors/_email_outbox_body.html:6
+#: templates/exhibitors/_email_sent_body.html:6
 msgid "Subject"
 msgstr ""
 
-#: exhibition/forms.py:1848
+#: forms.py:1895
 msgid "Send at"
 msgstr ""
 
-#: exhibition/forms.py:1851
+#: forms.py:1898
 msgid "Leave empty to send immediately or save to the outbox."
 msgstr ""
 
-#: exhibition/forms.py:1859 exhibition/models.py:1036 exhibition/models.py:1090
+#: forms.py:1906 forms.py:1960 models.py:1085 models.py:1147
 msgid "Body"
 msgstr ""
 
-#: exhibition/forms.py:1885 exhibition/views.py:2576
-msgid "Request received (confirmation)"
-msgstr ""
-
-#: exhibition/forms.py:1886 exhibition/views.py:2577
-msgid "Request accepted"
-msgstr ""
-
-#: exhibition/forms.py:1887 exhibition/views.py:2578
-msgid "Request rejected"
-msgstr ""
-
-#: exhibition/forms.py:1888 exhibition/views.py:2579
-msgid "Exhibitor lead scanning key"
-msgstr ""
-
-#: exhibition/forms.py:1897
-#, python-format
-msgid "%(role)s — subject"
-msgstr ""
-
-#: exhibition/forms.py:1904
-#, python-format
-msgid "%(role)s — body"
-msgstr ""
-
-#: exhibition/mail.py:57
+#: mail.py:59
 #, python-brace-format
 msgid "We received your request for {event_name}"
 msgstr ""
 
-#: exhibition/mail.py:59
+#: mail.py:61
 #, python-brace-format
 msgid ""
 "Hello,\n"
@@ -622,12 +558,12 @@ msgid ""
 "The {event_name} team"
 msgstr ""
 
-#: exhibition/mail.py:69
+#: mail.py:71
 #, python-brace-format
 msgid "Your request for {event_name} has been accepted"
 msgstr ""
 
-#: exhibition/mail.py:71
+#: mail.py:73
 #, python-brace-format
 msgid ""
 "Hello,\n"
@@ -639,12 +575,12 @@ msgid ""
 "The {event_name} team"
 msgstr ""
 
-#: exhibition/mail.py:80
+#: mail.py:82
 #, python-brace-format
 msgid "Update on your request for {event_name}"
 msgstr ""
 
-#: exhibition/mail.py:82
+#: mail.py:84
 #, python-brace-format
 msgid ""
 "Hello,\n"
@@ -658,12 +594,12 @@ msgid ""
 "The {event_name} team"
 msgstr ""
 
-#: exhibition/mail.py:91
+#: mail.py:93
 #, python-brace-format
 msgid "Lead Scanning Access for {event_name}"
 msgstr ""
 
-#: exhibition/mail.py:93
+#: mail.py:95
 #, python-brace-format
 msgid ""
 "Hello {exhibitor_name},\n"
@@ -689,983 +625,1084 @@ msgid ""
 "The {event_name} Team"
 msgstr ""
 
-#: exhibition/mail.py:174
+#: mail.py:110
+#, python-brace-format
+msgid "Your vouchers for {event_name} — {exhibitor_name}"
+msgstr ""
+
+#: mail.py:112
+#, python-brace-format
+msgid ""
+"Dear {exhibitor_name},\n"
+"\n"
+"Thank you for participating in {event_name}. Please share the voucher codes "
+"below with your audience — anyone who uses one gets credited to you as a "
+"lead.\n"
+"\n"
+"{voucher_list}\n"
+"\n"
+"They can redeem a code on the event ticket shop at checkout.\n"
+"\n"
+"If you have any questions, please don't hesitate to reach out.\n"
+"\n"
+"Best regards,\n"
+"The {event_name} Team"
+msgstr ""
+
+#: mail.py:190
 msgid "This value will be replaced based on dynamic parameters."
 msgstr ""
 
-#: exhibition/models.py:137 exhibition/models.py:515
+#: mail.py:312
+#, python-format
+msgid "…and %(count)d more voucher code in the attached CSV file."
+msgid_plural "…and %(count)d more voucher codes in the attached CSV file."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+msgstr[5] ""
+
+#: models.py:137 models.py:563
 msgid "Contact email"
 msgstr ""
 
-#: exhibition/models.py:156
-#: exhibition/templates/exhibitors/proposal_detail.html:132
+#: models.py:156 templates/exhibitors/proposal_detail.html:132
 msgid "Social media"
 msgstr ""
 
-#: exhibition/models.py:161
-#: exhibition/templates/exhibitors/proposal_detail.html:140
+#: models.py:161 templates/exhibitors/proposal_detail.html:140
 msgid "Extra links"
 msgstr ""
 
-#: exhibition/models.py:216
+#: models.py:212
+msgid "Vouchers per exhibitor"
+msgstr ""
+
+#: models.py:226
+msgid ""
+"The voucher tag created under Tickets → Vouchers that exhibitors draw their "
+"codes from."
+msgstr ""
+
+#: models.py:233
+msgid "Leave empty to draw sponsor codes from the exhibitor pool as well."
+msgstr ""
+
+#: models.py:239
+msgid "Attach voucher list as CSV"
+msgstr ""
+
+#: models.py:240
+msgid ""
+"Adds a spreadsheet of the recipient's own voucher codes to the voucher email."
+msgstr ""
+
+#: models.py:247
 msgid "Call headline"
 msgstr ""
 
-#: exhibition/models.py:220
+#: models.py:251
 msgid "Call text"
 msgstr ""
 
-#: exhibition/models.py:225
+#: models.py:256
 msgid "Submission deadline"
 msgstr ""
 
-#: exhibition/models.py:298
+#: models.py:329
 msgid "Show this sponsor group on the front page."
 msgstr ""
 
-#: exhibition/models.py:314 exhibition/models.py:558
-#: exhibition/templates/exhibitors/dashboard.html:73
-#: exhibition/templates/exhibitors/exhibitor_info.html:69
-#: exhibition/templates/exhibitors/proposal_list.html:19
-#: exhibition/templates/exhibitors/public_proposal_list.html:11
-#: exhibition/views.py:505
+#: models.py:345 models.py:606 templates/exhibitors/dashboard.html:73
+#: templates/exhibitors/exhibitor_info.html:79
+#: templates/exhibitors/proposal_list.html:19
+#: templates/exhibitors/public_proposal_list.html:11 views.py:544
 msgid "Name"
 msgstr ""
 
-#: exhibition/models.py:315 exhibition/models.py:559
-#: exhibition/templates/exhibitors/proposal_detail.html:117
+#: models.py:346 models.py:607 templates/exhibitors/proposal_detail.html:117
 msgid "Description"
 msgstr ""
 
-#: exhibition/models.py:316 exhibition/models.py:419 exhibition/models.py:435
-#: exhibition/models.py:565 exhibition/models.py:815 exhibition/models.py:831
-#: exhibition/models.py:844
-#: exhibition/templates/exhibitors/proposal_detail.html:103
+#: models.py:347 models.py:467 models.py:483 models.py:613 models.py:863
+#: models.py:879 models.py:892 templates/exhibitors/proposal_detail.html:103
 msgid "URL"
 msgstr ""
 
-#: exhibition/models.py:317 exhibition/models.py:566
-#: exhibition/templates/exhibitors/proposal_detail.html:77
-#: exhibition/views.py:505
+#: models.py:348 models.py:614 templates/exhibitors/proposal_detail.html:77
+#: views.py:544
 msgid "Email"
 msgstr ""
 
-#: exhibition/models.py:318 exhibition/models.py:567
-#: exhibition/templates/exhibitors/proposal_detail.html:105
+#: models.py:349 models.py:615 templates/exhibitors/proposal_detail.html:105
 msgid "Contact URL"
 msgstr ""
 
-#: exhibition/models.py:319 exhibition/models.py:568
-#: exhibition/templates/exhibitors/proposal_detail.html:107
+#: models.py:350 models.py:616 templates/exhibitors/proposal_detail.html:107
 msgid "Video URL"
 msgstr ""
 
-#: exhibition/models.py:322 exhibition/models.py:571
-#: exhibition/templates/exhibitors/proposal_detail.html:109
+#: models.py:353 models.py:619 templates/exhibitors/proposal_detail.html:109
 msgid "Slides"
 msgstr ""
 
-#: exhibition/models.py:326 exhibition/models.py:575
+#: models.py:357 models.py:623
 msgid "Slides URL"
 msgstr ""
 
-#: exhibition/models.py:328 exhibition/models.py:577
+#: models.py:359 models.py:625
 msgid "Logo URL"
 msgstr ""
 
-#: exhibition/models.py:330 exhibition/models.py:579
+#: models.py:361 models.py:627
 msgid "Header image URL"
 msgstr ""
 
-#: exhibition/models.py:434 exhibition/models.py:830
+#: models.py:482 models.py:878
 msgid "Label"
 msgstr ""
 
-#: exhibition/models.py:445
+#: models.py:493
 msgid "draft"
 msgstr ""
 
-#: exhibition/models.py:446
+#: models.py:494
 msgid "submitted"
 msgstr ""
 
-#: exhibition/models.py:447
+#: models.py:495
 msgid "accepted"
 msgstr ""
 
-#: exhibition/models.py:448
+#: models.py:496
 msgid "rejected"
 msgstr ""
 
-#: exhibition/models.py:449
+#: models.py:497
 msgid "withdrawn"
 msgstr ""
 
-#: exhibition/models.py:514
+#: models.py:562
 msgid "Organization Description"
 msgstr ""
 
-#: exhibition/models.py:516
+#: models.py:564
 msgid "Organization Website"
 msgstr ""
 
-#: exhibition/models.py:517
+#: models.py:565
 msgid "Contact Page URL"
 msgstr ""
 
-#: exhibition/models.py:518
+#: models.py:566
 msgid "Promotional Video URL"
 msgstr ""
 
-#: exhibition/models.py:519
+#: models.py:567
 msgid "Promotional Slides"
 msgstr ""
 
-#: exhibition/models.py:521
+#: models.py:569
 msgid "Header Image"
 msgstr ""
 
-#: exhibition/models.py:524 exhibition/templates/exhibitors/add.html:29
-#: exhibition/templates/exhibitors/public_proposal_form.html:38
+#: models.py:572 templates/exhibitors/add.html:29
+#: templates/exhibitors/public_proposal_form.html:38
 msgid "Social Media"
 msgstr ""
 
-#: exhibition/models.py:525 exhibition/templates/exhibitors/add.html:92
-#: exhibition/templates/exhibitors/public_proposal_form.html:91
+#: models.py:573 templates/exhibitors/add.html:92
+#: templates/exhibitors/public_proposal_form.html:91
 msgid "Extra Links"
 msgstr ""
 
-#: exhibition/models.py:841
+#: models.py:889
 msgid "Number"
 msgstr ""
 
-#: exhibition/models.py:842
+#: models.py:890
 msgid "Text (one line)"
 msgstr ""
 
-#: exhibition/models.py:843
+#: models.py:891
 msgid "Multiline text"
 msgstr ""
 
-#: exhibition/models.py:845
+#: models.py:893
 msgid "Email address"
 msgstr ""
 
-#: exhibition/models.py:846
+#: models.py:894
 msgid "Confirm Checkbox"
 msgstr ""
 
-#: exhibition/models.py:847
+#: models.py:895
 msgid "Radio button (Choose one option)"
 msgstr ""
 
-#: exhibition/models.py:848
+#: models.py:896
 msgid "Dropdown (Choose one option)"
 msgstr ""
 
-#: exhibition/models.py:849
+#: models.py:897
 msgid "Checkbox (Choose one or several options)"
 msgstr ""
 
-#: exhibition/models.py:850
+#: models.py:898
 msgid "File upload"
 msgstr ""
 
-#: exhibition/models.py:851
+#: models.py:899
 msgid "Date"
 msgstr ""
 
-#: exhibition/models.py:852
+#: models.py:900
 msgid "Time"
 msgstr ""
 
-#: exhibition/models.py:853
+#: models.py:901
 msgid "Date and time"
 msgstr ""
 
-#: exhibition/models.py:854
+#: models.py:902
 msgid "Country code (ISO 3166-1 alpha-2)"
 msgstr ""
 
-#: exhibition/models.py:855
+#: models.py:903
 msgid "Phone number"
 msgstr ""
 
-#: exhibition/models.py:883
+#: models.py:931
 msgid "help text"
 msgstr ""
 
-#: exhibition/models.py:885 exhibition/templates/exhibitors/add.html:29
-#: exhibition/templates/exhibitors/add.html:92
-#: exhibition/templates/exhibitors/public_proposal_form.html:38
-#: exhibition/templates/exhibitors/public_proposal_form.html:91
+#: models.py:933 templates/exhibitors/add.html:29
+#: templates/exhibitors/add.html:92
+#: templates/exhibitors/public_proposal_form.html:38
+#: templates/exhibitors/public_proposal_form.html:91
 msgid "required"
 msgstr ""
 
-#: exhibition/models.py:886
+#: models.py:934
 msgid "active"
 msgstr ""
 
-#: exhibition/models.py:906
+#: models.py:954
 msgid "Response"
 msgstr ""
 
-#: exhibition/models.py:938
+#: models.py:986
 msgid "Yes"
 msgstr ""
 
-#: exhibition/models.py:940
+#: models.py:988
 msgid "No"
 msgstr ""
 
-#: exhibition/models.py:1034
-#: exhibition/templates/exhibitors/_email_outbox_body.html:5
-#: exhibition/templates/exhibitors/_email_sent_body.html:5
+#: models.py:1083 templates/exhibitors/_email_outbox_body.html:5
+#: templates/exhibitors/_email_sent_body.html:5
 msgid "Recipient"
 msgstr ""
 
-#: exhibition/models.py:1045
+#: models.py:1101
 msgid "Queued email"
 msgstr ""
 
-#: exhibition/models.py:1046
+#: models.py:1102
 msgid "Queued emails"
 msgstr ""
 
-#: exhibition/models.py:1088
+#: models.py:1145
 msgid "Template name"
 msgstr ""
 
-#: exhibition/models.py:1095
+#: models.py:1152
 msgid "Custom email template"
 msgstr ""
 
-#: exhibition/models.py:1096
+#: models.py:1153
 msgid "Custom email templates"
 msgstr ""
 
-#: exhibition/signals.py:75
+#: signals.py:81
 msgid "Screen and evaluate exhibitor and sponsor requests for the event."
 msgstr ""
 
-#: exhibition/signals.py:76
+#: signals.py:82
 msgid "Request Review Dashboard"
 msgstr ""
 
-#: exhibition/signals.py:80
+#: signals.py:86
 msgid ""
 "Manage exhibitors and sponsors, maintain booth details, and create partner "
 "profiles for the event."
 msgstr ""
 
-#: exhibition/signals.py:82
+#: signals.py:88
 msgid "Exhibitors & Sponsors Dashboard"
 msgstr ""
 
-#: exhibition/signals.py:88 exhibition/templates/exhibitors/base.html:5
-#: exhibition/templates/exhibitors/base.html:125
-#: exhibition/templates/exhibitors/exhibitor_info.html:4
-#: exhibition/templates/exhibitors/exhibitor_info.html:15
+#: signals.py:94 templates/exhibitors/base.html:6
+#: templates/exhibitors/base.html:136
+#: templates/exhibitors/exhibitor_info.html:4
+#: templates/exhibitors/exhibitor_info.html:15
 msgid "Exhibitors & Sponsors"
 msgstr ""
 
-#: exhibition/signals.py:90
+#: signals.py:96
 msgid "Go to"
 msgstr ""
 
-#: exhibition/signals.py:166 exhibition/templates/exhibitors/call_base.html:4
-#: exhibition/templates/exhibitors/call_base.html:7
-#: exhibition/templates/exhibitors/public_call.html:7
-#: exhibition/templates/exhibitors/settings.html:8
-#: exhibition/templates/exhibitors/settings.html:25
+#: signals.py:172 templates/exhibitors/call_base.html:4
+#: templates/exhibitors/call_base.html:7
+#: templates/exhibitors/public_call.html:7 templates/exhibitors/settings.html:8
+#: templates/exhibitors/settings.html:27
 msgid "Call for Exhibitors"
 msgstr ""
 
-#: exhibition/signals.py:207 exhibition/signals.py:231
+#: signals.py:213 signals.py:237
 msgid "Acme Corp"
 msgstr ""
 
-#: exhibition/signals.py:225
+#: signals.py:231
 msgid "Jane Doe"
 msgstr ""
 
-#: exhibition/signals.py:293 exhibition/templates/exhibitors/base.html:62
-#: exhibition/templates/exhibitors/proposal_list.html:5
-#: exhibition/templates/exhibitors/proposal_list.html:15
+#: signals.py:305 templates/exhibitors/base.html:73
+#: templates/exhibitors/proposal_list.html:5
+#: templates/exhibitors/proposal_list.html:15
 msgid "Exhibition requests"
 msgstr ""
 
-#: exhibition/signals.py:298
+#: signals.py:310
 msgid "Exhibition request approved."
 msgstr ""
 
-#: exhibition/signals.py:299
+#: signals.py:311
 msgid "Exhibition request rejected."
 msgstr ""
 
-#: exhibition/signals.py:300
+#: signals.py:312
 msgid "Exhibition request withdrawn."
 msgstr ""
 
-#: exhibition/signals.py:301
+#: signals.py:313
 msgid "Exhibition request reopened for review."
 msgstr ""
 
-#: exhibition/signals.py:302
+#: signals.py:314
 msgid "Exhibition request changed."
 msgstr ""
 
-#: exhibition/signals.py:303
+#: signals.py:315
 msgid "Organization profile created from an approved request."
 msgstr ""
 
-#: exhibition/signals.py:304
+#: signals.py:316
 msgid "Organization profile reactivated after re-approval."
 msgstr ""
 
-#: exhibition/signals.py:305
+#: signals.py:317
 msgid "Organization profile updated from the submitter's changes."
 msgstr ""
 
-#: exhibition/signals.py:306
+#: signals.py:318
 msgid "Organization profile created."
 msgstr ""
 
-#: exhibition/signals.py:307
+#: signals.py:319
 msgid "Organization profile changed."
 msgstr ""
 
-#: exhibition/signals.py:308
+#: signals.py:320
 msgid "Organization profile deleted."
 msgstr ""
 
-#: exhibition/signals.py:309
+#: signals.py:321
 msgid "Exhibition settings changed."
 msgstr ""
 
-#: exhibition/signals.py:310
+#: signals.py:322
 msgid "Call for exhibitors settings changed."
 msgstr ""
 
-#: exhibition/signals.py:311
+#: signals.py:323
 msgid "Private call link regenerated."
 msgstr ""
 
-#: exhibition/signals.py:312
+#: signals.py:324
 msgid "Sponsor group created."
 msgstr ""
 
-#: exhibition/signals.py:313
+#: signals.py:325
 msgid "Sponsor group changed."
 msgstr ""
 
-#: exhibition/signals.py:314 exhibition/views.py:457
+#: signals.py:326 views.py:496
 msgid "Sponsor group deleted."
 msgstr ""
 
-#: exhibition/signals.py:315
+#: signals.py:327
 msgid "Exhibitor form question created."
 msgstr ""
 
-#: exhibition/signals.py:316
+#: signals.py:328
 msgid "Exhibitor form question changed."
 msgstr ""
 
-#: exhibition/signals.py:317
+#: signals.py:329
 msgid "Exhibitor form question deleted."
 msgstr ""
 
-#: exhibition/signals.py:318
+#: signals.py:330
 msgid "Email sent."
 msgstr ""
 
-#: exhibition/signals.py:337
+#: signals.py:349
 #, python-brace-format
 msgid "Updated: {fields}."
 msgstr ""
 
-#: exhibition/signals.py:360
+#: signals.py:372
 #, python-brace-format
 msgid "State changed from {old} to {new}."
 msgstr ""
 
-#: exhibition/signals.py:382
+#: signals.py:394
 #, python-brace-format
 msgid "Exhibition request {val}"
 msgstr ""
 
-#: exhibition/signals.py:391
+#: signals.py:403
 #, python-brace-format
 msgid "Organization profile {val}"
 msgstr ""
 
-#: exhibition/signals.py:400
+#: signals.py:412
 #, python-brace-format
 msgid "Exhibitor form question {val}"
 msgstr ""
 
-#: exhibition/signals.py:409
+#: signals.py:421
 #, python-brace-format
 msgid "Sponsor group {val}"
 msgstr ""
 
-#: exhibition/social_links.py:36
+#: social_links.py:36
 msgid "Facebook"
 msgstr ""
 
-#: exhibition/social_links.py:43
+#: social_links.py:43
 msgid "Flickr"
 msgstr ""
 
-#: exhibition/social_links.py:50
+#: social_links.py:50
 msgid "GitHub"
 msgstr ""
 
-#: exhibition/social_links.py:57
+#: social_links.py:57
 msgid "GitLab"
 msgstr ""
 
-#: exhibition/social_links.py:64
+#: social_links.py:64
 msgid "Gitter"
 msgstr ""
 
-#: exhibition/social_links.py:71
+#: social_links.py:71
 msgid "Google Groups"
 msgstr ""
 
-#: exhibition/social_links.py:78
+#: social_links.py:78
 msgid "Instagram"
 msgstr ""
 
-#: exhibition/social_links.py:85
+#: social_links.py:85
 msgid "LinkedIn"
 msgstr ""
 
-#: exhibition/social_links.py:92
+#: social_links.py:92
 msgid "Mastodon"
 msgstr ""
 
-#: exhibition/social_links.py:99
+#: social_links.py:99
 msgid "Patreon"
 msgstr ""
 
-#: exhibition/social_links.py:106
+#: social_links.py:106
 msgid "Telegram"
 msgstr ""
 
-#: exhibition/social_links.py:113
+#: social_links.py:113
 msgid "Vimeo"
 msgstr ""
 
-#: exhibition/social_links.py:120
+#: social_links.py:120
 msgid "VK"
 msgstr ""
 
-#: exhibition/social_links.py:127
+#: social_links.py:127
 msgid "Weibo"
 msgstr ""
 
-#: exhibition/social_links.py:134
+#: social_links.py:134
 msgid "X"
 msgstr ""
 
-#: exhibition/social_links.py:141
+#: social_links.py:141
 msgid "Xing"
 msgstr ""
 
-#: exhibition/social_links.py:148
+#: social_links.py:148
 msgid "YouTube"
 msgstr ""
 
-#: exhibition/social_links.py:155
+#: social_links.py:155
 msgid "YouTube Privacy"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:7
+#: templates/exhibitors/_email_outbox_body.html:7
 msgid "Created"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:14
+#: templates/exhibitors/_email_outbox_body.html:14
 msgid "Send selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:17
+#: templates/exhibitors/_email_outbox_body.html:17
 msgid "Discard selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:20
+#: templates/exhibitors/_email_outbox_body.html:20
 msgid "Send all"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:23
+#: templates/exhibitors/_email_outbox_body.html:23
 msgid "Discard all"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:35
+#: templates/exhibitors/_email_outbox_body.html:35
 msgid "Scheduled"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:36
-#: exhibition/templates/exhibitors/proposal_list.html:65
+#: templates/exhibitors/_email_outbox_body.html:36
+#: templates/exhibitors/proposal_list.html:65
 msgid "Actions"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:67
-msgid "Send this email"
+#: templates/exhibitors/_email_outbox_body.html:68
+msgid "Send"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:73
-msgid "Edit this email"
+#: templates/exhibitors/_email_outbox_body.html:75
+#: templates/exhibitors/_partner_row.html:54
+#: templates/exhibitors/call_questions.html:73
+#: templates/exhibitors/call_questions.html:76
+#: templates/exhibitors/dashboard.html:120
+#: templates/exhibitors/email_compose.html:55
+#: templates/exhibitors/email_custom_template_form.html:30
+#: templates/exhibitors/email_templates.html:50
+#: templates/exhibitors/email_templates.html:97
+#: templates/exhibitors/public_proposal_list.html:32
+#: templates/exhibitors/settings.html:59
+msgid "Edit"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:79
-msgid "Discard this email"
+#: templates/exhibitors/_email_outbox_body.html:82
+#: templates/exhibitors/email_bulk_discard.html:30
+#: templates/exhibitors/email_delete.html:31
+msgid "Discard"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:91
-#: exhibition/templates/exhibitors/_email_sent_body.html:34
+#: templates/exhibitors/_email_outbox_body.html:95
+#: templates/exhibitors/_email_sent_body.html:35
 msgid "No emails match your search."
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:93
+#: templates/exhibitors/_email_outbox_body.html:97
 msgid "The outbox is empty."
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_sent_body.html:7
-#: exhibition/templates/exhibitors/base.html:105
+#: templates/exhibitors/_email_sent_body.html:7
+#: templates/exhibitors/_partner_row.html:45 templates/exhibitors/base.html:116
 msgid "Sent"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_sent_body.html:36
+#: templates/exhibitors/_email_sent_body.html:37
 msgid "No emails have been sent yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:12
-#: exhibition/templates/exhibitors/public_list.html:29
+#: templates/exhibitors/_filter_form.html:12
+#: templates/exhibitors/public_list.html:29
 msgid "Search"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:18
-#: exhibition/templates/exhibitors/_filter_form.html:20
+#: templates/exhibitors/_filter_form.html:18
+#: templates/exhibitors/_filter_form.html:21
 msgid "Clear filters"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:29
+#: templates/exhibitors/_filter_form.html:30
 msgid "Filters"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:50
+#: templates/exhibitors/_filter_form.html:51
 msgid "Apply filters"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:5
+#: templates/exhibitors/_image_preview_dialog.html:11
+msgid "Close preview"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:5
 #, python-format
 msgid "Select %(name)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:33
+#: templates/exhibitors/_partner_row.html:33
 msgid "Untitled"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:40
+#: templates/exhibitors/_partner_row.html:40
+msgid "Waiting in the outbox"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:41
+msgid "In outbox"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:44
+#, python-format
+msgid "Last sent %(sent)s"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:48
+msgid "Not sent"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:55
 msgid "Copied!"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:40
+#: templates/exhibitors/_partner_row.html:55
 msgid "Copy failed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:40
+#: templates/exhibitors/_partner_row.html:55
 msgid "Key"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:41
-#: exhibition/templates/exhibitors/add.html:231
-#: exhibition/templates/exhibitors/vouchers.html:5
+#: templates/exhibitors/_partner_row.html:56 templates/exhibitors/add.html:235
+#: templates/exhibitors/base.html:42
+#: templates/exhibitors/exhibitor_info.html:95
+#: templates/exhibitors/exhibitor_info.html:125
+#: templates/exhibitors/vouchers.html:5 views.py:2933
 msgid "Vouchers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:42
-#: exhibition/templates/exhibitors/devices.html:5
+#: templates/exhibitors/_partner_row.html:57
+#: templates/exhibitors/devices.html:5
 msgid "Lead-scanning devices"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:45
+#: templates/exhibitors/_partner_row.html:58
+#: templates/exhibitors/call_question_delete.html:19
+#: templates/exhibitors/call_questions.html:74
+#: templates/exhibitors/delete.html:19
+#: templates/exhibitors/email_custom_template_delete.html:19
+#: templates/exhibitors/settings.html:335
+msgid "Delete"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:60
 msgid "Move"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_sort_header.html:7
+#: templates/exhibitors/_sort_header.html:7
 msgid "Sort ascending"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_sort_header.html:10
+#: templates/exhibitors/_sort_header.html:10
 msgid "Sort descending"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:24
+#: templates/exhibitors/add.html:24
 msgid "Profile"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:29
-#: exhibition/templates/exhibitors/add.html:92
-#: exhibition/templates/exhibitors/call_questions.html:62
-#: exhibition/templates/exhibitors/settings.html:50
+#: templates/exhibitors/add.html:29 templates/exhibitors/add.html:92
+#: templates/exhibitors/call_questions.html:62
+#: templates/exhibitors/settings.html:54
 msgid "Optional"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:80
-#: exhibition/templates/exhibitors/public_proposal_form.html:79
+#: templates/exhibitors/add.html:80
+#: templates/exhibitors/public_proposal_form.html:79
 msgid "Add social media link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:137
-#: exhibition/templates/exhibitors/public_proposal_form.html:120
+#: templates/exhibitors/add.html:137
+#: templates/exhibitors/public_proposal_form.html:120
 msgid "Add extra link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:157
-#: exhibition/templates/exhibitors/add.html:160
-#: exhibition/templates/exhibitors/public_proposal_form.html:140
-#: exhibition/templates/exhibitors/public_proposal_form.html:143
+#: templates/exhibitors/add.html:157 templates/exhibitors/add.html:161
+#: templates/exhibitors/public_proposal_form.html:140
+#: templates/exhibitors/public_proposal_form.html:144
 msgid "Logo preview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:162
-#: exhibition/templates/exhibitors/add.html:180
-#: exhibition/templates/exhibitors/public_proposal_form.html:145
-#: exhibition/templates/exhibitors/public_proposal_form.html:163
+#: templates/exhibitors/add.html:164 templates/exhibitors/add.html:184
+#: templates/exhibitors/public_proposal_form.html:147
+#: templates/exhibitors/public_proposal_form.html:167
 msgid "We could not load this image preview."
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:175
-#: exhibition/templates/exhibitors/add.html:178
-#: exhibition/templates/exhibitors/public_proposal_form.html:158
-#: exhibition/templates/exhibitors/public_proposal_form.html:161
+#: templates/exhibitors/add.html:177 templates/exhibitors/add.html:181
+#: templates/exhibitors/public_proposal_form.html:160
+#: templates/exhibitors/public_proposal_form.html:164
 msgid "Header image preview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:196
+#: templates/exhibitors/add.html:200
 msgid "Organizer only"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:237
+#: templates/exhibitors/add.html:241
 msgid "Internal notes"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:244
-#: exhibition/templates/exhibitors/email_edit.html:38
-#: exhibition/templates/exhibitors/public_proposal_form.html:182
-#: exhibition/templates/exhibitors/public_proposal_form.html:186
+#: templates/exhibitors/add.html:248 templates/exhibitors/email_edit.html:38
+#: templates/exhibitors/public_proposal_form.html:186
+#: templates/exhibitors/public_proposal_form.html:190
 msgid "Save changes"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:246
-#: exhibition/templates/exhibitors/call_default_field_form.html:21
-#: exhibition/templates/exhibitors/call_question_form.html:30
-#: exhibition/templates/exhibitors/call_questions.html:96
-#: exhibition/templates/exhibitors/email_custom_template_form.html:51
-#: exhibition/templates/exhibitors/email_templates.html:123
-#: exhibition/templates/exhibitors/proposal_detail.html:188
-#: exhibition/templates/exhibitors/settings.html:85
-#: exhibition/templates/exhibitors/settings.html:170
-#: exhibition/templates/exhibitors/settings.html:269
+#: templates/exhibitors/add.html:250
+#: templates/exhibitors/call_default_field_form.html:21
+#: templates/exhibitors/call_question_form.html:114
+#: templates/exhibitors/call_questions.html:96
+#: templates/exhibitors/email_custom_template_form.html:51
+#: templates/exhibitors/email_templates.html:123
+#: templates/exhibitors/proposal_detail.html:188
+#: templates/exhibitors/settings.html:89 templates/exhibitors/settings.html:217
+#: templates/exhibitors/settings.html:250
+#: templates/exhibitors/settings.html:359
 msgid "Save"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:255
-#: exhibition/templates/exhibitors/call_default_field_form.html:23
-#: exhibition/templates/exhibitors/call_default_field_reset.html:24
-#: exhibition/templates/exhibitors/call_question_delete.html:21
-#: exhibition/templates/exhibitors/call_question_form.html:32
-#: exhibition/templates/exhibitors/delete.html:24
-#: exhibition/templates/exhibitors/email_bulk_discard.html:27
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:21
-#: exhibition/templates/exhibitors/email_custom_template_form.html:53
-#: exhibition/templates/exhibitors/email_delete.html:28
-#: exhibition/templates/exhibitors/proposal_list.html:174
-#: exhibition/templates/exhibitors/public_proposal_form.html:176
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:16
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:21
-#: exhibition/templates/exhibitors/settings.html:194
-#: exhibition/templates/exhibitors/settings.html:270
+#: templates/exhibitors/add.html:259
+#: templates/exhibitors/call_default_field_form.html:23
+#: templates/exhibitors/call_default_field_reset.html:24
+#: templates/exhibitors/call_question_delete.html:21
+#: templates/exhibitors/call_question_form.html:116
+#: templates/exhibitors/delete.html:24
+#: templates/exhibitors/email_bulk_discard.html:27
+#: templates/exhibitors/email_custom_template_delete.html:21
+#: templates/exhibitors/email_custom_template_form.html:53
+#: templates/exhibitors/email_delete.html:28
+#: templates/exhibitors/proposal_list.html:175
+#: templates/exhibitors/public_proposal_form.html:180
+#: templates/exhibitors/public_proposal_reinstate.html:16
+#: templates/exhibitors/public_proposal_withdraw.html:21
+#: templates/exhibitors/settings.html:278
+#: templates/exhibitors/settings.html:360
+#: templates/exhibitors/voucher_bulk_send.html:96
 msgid "Cancel"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:262
-#: exhibition/templates/exhibitors/proposal_detail.html:208
+#: templates/exhibitors/add.html:266
+#: templates/exhibitors/proposal_detail.html:208
 msgid "History"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:11
+#: templates/exhibitors/base.html:17
 msgid "Overview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:18
-#: exhibition/templates/exhibitors/call_questions.html:33
+#: templates/exhibitors/base.html:24
+#: templates/exhibitors/call_questions.html:33
 msgid "Settings"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:26
-#: exhibition/templates/exhibitors/base.html:70
-#: exhibition/templates/exhibitors/dashboard.html:21
-#: exhibition/templates/exhibitors/exhibitor_info.html:4
-#: exhibition/templates/exhibitors/exhibitor_info.html:15
+#: templates/exhibitors/base.html:32 templates/exhibitors/base.html:81
+#: templates/exhibitors/dashboard.html:21
+#: templates/exhibitors/exhibitor_info.html:4
+#: templates/exhibitors/exhibitor_info.html:15
 msgid "Exhibitors"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:31
-#: exhibition/templates/exhibitors/base.html:76
-#: exhibition/templates/exhibitors/dashboard.html:29
-#: exhibition/templates/exhibitors/exhibitor_info.html:4
-#: exhibition/templates/exhibitors/exhibitor_info.html:15
+#: templates/exhibitors/base.html:37 templates/exhibitors/base.html:87
+#: templates/exhibitors/dashboard.html:29
+#: templates/exhibitors/exhibitor_info.html:4
+#: templates/exhibitors/exhibitor_info.html:15
 msgid "Sponsors"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:39
-#: exhibition/templates/exhibitors/dashboard.html:117
+#: templates/exhibitors/base.html:50 templates/exhibitors/dashboard.html:117
 msgid "Call for exhibitors"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:47
+#: templates/exhibitors/base.html:58
 msgid "Content"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:52
-#: exhibition/templates/exhibitors/call_questions.html:5
-#: exhibition/templates/exhibitors/call_questions.html:16
+#: templates/exhibitors/base.html:63 templates/exhibitors/call_questions.html:5
+#: templates/exhibitors/call_questions.html:16
 msgid "Exhibitor form"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:85
+#: templates/exhibitors/base.html:96
 msgid "Message center"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:94
+#: templates/exhibitors/base.html:105
 msgid "Compose"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:99
+#: templates/exhibitors/base.html:110
 msgid "Outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:111
+#: templates/exhibitors/base.html:122
 msgid "Templates"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:130
+#: templates/exhibitors/base.html:141
 msgid "Home"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:134
+#: templates/exhibitors/base.html:145
 msgid "Tickets"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:138
+#: templates/exhibitors/base.html:149
 msgid "Talks"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:143
+#: templates/exhibitors/base.html:154
 msgid "Access videos related to this event"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:144
+#: templates/exhibitors/base.html:155
 msgid "Videos"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_form.html:5
-#: exhibition/templates/exhibitors/call_default_field_form.html:8
-#: exhibition/templates/exhibitors/call_question_form.html:11
-#: exhibition/templates/exhibitors/call_question_form.html:14
+#: templates/exhibitors/call_default_field_form.html:5
+#: templates/exhibitors/call_default_field_form.html:8
+#: templates/exhibitors/call_question_form.html:14
+#: templates/exhibitors/call_question_form.html:17
 msgid "Form field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:4
-#: exhibition/templates/exhibitors/call_default_field_reset.html:7
+#: templates/exhibitors/call_default_field_reset.html:4
+#: templates/exhibitors/call_default_field_reset.html:7
 msgid "Reset form field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:14
+#: templates/exhibitors/call_default_field_reset.html:14
 #, python-format
 msgid ""
 "Are you sure you want to reset \"%(label)s\" back to the default "
 "\"%(default_label)s\"?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:19
+#: templates/exhibitors/call_default_field_reset.html:19
 msgid ""
 "This clears the custom label and help text. Default fields are part of the "
 "form and cannot be deleted; turn the field off with the Active toggle to "
 "hide it."
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:22
-#: exhibition/templates/exhibitors/public_list.html:32
+#: templates/exhibitors/call_default_field_reset.html:22
 msgid "Reset"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_question_delete.html:4
-#: exhibition/templates/exhibitors/call_question_delete.html:7
+#: templates/exhibitors/call_question_delete.html:4
+#: templates/exhibitors/call_question_delete.html:7
 msgid "Delete form field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_question_delete.html:14
+#: templates/exhibitors/call_question_delete.html:14
 #, python-format
 msgid "Are you sure you want to delete the question \"%(question)s\"?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_question_delete.html:19
-#: exhibition/templates/exhibitors/call_questions.html:74
-#: exhibition/templates/exhibitors/delete.html:19
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:19
-msgid "Delete"
+#: templates/exhibitors/call_question_form.html:31
+msgid "Answer options"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:23
+#: templates/exhibitors/call_question_form.html:34
+msgid "Only applicable if you choose a choice field type above."
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:48
+#, python-format
+msgid "Answer option %(id)s"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:56
+#: templates/exhibitors/call_question_form.html:58
+#: templates/exhibitors/call_question_form.html:87
+#: templates/exhibitors/call_question_form.html:89
+msgid "Move option up"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:60
+#: templates/exhibitors/call_question_form.html:62
+#: templates/exhibitors/call_question_form.html:91
+#: templates/exhibitors/call_question_form.html:93
+msgid "Move option down"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:64
+#: templates/exhibitors/call_question_form.html:66
+#: templates/exhibitors/call_question_form.html:95
+#: templates/exhibitors/call_question_form.html:97
+msgid "Delete option"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:81
+msgid "New answer option"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:106
+msgid "Add a new option"
+msgstr ""
+
+#: templates/exhibitors/call_questions.html:23
 msgid "Form fields"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:24
+#: templates/exhibitors/call_questions.html:24
 msgid ""
 "Choose which fields are shown on the exhibitor form and drag any row to "
 "reorder it."
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:29
-#: exhibition/templates/exhibitors/proposal_detail.html:38
+#: templates/exhibitors/call_questions.html:29
+#: templates/exhibitors/proposal_detail.html:38
 msgid "Field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:32
+#: templates/exhibitors/call_questions.html:32
 msgid "Answers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:42
+#: templates/exhibitors/call_questions.html:42
 msgid "Custom"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:48
+#: templates/exhibitors/call_questions.html:48
 #, python-format
 msgid "Toggle active state for %(field)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:61
+#: templates/exhibitors/call_questions.html:61
 #, python-format
 msgid "Required status for %(field)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:73
-#: exhibition/templates/exhibitors/call_questions.html:76
-#: exhibition/templates/exhibitors/dashboard.html:120
-#: exhibition/templates/exhibitors/email_compose.html:55
-#: exhibition/templates/exhibitors/email_custom_template_form.html:30
-#: exhibition/templates/exhibitors/email_templates.html:50
-#: exhibition/templates/exhibitors/email_templates.html:97
-#: exhibition/templates/exhibitors/public_proposal_list.html:32
-#: exhibition/templates/exhibitors/settings.html:55
-msgid "Edit"
-msgstr ""
-
-#: exhibition/templates/exhibitors/call_questions.html:77
+#: templates/exhibitors/call_questions.html:77
 msgid "Reset to default"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:79
+#: templates/exhibitors/call_questions.html:79
 msgid "Move field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:90
+#: templates/exhibitors/call_questions.html:90
 msgid "New custom field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:5
-#: exhibition/templates/exhibitors/dashboard.html:9
+#: templates/exhibitors/dashboard.html:5 templates/exhibitors/dashboard.html:9
 msgid "Exhibition overview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:39
+#: templates/exhibitors/dashboard.html:39
 msgid "Requests awaiting review"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:48
+#: templates/exhibitors/dashboard.html:48
 msgid "Emails in outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:61
+#: templates/exhibitors/dashboard.html:61
 msgid "Recent requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:64
+#: templates/exhibitors/dashboard.html:64
 msgid "View all"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:76
+#: templates/exhibitors/dashboard.html:76
 msgid "Submitted"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:91
-#: exhibition/templates/exhibitors/proposal_detail.html:97
-#: exhibition/templates/exhibitors/proposal_list.html:97
+#: templates/exhibitors/dashboard.html:91
+#: templates/exhibitors/proposal_detail.html:97
+#: templates/exhibitors/proposal_list.html:97
 msgid "Sponsor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:93
-#: exhibition/templates/exhibitors/proposal_detail.html:99
-#: exhibition/templates/exhibitors/proposal_list.html:99
+#: templates/exhibitors/dashboard.html:93
+#: templates/exhibitors/proposal_detail.html:99
+#: templates/exhibitors/proposal_list.html:99
 msgid "Exhibitor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:105
+#: templates/exhibitors/dashboard.html:105
 msgid "No requests have been submitted yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:128
+#: templates/exhibitors/dashboard.html:128
 msgid "The call is not published, so nobody can submit a request."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:131
+#: templates/exhibitors/dashboard.html:131
 msgid "Open"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:134
+#: templates/exhibitors/dashboard.html:134
 #, python-format
 msgid "Closes on %(deadline)s."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:139
+#: templates/exhibitors/dashboard.html:139
 msgid "No deadline set."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:142
+#: templates/exhibitors/dashboard.html:142
 msgid "Closed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:144
+#: templates/exhibitors/dashboard.html:144
 #, python-format
 msgid "The deadline passed on %(deadline)s."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:151
+#: templates/exhibitors/dashboard.html:151
 msgid "Private — reachable only with the secret link."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:157
-#: exhibition/templates/exhibitors/settings.html:90
-#: exhibition/templates/exhibitors/settings.html:94
+#: templates/exhibitors/dashboard.html:157
+#: templates/exhibitors/settings.html:94 templates/exhibitors/settings.html:98
 msgid "View call page"
 msgstr ""
 
-#: exhibition/templates/exhibitors/delete.html:11
+#: templates/exhibitors/delete.html:11
 #, python-format
 msgid ""
 "Are you sure you want to delete “%(name)s”? This action cannot be undone."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:8
+#: templates/exhibitors/devices.html:8
 #, python-format
 msgid "Lead-scanning devices for %(name)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:13
+#: templates/exhibitors/devices.html:13
 #, python-brace-format
 msgid ""
 "Provision check-in app devices for this partner. Each device gets its own "
@@ -1673,66 +1710,64 @@ msgid ""
 "through the {device_tokens} placeholder."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:21
+#: templates/exhibitors/devices.html:21
 msgid ""
 "Provisioning devices requires organizer-level permissions. Ask an organizer "
 "admin to create the devices for this partner."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:29
+#: templates/exhibitors/devices.html:29
 msgid "Provisioned devices"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:35
+#: templates/exhibitors/devices.html:35
 msgid "Device"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:36
+#: templates/exhibitors/devices.html:36
 msgid "Setup token"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:37
+#: templates/exhibitors/devices.html:37
 msgid "Status"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:47
+#: templates/exhibitors/devices.html:47
 msgid "Connected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:49
+#: templates/exhibitors/devices.html:49
 msgid "Awaiting setup"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:60
+#: templates/exhibitors/devices.html:60
 msgid ""
 "Generate new setup tokens? Any device that is already scanning will be "
 "disconnected and must be set up again."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:65
+#: templates/exhibitors/devices.html:65
 msgid "Generate new setup tokens"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:70
+#: templates/exhibitors/devices.html:70
 msgid "No devices have been provisioned for this partner yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:80
-#: exhibition/templates/exhibitors/devices.html:85
+#: templates/exhibitors/devices.html:80 templates/exhibitors/devices.html:85
 msgid "Add devices"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:87
-#: exhibition/templates/exhibitors/vouchers.html:88
+#: templates/exhibitors/devices.html:87 templates/exhibitors/vouchers.html:133
 msgid "Back"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_bulk_discard.html:4
-#: exhibition/templates/exhibitors/email_bulk_discard.html:7
+#: templates/exhibitors/email_bulk_discard.html:4
+#: templates/exhibitors/email_bulk_discard.html:7
 msgid "Discard emails"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_bulk_discard.html:19
+#: templates/exhibitors/email_bulk_discard.html:19
 #, python-format
 msgid ""
 "Are you sure you want to discard %(counter)s queued email? This cannot be "
@@ -1743,80 +1778,80 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/templates/exhibitors/email_bulk_discard.html:30
-#: exhibition/templates/exhibitors/email_delete.html:31
-msgid "Discard"
-msgstr ""
-
-#: exhibition/templates/exhibitors/email_compose.html:7
-#: exhibition/templates/exhibitors/email_compose.html:16
+#: templates/exhibitors/email_compose.html:7
+#: templates/exhibitors/email_compose.html:16
 msgid "Compose email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:21
+#: templates/exhibitors/email_compose.html:21
 msgid ""
 "Send an update to a group of applicants. One email is queued per recipient, "
 "with placeholders resolved individually."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:26
+#: templates/exhibitors/email_compose.html:26
 msgid "Load from template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:28
+#: templates/exhibitors/email_compose.html:28
 msgid "Select a saved template…"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:33
+#: templates/exhibitors/email_compose.html:33
 msgid "Load"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:41
-#: exhibition/templates/exhibitors/email_edit.html:23
+#: templates/exhibitors/email_compose.html:41
+#: templates/exhibitors/email_edit.html:23
 msgid "Recipients"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:47
+#: templates/exhibitors/email_compose.html:47
 msgid "Message"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:58
-#: exhibition/templates/exhibitors/email_custom_template_form.html:33
-#: exhibition/templates/exhibitors/email_templates.html:53
-#: exhibition/templates/exhibitors/email_templates.html:100
-#: exhibition/templates/exhibitors/settings.html:58
+#: templates/exhibitors/email_compose.html:51
+msgctxt "form"
+msgid "required"
+msgstr ""
+
+#: templates/exhibitors/email_compose.html:58
+#: templates/exhibitors/email_custom_template_form.html:33
+#: templates/exhibitors/email_templates.html:53
+#: templates/exhibitors/email_templates.html:100
+#: templates/exhibitors/settings.html:62
 msgid "Preview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:80
+#: templates/exhibitors/email_compose.html:80
 msgid "Save to outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:83
+#: templates/exhibitors/email_compose.html:83
 msgid "Send / Schedule"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:4
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:7
+#: templates/exhibitors/email_custom_template_delete.html:4
+#: templates/exhibitors/email_custom_template_delete.html:7
 msgid "Delete custom template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:14
+#: templates/exhibitors/email_custom_template_delete.html:14
 #, python-format
 msgid "Are you sure you want to delete the custom template \"%(name)s\"?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_custom_template_form.html:7
-#: exhibition/templates/exhibitors/email_custom_template_form.html:15
+#: templates/exhibitors/email_custom_template_form.html:7
+#: templates/exhibitors/email_custom_template_form.html:15
 msgid "Custom template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_delete.html:4
-#: exhibition/templates/exhibitors/email_delete.html:7
+#: templates/exhibitors/email_delete.html:4
+#: templates/exhibitors/email_delete.html:7
 msgid "Discard email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_delete.html:15
+#: templates/exhibitors/email_delete.html:15
 #, python-format
 msgid ""
 "Are you sure you want to discard the email “%(subject)s” to %(counter)s "
@@ -1827,908 +1862,1226 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/templates/exhibitors/email_delete.html:21
+#: templates/exhibitors/email_delete.html:21
 #, python-format
 msgid ""
 "Are you sure you want to discard the email “%(subject)s” to %(to)s? This "
 "cannot be undone."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:5
+#: templates/exhibitors/email_edit.html:5
 msgid "Edit email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:8
+#: templates/exhibitors/email_edit.html:8
 msgid "Preview / edit email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:14
+#: templates/exhibitors/email_edit.html:14
 msgid "Back to outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:41
+#: templates/exhibitors/email_edit.html:41
 msgid "Save & send"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_outbox.html:12
-#: exhibition/templates/exhibitors/email_outbox.html:15
+#: templates/exhibitors/email_outbox.html:12
+#: templates/exhibitors/email_outbox.html:15
 msgid "Email outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_outbox.html:20
+#: templates/exhibitors/email_outbox.html:20
 msgid ""
 "Emails waiting to be sent. Review, edit, or discard them before sending."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_sent.html:12
-#: exhibition/templates/exhibitors/email_sent.html:15
+#: templates/exhibitors/email_sent.html:12
+#: templates/exhibitors/email_sent.html:15
 msgid "Sent emails"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:7
-#: exhibition/templates/exhibitors/email_templates.html:16
+#: templates/exhibitors/email_templates.html:7
+#: templates/exhibitors/email_templates.html:16
 msgid "Email templates"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:22
+#: templates/exhibitors/email_templates.html:22
 msgid "New template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:27
+#: templates/exhibitors/email_templates.html:27
 msgid ""
 "These templates are used for the confirmation email sent when an applicant "
 "submits a request, and for the accept/reject emails you send from the outbox."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:81
+#: templates/exhibitors/email_templates.html:81
 msgid "Discard this template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:31
+#: templates/exhibitors/exhibitor_info.html:31
 msgid "No organizations match your filters."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:33
+#: templates/exhibitors/exhibitor_info.html:33
 msgid "You don't have any sponsors yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:35
+#: templates/exhibitors/exhibitor_info.html:35
 msgid "You don't have any exhibitors yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:37
+#: templates/exhibitors/exhibitor_info.html:37
 msgid "You don't have any exhibitors or sponsors yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:43
-#: exhibition/templates/exhibitors/exhibitor_info.html:52
-#: exhibition/views.py:1837
+#: templates/exhibitors/exhibitor_info.html:43
+#: templates/exhibitors/exhibitor_info.html:57 views.py:1979
 msgid "Add a Sponsor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:43
-#: exhibition/templates/exhibitors/exhibitor_info.html:52
-#: exhibition/views.py:1838
+#: templates/exhibitors/exhibitor_info.html:43
+#: templates/exhibitors/exhibitor_info.html:57 views.py:1980
 msgid "Add an Exhibitor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:43
-#: exhibition/templates/exhibitors/exhibitor_info.html:52
-#: exhibition/views.py:1839
+#: templates/exhibitors/exhibitor_info.html:43
+#: templates/exhibitors/exhibitor_info.html:57 views.py:1981
 msgid "Add an Exhibitor or Sponsor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:48
-#: exhibition/templates/exhibitors/proposal_list.html:169
+#: templates/exhibitors/exhibitor_info.html:48
+#: templates/exhibitors/proposal_list.html:170
 msgid "selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:54
+#: templates/exhibitors/exhibitor_info.html:59
 msgid "Download access keys as CSV"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:56
+#: templates/exhibitors/exhibitor_info.html:61
 msgid "Download sponsor keys"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:56
+#: templates/exhibitors/exhibitor_info.html:61
 msgid "Download exhibitor keys"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:56
+#: templates/exhibitors/exhibitor_info.html:61
 msgid "Download access keys"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:65
+#: templates/exhibitors/exhibitor_info.html:64
+msgid "Queue a voucher email for everyone in this list"
+msgstr ""
+
+#: templates/exhibitors/exhibitor_info.html:65
+msgid "Send vouchers to all"
+msgstr ""
+
+#: templates/exhibitors/exhibitor_info.html:75
 msgid ""
 "Drag-and-drop ordering is available only on the unfiltered, single-page list."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:70
+#: templates/exhibitors/exhibitor_info.html:80
 msgid "Booth"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:78
-#: exhibition/templates/exhibitors/exhibitor_info.html:106
+#: templates/exhibitors/exhibitor_info.html:88
+#: templates/exhibitors/exhibitor_info.html:117
 msgid "Select all partners"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:84
-#: exhibition/templates/exhibitors/exhibitor_info.html:112
+#: templates/exhibitors/exhibitor_info.html:94
+#: templates/exhibitors/exhibitor_info.html:123
 msgid "Group"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:12
-#: exhibition/templates/exhibitors/proposal_detail.html:15
+#: templates/exhibitors/proposal_detail.html:12
+#: templates/exhibitors/proposal_detail.html:15
 msgid "Review exhibition request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:21
+#: templates/exhibitors/proposal_detail.html:21
 msgid "Back to exhibition requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:29
+#: templates/exhibitors/proposal_detail.html:29
 #, python-format
 msgid "Changes made by the applicant after acceptance (%(when)s)"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:39
+#: templates/exhibitors/proposal_detail.html:39
 msgid "Before acceptance"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:40
+#: templates/exhibitors/proposal_detail.html:40
 msgid "After edit"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:55
+#: templates/exhibitors/proposal_detail.html:55
 msgid "The applicant edited the profile, but the tracked fields are unchanged."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:57
+#: templates/exhibitors/proposal_detail.html:57
 msgid ""
 "This profile was edited before change tracking was available, so the "
 "original values are not recorded."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:69
-#: exhibition/templates/exhibitors/proposal_list.html:20
+#: templates/exhibitors/proposal_detail.html:69
+#: templates/exhibitors/proposal_list.html:20
 msgid "Submitter"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:80
+#: templates/exhibitors/proposal_detail.html:80
 msgid "Hidden"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:121
+#: templates/exhibitors/proposal_detail.html:121
 msgid "Message to organizers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:129
+#: templates/exhibitors/proposal_detail.html:129
 msgid "Links"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:152
+#: templates/exhibitors/proposal_detail.html:152
 msgid "Download"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:154
+#: templates/exhibitors/proposal_detail.html:154
 msgid "Custom answers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:176
+#: templates/exhibitors/proposal_detail.html:176
 msgid "Review"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:192
-#: exhibition/templates/exhibitors/proposal_list.html:117
-#: exhibition/templates/exhibitors/proposal_list.html:164
+#: templates/exhibitors/proposal_detail.html:192
+#: templates/exhibitors/proposal_list.html:118
+#: templates/exhibitors/proposal_list.html:165
 msgid "Approve"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:195
-#: exhibition/templates/exhibitors/proposal_list.html:122
-#: exhibition/templates/exhibitors/proposal_list.html:165
+#: templates/exhibitors/proposal_detail.html:195
+#: templates/exhibitors/proposal_list.html:123
+#: templates/exhibitors/proposal_list.html:166
 msgid "Reject"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:200
+#: templates/exhibitors/proposal_detail.html:200
 msgid "Open profile"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:22
+#: templates/exhibitors/proposal_list.html:22
 msgid "Updated"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:33
+#: templates/exhibitors/proposal_list.html:33
 msgid "Select at least one request."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:34
+#: templates/exhibitors/proposal_list.html:34
 msgid "None of the selected requests can be approved."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:35
+#: templates/exhibitors/proposal_list.html:35
 msgid "None of the selected requests can be rejected."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:36
+#: templates/exhibitors/proposal_list.html:36
 #, python-brace-format
 msgid "{count} selected requests cannot be approved and will be skipped."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:37
+#: templates/exhibitors/proposal_list.html:37
 #, python-brace-format
 msgid "{count} selected requests cannot be rejected and will be skipped."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:41
+#: templates/exhibitors/proposal_list.html:41
 msgid "Approve selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:44
+#: templates/exhibitors/proposal_list.html:44
 msgid "Reject selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:55
+#: templates/exhibitors/proposal_list.html:55
 msgid "Select all matching requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:75
+#: templates/exhibitors/proposal_list.html:75
 msgid "Select request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:106
+#: templates/exhibitors/proposal_list.html:106
 msgid "Edited after acceptance, see detail view for changes."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:127
-#: exhibition/templates/exhibitors/proposal_list.html:166
-#: exhibition/templates/exhibitors/public_proposal_list.html:39
+#: templates/exhibitors/proposal_list.html:128
+#: templates/exhibitors/proposal_list.html:167
+#: templates/exhibitors/public_proposal_list.html:39
 msgid "Withdraw"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:132
-#: exhibition/templates/exhibitors/proposal_list.html:167
+#: templates/exhibitors/proposal_list.html:133
+#: templates/exhibitors/proposal_list.html:168
 msgid "Reopen for review"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:137
-#: exhibition/templates/exhibitors/public_proposal_list.html:34
+#: templates/exhibitors/proposal_list.html:138
+#: templates/exhibitors/public_proposal_list.html:34
 msgid "View"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:149
+#: templates/exhibitors/proposal_list.html:150
 msgid "No exhibition requests match your filters."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:151
+#: templates/exhibitors/proposal_list.html:152
 msgid "No exhibition requests have been submitted yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:159
+#: templates/exhibitors/proposal_list.html:160
 msgid "Approve the selected requests and create their partner profiles?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:160
+#: templates/exhibitors/proposal_list.html:161
 msgid "Reject the selected requests?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:161
+#: templates/exhibitors/proposal_list.html:162
 msgid "Reject this request?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:162
+#: templates/exhibitors/proposal_list.html:163
 msgid "Withdraw this request?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:163
+#: templates/exhibitors/proposal_list.html:164
 msgid "Reopen this request for review?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:168
+#: templates/exhibitors/proposal_list.html:169
 msgid "The action could not be completed. Please try again."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:170
+#: templates/exhibitors/proposal_list.html:171
 msgid ""
 "Approve every request matching the current filters, including those on other "
 "pages?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:171
+#: templates/exhibitors/proposal_list.html:172
 msgid ""
 "Reject every request matching the current filters, including those on other "
 "pages?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:172
+#: templates/exhibitors/proposal_list.html:173
 msgid "Please confirm"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:173
+#: templates/exhibitors/proposal_list.html:174
 msgid "Confirm"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:14
+#: templates/exhibitors/public_call.html:14
 msgid "Submit a request to become an exhibitor for this event."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:20
+#: templates/exhibitors/public_call.html:20
 #, python-format
 msgid "You can submit requests until %(deadline)s (%(timezone)s)."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:24
+#: templates/exhibitors/public_call.html:24
 #, python-format
 msgid "This call closed on %(deadline)s (%(timezone)s)."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:34
+#: templates/exhibitors/public_call.html:34
 msgid "View your requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:40
-#: exhibition/templates/exhibitors/public_proposal_form.html:18
-#: exhibition/templates/exhibitors/public_proposal_list.html:65
+#: templates/exhibitors/public_call.html:40
+#: templates/exhibitors/public_proposal_form.html:18
+#: templates/exhibitors/public_proposal_list.html:65
 msgid "Submit a request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:42
+#: templates/exhibitors/public_call.html:42
 msgid "Requests are closed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:21
-#: exhibition/templates/exhibitors/public_detail.html:94
+#: templates/exhibitors/public_detail.html:21
+#: templates/exhibitors/public_detail.html:93
 msgid "Previous"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:24
-#: exhibition/templates/exhibitors/public_detail.html:98
+#: templates/exhibitors/public_detail.html:24
+#: templates/exhibitors/public_detail.html:97
 msgid "Next"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:47
+#: templates/exhibitors/public_detail.html:47
 msgid "Get In Touch"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:87
-#: exhibition/templates/exhibitors/public_detail.html:103
+#: templates/exhibitors/public_detail.html:87
+#: templates/exhibitors/public_detail.html:102
 msgid "Open slides PDF"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:88
-#, python-brace-format
-msgid "Slide {current} of {total}"
-msgstr ""
-
-#: exhibition/templates/exhibitors/public_detail.html:112
+#: templates/exhibitors/public_detail.html:111
 msgid "Send email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:126
+#: templates/exhibitors/public_detail.html:125
 msgid "Visit website"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_list.html:54
+#: templates/exhibitors/public_list.html:32
+msgid "Clear"
+msgstr ""
+
+#: templates/exhibitors/public_list.html:54
 msgid "No exhibitors match your search."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_list.html:56
+#: templates/exhibitors/public_list.html:56
 msgid "No exhibitors are currently available."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:16
+#: templates/exhibitors/public_proposal_form.html:16
 msgid "Edit request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:23
-#: exhibition/views.py:883
+#: templates/exhibitors/public_proposal_form.html:23 views.py:958
 msgid "This request can no longer be edited."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:186
+#: templates/exhibitors/public_proposal_form.html:190
 msgid "Submit request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:189
+#: templates/exhibitors/public_proposal_form.html:193
 msgid "or save as draft for now"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:199
+#: templates/exhibitors/public_proposal_form.html:203
 msgid "Back to your requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:5
+#: templates/exhibitors/public_proposal_list.html:5
 msgid "Your exhibition requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:13
+#: templates/exhibitors/public_proposal_list.html:13
 msgid "Last modified"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:23
+#: templates/exhibitors/public_proposal_list.html:23
 msgid "Withdrawn"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:44
+#: templates/exhibitors/public_proposal_list.html:44
 msgid "Reinstate"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:56
+#: templates/exhibitors/public_proposal_list.html:56
 msgid "Create a new request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:61
+#: templates/exhibitors/public_proposal_list.html:61
 msgid "You have not submitted an exhibition request yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:5
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:21
+#: templates/exhibitors/public_proposal_reinstate.html:5
+#: templates/exhibitors/public_proposal_reinstate.html:21
 msgid "Reinstate request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:7
+#: templates/exhibitors/public_proposal_reinstate.html:7
 #, python-format
 msgid ""
 "Do you want to reinstate your withdrawn request “%(name)s”? It will be "
 "pending review again."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:5
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:26
+#: templates/exhibitors/public_proposal_withdraw.html:5
+#: templates/exhibitors/public_proposal_withdraw.html:26
 msgid "Withdraw request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:7
+#: templates/exhibitors/public_proposal_withdraw.html:7
 #, python-format
 msgid "Are you sure you want to withdraw your request “%(name)s”?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:13
+#: templates/exhibitors/public_proposal_withdraw.html:13
 msgid ""
 "This request has already been approved. Withdrawing it will hide the "
 "exhibitor or sponsor profile created from it from public listings."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:10
-#: exhibition/templates/exhibitors/settings.html:27
+#: templates/exhibitors/settings.html:10 templates/exhibitors/settings.html:29
 msgid "Sponsor Settings"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:12
-#: exhibition/templates/exhibitors/settings.html:29
+#: templates/exhibitors/settings.html:12 templates/exhibitors/settings.html:31
+msgid "Voucher Settings"
+msgstr ""
+
+#: templates/exhibitors/settings.html:14 templates/exhibitors/settings.html:33
 msgid "Exhibitor Settings"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:42
+#: templates/exhibitors/settings.html:46
 msgid "Publish your call"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:43
+#: templates/exhibitors/settings.html:47
 msgid "Publish a login-required application form for exhibitors."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:72
+#: templates/exhibitors/settings.html:76
 msgid ""
 "This panel renders unsaved draft text using the same styling as the live "
 "public call page."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:104
+#: templates/exhibitors/settings.html:108
 msgid "Secret call link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:107
+#: templates/exhibitors/settings.html:111
 msgid ""
 "This call is private: it is not linked anywhere public. Share the link below "
 "with the organizations you want to invite. Anyone who has it can open the "
 "call and apply."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:113
+#: templates/exhibitors/settings.html:117
 msgid "Copied"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:113
+#: templates/exhibitors/settings.html:117
 msgid "Copy to clipboard"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:114
+#: templates/exhibitors/settings.html:118
 msgid "Copy"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:119
+#: templates/exhibitors/settings.html:123
 msgid ""
 "Regenerate the secret link? The current link will stop working immediately."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:125
+#: templates/exhibitors/settings.html:129
 msgid "Regenerate link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:127
+#: templates/exhibitors/settings.html:131
 msgid "Regenerating immediately invalidates the current link."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:138
+#: templates/exhibitors/settings.html:143
+msgid "Voucher pools"
+msgstr ""
+
+#: templates/exhibitors/settings.html:147
+msgid ""
+"Create the voucher codes under Tickets → Vouchers and give them a tag, then "
+"pick that tag here. Exhibitors and sponsors are handed codes from the pool "
+"you choose. Reload this page to pick up a tag you just created."
+msgstr ""
+
+#: templates/exhibitors/settings.html:157
+msgid "Create vouchers pool"
+msgstr ""
+
+#: templates/exhibitors/settings.html:159
+msgid "(opens in a new tab)"
+msgstr ""
+
+#: templates/exhibitors/settings.html:168
+#: templates/exhibitors/settings.html:182
+#, python-format
+msgid "%(counter)s voucher in this pool is not assigned to anyone yet."
+msgid_plural ""
+"%(counter)s vouchers in this pool are not assigned to anyone yet."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+msgstr[5] ""
+
+#: templates/exhibitors/settings.html:194
+msgid "How many each one gets"
+msgstr ""
+
+#: templates/exhibitors/settings.html:196
+msgid ""
+"Applies to any exhibitor or sponsor that does not belong to a sponsor group. "
+"Sponsor groups set their own number on the Sponsors page, and an individual "
+"exhibitor or sponsor can be given a different number on their own voucher "
+"page."
+msgstr ""
+
+#: templates/exhibitors/settings.html:206
+msgid "Voucher email"
+msgstr ""
+
+#: templates/exhibitors/settings.html:208
+msgid "Applies to the voucher email sent to exhibitors and sponsors alike."
+msgstr ""
+
+#: templates/exhibitors/settings.html:228
 msgid "Data access"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:139
+#: templates/exhibitors/settings.html:229
 msgid ""
 "In this section, you can control which attendee data is shared with "
 "exhibitors when an exhibitor voucher is used or when the exhibitor uses the "
 "lead scanning app."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:142
+#: templates/exhibitors/settings.html:232
 msgid "Exhibitor vouchers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:158
-msgid "Exhibitor login"
-msgstr ""
-
-#: exhibition/templates/exhibitors/settings.html:160
-msgid ""
-"The access-code email sent to exhibitors is now edited together with the "
-"plugin's other email templates."
-msgstr ""
-
-#: exhibition/templates/exhibitors/settings.html:162
-msgid "Edit email templates"
-msgstr ""
-
-#: exhibition/templates/exhibitors/settings.html:177
+#: templates/exhibitors/settings.html:257
 msgid "Group List"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:180
+#: templates/exhibitors/settings.html:260
 msgid "Add a Group"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:193
+#: templates/exhibitors/settings.html:272
+#: templates/exhibitors/settings.html:354
+msgid "Voucher defaults for this group"
+msgstr ""
+
+#: templates/exhibitors/settings.html:277
 msgid "Add"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:204
+#: templates/exhibitors/settings.html:288
 msgid "Group Name"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:206
+#: templates/exhibitors/settings.html:290
 msgid "Partners"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:207
+#: templates/exhibitors/settings.html:291
 msgid "Front Page"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:220
-#: exhibition/templates/exhibitors/settings.html:226
+#: templates/exhibitors/settings.html:304
+#: templates/exhibitors/settings.html:310
 msgid "Show this sponsor group in the Supported By section on the front page."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:251
+#: templates/exhibitors/settings.html:326
+msgid "Edit sponsor group"
+msgstr ""
+
+#: templates/exhibitors/settings.html:337
 msgid "Reorder sponsor group"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:281
+#: templates/exhibitors/settings.html:371
 msgid "You do not have any sponsor groups yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:8
+#: templates/exhibitors/voucher_bulk_send.html:4
+#: templates/exhibitors/voucher_bulk_send.html:7
+msgid "Send vouchers"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:18
+#, python-format
+msgid "A voucher email will be placed in the outbox for %(counter)s sponsor."
+msgid_plural ""
+"A voucher email will be placed in the outbox for %(counter)s sponsors."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+msgstr[5] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:24
+#, python-format
+msgid "A voucher email will be placed in the outbox for %(counter)s exhibitor."
+msgid_plural ""
+"A voucher email will be placed in the outbox for %(counter)s exhibitors."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+msgstr[5] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:37
+#, python-format
+msgid "&mdash; %(counter)s voucher will be created"
+msgid_plural "&mdash; %(counter)s vouchers will be created"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+msgstr[5] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:45
+#, python-format
+msgid "&mdash; %(counter)s existing voucher"
+msgid_plural "&mdash; %(counter)s existing vouchers"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+msgstr[5] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:58
+msgid "None of the sponsors in this list can be emailed yet."
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:60
+msgid "None of the exhibitors in this list can be emailed yet."
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:66
+msgid "Skipped: no email address"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:75
+msgid "Skipped: voucher count is set to 0"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:84
+msgid "Skipped: no vouchers available from their pool"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:86
+msgid ""
+"Check that a voucher pool is selected under Settings → Vouchers and that it "
+"still has unassigned codes."
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:99
+msgid "Queue emails"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:8
 #, python-format
 msgid "Vouchers for %(name)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:13
+#: templates/exhibitors/vouchers.html:13
 msgid ""
-"Issue ticket vouchers for this partner to hand out. Whoever redeems one on "
-"the ticket shop becomes a lead this partner can retrieve, as long as voucher "
+"Hand this exhibitor or sponsor codes from the voucher pool. Whoever redeems "
+"one on the ticket shop becomes a lead they can retrieve, as long as voucher "
 "data access is enabled for them."
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:20
-msgid "Issued vouchers"
+#: templates/exhibitors/vouchers.html:20
+msgid "Assigned vouchers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:24
+#: templates/exhibitors/vouchers.html:24
 msgid "Download codes (CSV)"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:31
+#: templates/exhibitors/vouchers.html:31
 msgid "Code"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:32 exhibition/views.py:1994
+#: templates/exhibitors/vouchers.html:32 utils.py:495
 msgid "Product"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:34 exhibition/views.py:1998
+#: templates/exhibitors/vouchers.html:33 utils.py:496
+msgid "Price effect"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:34 utils.py:499
 msgid "Redeemed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:56
+#: templates/exhibitors/vouchers.html:35 utils.py:498
+msgid "Valid until"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:56
 msgid "Already redeemed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:67
-msgid "No vouchers have been issued for this partner yet."
+#: templates/exhibitors/vouchers.html:62
+msgid "Return to pool"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:76
-msgid "Issue new vouchers"
+#: templates/exhibitors/vouchers.html:74
+msgid "No vouchers have been assigned to this partner yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:86
-msgid "Create vouchers"
+#: templates/exhibitors/vouchers.html:82
+msgid "Take more from the pool"
 msgstr ""
 
-#: exhibition/templates/sponsors/presale_supported_by.html:4
+#: templates/exhibitors/vouchers.html:84
+msgid ""
+"Codes come from the voucher pool chosen under Settings. The email always "
+"carries this partner's complete list of codes, so you can assign some now "
+"and send them together with more later. It is placed in the outbox for you "
+"to review before it goes out."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:92
+#, python-format
+msgid "%(counter)s voucher is left unassigned in the pool."
+msgid_plural "%(counter)s vouchers are left unassigned in the pool."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+msgstr[5] ""
+
+#: templates/exhibitors/vouchers.html:100 views.py:2230
+msgid "No voucher pool is selected yet. Choose one under Settings → Vouchers."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:106
+msgid "A voucher email for this partner is waiting in the outbox."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:108
+msgid "Go to outbox"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:114
+#, python-format
+msgid "Vouchers were last emailed to this partner on %(sent)s."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:120
+msgid ""
+"This partner has no email address on file, so vouchers cannot be emailed."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:127
+msgid "Assign and prepare email"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:130
+msgid "Assign without emailing"
+msgstr ""
+
+#: templates/sponsors/presale_supported_by.html:4
 msgid "Supported By"
 msgstr ""
 
-#: exhibition/views.py:324
+#: utils.py:493
+msgid "Voucher code"
+msgstr ""
+
+#: utils.py:494
+msgid "Redeem link"
+msgstr ""
+
+#: utils.py:497
+msgid "Value"
+msgstr ""
+
+#: utils.py:500
+msgid "Maximum usages"
+msgstr ""
+
+#: views.py:342
 msgid "Company name"
 msgstr ""
 
-#: exhibition/views.py:325
+#: views.py:343
 msgid "Job title"
 msgstr ""
 
-#: exhibition/views.py:326
+#: views.py:344
 msgid "Address"
 msgstr ""
 
-#: exhibition/views.py:333
+#: views.py:351
 msgid "Attendee Name"
 msgstr ""
 
-#: exhibition/views.py:338
+#: views.py:356
 msgid "Attendee Email"
 msgstr ""
 
-#: exhibition/views.py:377
+#: views.py:395 views.py:412
 msgid "Settings have been saved."
 msgstr ""
 
-#: exhibition/views.py:393
+#: views.py:428
 msgid "Call settings have been saved."
 msgstr ""
 
-#: exhibition/views.py:401
+#: views.py:436
 msgid ""
 "A new secret call link has been generated. The old link no longer works."
 msgstr ""
 
-#: exhibition/views.py:416
+#: views.py:451
 msgid "Sponsor group added."
 msgstr ""
 
-#: exhibition/views.py:437
+#: views.py:454 views.py:477 views.py:853 views.py:1169 views.py:1796
+#: views.py:1918 views.py:2564 views.py:3025
+msgid "We could not save your changes. See below for details."
+msgstr ""
+
+#: views.py:474
 msgid "Sponsor group updated."
 msgstr ""
 
-#: exhibition/views.py:452
+#: views.py:491
 msgid "This sponsor group cannot be deleted while it is assigned to partners."
 msgstr ""
 
-#: exhibition/views.py:460
+#: views.py:499
 msgid "Unknown action."
 msgstr ""
 
-#: exhibition/views.py:505
+#: views.py:544
 msgid "Access key"
 msgstr ""
 
-#: exhibition/views.py:745 exhibition/views.py:1060
+#: views.py:819 views.py:1135
 msgid "Add at least one social media link."
 msgstr ""
 
-#: exhibition/views.py:754 exhibition/views.py:1069
+#: views.py:828 views.py:1144
 msgid "Add at least one extra link."
 msgstr ""
 
-#: exhibition/views.py:809
+#: views.py:884
 msgid "The call for exhibitors is closed."
 msgstr ""
 
-#: exhibition/views.py:837
+#: views.py:912
 msgid "Your request has been saved."
 msgstr ""
 
-#: exhibition/views.py:920 exhibition/views.py:1776
+#: views.py:995 views.py:1914
 msgid "Your changes have been saved."
 msgstr ""
 
-#: exhibition/views.py:953
+#: views.py:1028
 msgid "This proposal can no longer be withdrawn."
 msgstr ""
 
-#: exhibition/views.py:961
+#: views.py:1036
 msgid "Your request has been withdrawn."
 msgstr ""
 
-#: exhibition/views.py:963
+#: views.py:1038
 msgid "This request can no longer be withdrawn."
 msgstr ""
 
-#: exhibition/views.py:989 exhibition/views.py:999
+#: views.py:1064 views.py:1074
 msgid "This request can no longer be reinstated."
 msgstr ""
 
-#: exhibition/views.py:997
+#: views.py:1072
 msgid "Your request has been reinstated and is pending review again."
 msgstr ""
 
-#: exhibition/views.py:1121
+#: views.py:1197
 msgid "Invalid request body."
 msgstr ""
 
-#: exhibition/views.py:1124 exhibition/views.py:1129
+#: views.py:1200 views.py:1205
 msgid "Invalid sponsor group IDs."
 msgstr ""
 
-#: exhibition/views.py:1133
+#: views.py:1209
 msgid "Sponsor group IDs must be unique."
 msgstr ""
 
-#: exhibition/views.py:1141
+#: views.py:1217
 msgid "Reorder request must include each sponsor group exactly once."
 msgstr ""
 
-#: exhibition/views.py:1346
+#: views.py:1422
 msgid "This request can no longer be changed to that state."
 msgstr ""
 
-#: exhibition/views.py:1350
+#: views.py:1426
 msgid "Review details saved."
 msgstr ""
 
-#: exhibition/views.py:1359
+#: views.py:1435
 msgid ""
 "Request approved and partner profile created. An acceptance email was placed "
 "in the outbox."
 msgstr ""
 
-#: exhibition/views.py:1369
+#: views.py:1445
 msgid "Request rejected. A rejection email was placed in the outbox."
 msgstr ""
 
-#: exhibition/views.py:1372
+#: views.py:1448
 msgid "Request withdrawn."
 msgstr ""
 
-#: exhibition/views.py:1375
+#: views.py:1451
 msgid "Request reopened for review."
 msgstr ""
 
-#: exhibition/views.py:1407
+#: views.py:1483
 msgid "No valid action was selected."
 msgstr ""
 
-#: exhibition/views.py:1454
+#: views.py:1530
 #, python-format
 msgid "%(count)d request was approved."
 msgid_plural "%(count)d requests were approved."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1455
+#: views.py:1531
 #, python-format
 msgid "%(count)d request was rejected."
 msgid_plural "%(count)d requests were rejected."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1456
+#: views.py:1532
 #, python-format
 msgid "%(count)d request was withdrawn."
 msgid_plural "%(count)d requests were withdrawn."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1457
+#: views.py:1533
 #, python-format
 msgid "%(count)d request was reopened."
 msgid_plural "%(count)d requests were reopened."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1461
+#: views.py:1537
 msgid "No proposals were updated."
 msgstr ""
 
-#: exhibition/views.py:1464
+#: views.py:1540
 #, python-format
 msgid "%(skipped)d was skipped because it was already processed."
 msgid_plural "%(skipped)d were skipped because they were already processed."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1605
+#: views.py:1681
 msgid "Exhibitor form settings have been saved."
 msgstr ""
 
-#: exhibition/views.py:1730
+#: views.py:1868
 msgid "The requested form field does not exist."
 msgstr ""
 
-#: exhibition/views.py:1791
+#: views.py:1933
 msgid "The field has been reset to its default."
 msgstr ""
 
-#: exhibition/views.py:1829 exhibition/views.py:1900
+#: views.py:1971 views.py:2042
 msgid "An access-credentials email was placed in the outbox."
 msgstr ""
 
-#: exhibition/views.py:1907
+#: views.py:2049
 msgid "Edit Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1908
+#: views.py:2050
 msgid "Edit Exhibitor"
 msgstr ""
 
-#: exhibition/views.py:1909
+#: views.py:2051
 msgid "Edit Exhibitor & Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1910
+#: views.py:2052
 msgid "Edit Exhibitor or Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1940
+#: views.py:2082
 msgid "Delete Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1941
+#: views.py:2083
 msgid "Delete Exhibitor"
 msgstr ""
 
-#: exhibition/views.py:1942
+#: views.py:2084
 msgid "Delete Exhibitor & Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1943
+#: views.py:2085
 msgid "Delete Exhibitor or Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1992
-msgid "Voucher code"
+#: views.py:2164
+msgid "This voucher has already been redeemed and cannot be returned."
 msgstr ""
 
-#: exhibition/views.py:1993
-msgid "Redeem link"
+#: views.py:2170
+msgid ""
+"This code was already included in a voucher email to this partner, so it "
+"cannot be returned to the pool. Delete it under Tickets → Vouchers instead."
 msgstr ""
 
-#: exhibition/views.py:1999
-msgid "Maximum usages"
+#: views.py:2176
+msgid "Voucher returned to the pool."
 msgstr ""
 
-#: exhibition/views.py:2035
-msgid "This voucher has already been redeemed and cannot be removed."
+#: views.py:2207
+msgid "Enter how many vouchers to take from the pool."
 msgstr ""
 
-#: exhibition/views.py:2040
-msgid "Voucher removed."
-msgstr ""
-
-#: exhibition/views.py:2060
+#: views.py:2215
 #, python-format
-msgid "%(count)d voucher created."
-msgid_plural "%(count)d vouchers created."
+msgid "%(count)d voucher taken from the pool."
+msgid_plural "%(count)d vouchers taken from the pool."
 msgstr[0] ""
 msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+msgstr[5] ""
 
-#: exhibition/views.py:2112
+#: views.py:2232
+#, python-format
+msgid ""
+"The pool only has %(remaining)d voucher(s) left, so %(count)d cannot be "
+"taken."
+msgstr ""
+
+#: views.py:2244
+msgid "No email address is on file, so vouchers cannot be emailed."
+msgstr ""
+
+#: views.py:2253
+msgid "This partner holds no vouchers yet, so there is nothing to email."
+msgstr ""
+
+#: views.py:2259
+#, python-format
+msgid "An email with %(count)d voucher code was placed in the outbox."
+msgid_plural "An email with %(count)d voucher codes was placed in the outbox."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+msgstr[5] ""
+
+#: views.py:2347
+msgid "There is nobody to send vouchers to in this list."
+msgstr ""
+
+#: views.py:2354
+#, python-format
+msgid "%(count)d voucher email was placed in the outbox."
+msgid_plural "%(count)d voucher emails were placed in the outbox."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+msgstr[5] ""
+
+#: views.py:2371
+#, python-format
+msgid ""
+"%(count)d was skipped because no unassigned codes were available from their "
+"pool."
+msgid_plural ""
+"%(count)d were skipped because no unassigned codes were available from their "
+"pool."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+msgstr[5] ""
+
+#: views.py:2386
+#, python-format
+msgid "%(count)d sponsor was skipped because it has no email address."
+msgid_plural ""
+"%(count)d sponsors were skipped because they have no email address."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+msgstr[5] ""
+
+#: views.py:2392
+#, python-format
+msgid "%(count)d exhibitor was skipped because it has no email address."
+msgid_plural ""
+"%(count)d exhibitors were skipped because they have no email address."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+msgstr[5] ""
+
+#: views.py:2401
+#, python-format
+msgid "%(count)d sponsor was skipped because their voucher count is set to 0."
+msgid_plural ""
+"%(count)d sponsors were skipped because their voucher count is set to 0."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+msgstr[5] ""
+
+#: views.py:2407
+#, python-format
+msgid ""
+"%(count)d exhibitor was skipped because their voucher count is set to 0."
+msgid_plural ""
+"%(count)d exhibitors were skipped because their voucher count is set to 0."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+msgstr[5] ""
+
+#: views.py:2461
 #, python-format
 msgid "%(count)d device added."
 msgid_plural "%(count)d devices added."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2123
+#: views.py:2472
 #, python-format
 msgid ""
 "New setup tokens generated. %(count)d device that was already scanning is "
@@ -2739,79 +3092,95 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2132
+#: views.py:2481
 msgid "New setup tokens generated."
 msgstr ""
 
-#: exhibition/views.py:2194
+#: views.py:2543
 msgid "No applicants matched the selected filters."
 msgstr ""
 
-#: exhibition/views.py:2202
+#: views.py:2551
 #, python-format
 msgid "%(count)d emails have been scheduled."
 msgstr ""
 
-#: exhibition/views.py:2206
+#: views.py:2555
 #, python-format
 msgid "%(count)d emails have been sent."
 msgstr ""
 
-#: exhibition/views.py:2210
+#: views.py:2559
 #, python-format
 msgid "%(count)d emails have been placed in the outbox."
 msgstr ""
 
-#: exhibition/views.py:2385
+#: views.py:2738
 msgid "The emails have been saved and sent."
 msgstr ""
 
-#: exhibition/views.py:2389
+#: views.py:2742
 msgid "The emails have been saved."
 msgstr ""
 
-#: exhibition/views.py:2395
+#: views.py:2748
 msgid "The email has been saved and sent."
 msgstr ""
 
-#: exhibition/views.py:2399
+#: views.py:2752
 msgid "The email has been saved."
 msgstr ""
 
-#: exhibition/views.py:2423 exhibition/views.py:2497
+#: views.py:2776 views.py:2850
 #, python-format
 msgid "%(count)d email has been sent."
 msgid_plural "%(count)d emails have been sent."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2459
+#: views.py:2812
 msgid "The email has been discarded."
 msgstr ""
 
-#: exhibition/views.py:2501 exhibition/views.py:2514 exhibition/views.py:2519
+#: views.py:2854 views.py:2867 views.py:2872
 msgid "No emails were selected."
 msgstr ""
 
-#: exhibition/views.py:2510
+#: views.py:2863
 #, python-format
 msgid "%(count)d email has been discarded."
 msgid_plural "%(count)d emails have been discarded."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2594
+#: views.py:2929
+msgid "Request received (confirmation)"
+msgstr ""
+
+#: views.py:2930
+msgid "Request accepted"
+msgstr ""
+
+#: views.py:2931
+msgid "Request rejected"
+msgstr ""
+
+#: views.py:2932
+msgid "Exhibitor lead scanning key"
+msgstr ""
+
+#: views.py:2948
 msgid "Email templates have been saved."
 msgstr ""
 
-#: exhibition/views.py:2617 exhibition/views.py:2621
+#: views.py:2971 views.py:2975
 msgid "Unknown template."
 msgstr ""
 
-#: exhibition/views.py:2667
+#: views.py:3021
 msgid "Custom template has been created."
 msgstr ""
 
-#: exhibition/views.py:2683
+#: views.py:3041
 msgid "Custom template has been deleted."
 msgstr ""

--- a/exhibition/locale/bn/LC_MESSAGES/django.po
+++ b/exhibition/locale/bn/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 10:11+0000\n"
+"POT-Creation-Date: 2026-09-11 11:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,595 +18,531 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: exhibition/apps.py:14 exhibition/apps.py:17 exhibition/signals.py:157
-#: exhibition/templates/exhibitors/public_list.html:6
-#: exhibition/templates/exhibitors/public_list.html:14
-#: exhibition/templates/exhibitors/public_list.html:16
+#: apps.py:14 apps.py:17 signals.py:163 templates/exhibitors/public_list.html:6
+#: templates/exhibitors/public_list.html:14
+#: templates/exhibitors/public_list.html:16
 msgid "Exhibition"
 msgstr ""
 
-#: exhibition/apps.py:19
+#: apps.py:19
 msgid "This plugin enables to add and control exhibitors in eventyay"
 msgstr ""
 
-#: exhibition/filters.py:9
+#: filters.py:9
 msgid "Any"
 msgstr ""
 
-#: exhibition/filters.py:10
+#: filters.py:10
 msgid "Enabled"
 msgstr ""
 
-#: exhibition/filters.py:11 exhibition/templates/exhibitors/dashboard.html:127
+#: filters.py:11 templates/exhibitors/dashboard.html:127
 msgid "Disabled"
 msgstr ""
 
-#: exhibition/filters.py:15
+#: filters.py:15
 msgid "All types"
 msgstr ""
 
-#: exhibition/filters.py:16
+#: filters.py:16
 msgid "Exhibitor only"
 msgstr ""
 
-#: exhibition/filters.py:17
+#: filters.py:17
 msgid "Sponsor only"
 msgstr ""
 
-#: exhibition/filters.py:18 exhibition/templates/exhibitors/dashboard.html:89
-#: exhibition/templates/exhibitors/proposal_detail.html:95
-#: exhibition/templates/exhibitors/proposal_list.html:95
+#: filters.py:18 templates/exhibitors/dashboard.html:89
+#: templates/exhibitors/proposal_detail.html:95
+#: templates/exhibitors/proposal_list.html:95
 msgid "Exhibitor and sponsor"
 msgstr ""
 
-#: exhibition/filters.py:80 exhibition/filters.py:81
+#: filters.py:80 filters.py:81
 msgid "Search requests…"
 msgstr ""
 
-#: exhibition/filters.py:81
+#: filters.py:81
 msgid "Search requests"
 msgstr ""
 
-#: exhibition/filters.py:85 exhibition/templates/exhibitors/dashboard.html:75
-#: exhibition/templates/exhibitors/proposal_detail.html:85
-#: exhibition/templates/exhibitors/proposal_list.html:21
-#: exhibition/templates/exhibitors/public_proposal_list.html:12
+#: filters.py:85 templates/exhibitors/dashboard.html:75
+#: templates/exhibitors/proposal_detail.html:85
+#: templates/exhibitors/proposal_list.html:21
+#: templates/exhibitors/public_proposal_list.html:12
 msgid "State"
 msgstr ""
 
-#: exhibition/filters.py:86
+#: filters.py:86
 msgid "All states"
 msgstr ""
 
-#: exhibition/filters.py:90 exhibition/templates/exhibitors/dashboard.html:74
-#: exhibition/templates/exhibitors/proposal_detail.html:91
-#: exhibition/templates/exhibitors/proposal_list.html:62
+#: filters.py:90 templates/exhibitors/dashboard.html:74
+#: templates/exhibitors/proposal_detail.html:91
+#: templates/exhibitors/proposal_list.html:62
 msgid "Type"
 msgstr ""
 
-#: exhibition/filters.py:99 exhibition/filters.py:102
+#: filters.py:99 filters.py:102
 msgid "Search by name…"
 msgstr ""
 
-#: exhibition/filters.py:103
+#: filters.py:103
 msgid "Search requests by name"
 msgstr ""
 
-#: exhibition/filters.py:132 exhibition/filters.py:133
+#: filters.py:132 filters.py:133
 msgid "Search organizations…"
 msgstr ""
 
-#: exhibition/filters.py:133
+#: filters.py:133
 msgid "Search organizations"
 msgstr ""
 
-#: exhibition/filters.py:137
+#: filters.py:137
 msgid "Visibility"
 msgstr ""
 
-#: exhibition/filters.py:139
+#: filters.py:139
 msgid "All organizations"
 msgstr ""
 
-#: exhibition/filters.py:140 exhibition/forms.py:1512
-#: exhibition/templates/exhibitors/call_questions.html:30
+#: filters.py:140 forms.py:1553 templates/exhibitors/call_questions.html:30
 msgid "Active"
 msgstr ""
 
-#: exhibition/filters.py:141
+#: filters.py:141
 msgid "Inactive"
 msgstr ""
 
-#: exhibition/filters.py:146 exhibition/filters.py:207 exhibition/forms.py:207
-#: exhibition/forms.py:1410 exhibition/forms.py:1841
+#: filters.py:146 filters.py:207 forms.py:212 forms.py:1411 forms.py:1888
 msgid "Sponsor group"
 msgstr ""
 
-#: exhibition/filters.py:149 exhibition/filters.py:210
+#: filters.py:149 filters.py:210
 msgid "All groups"
 msgstr ""
 
-#: exhibition/filters.py:152 exhibition/templates/exhibitors/add.html:222
+#: filters.py:152 templates/exhibitors/add.html:226
 msgid "Lead scanning"
 msgstr ""
 
-#: exhibition/filters.py:157
+#: filters.py:157
 msgid "Lead access"
 msgstr ""
 
-#: exhibition/filters.py:162
+#: filters.py:162
 msgid "Voucher access"
 msgstr ""
 
-#: exhibition/filters.py:202 exhibition/filters.py:203
+#: filters.py:202 filters.py:203
 msgid "Search exhibitors…"
 msgstr ""
 
-#: exhibition/filters.py:203
+#: filters.py:203
 msgid "Search exhibitors"
 msgstr ""
 
-#: exhibition/filters.py:240 exhibition/filters.py:241
+#: filters.py:240 filters.py:241
 msgid "Search emails…"
 msgstr ""
 
-#: exhibition/filters.py:241
+#: filters.py:241
 msgid "Search emails"
 msgstr ""
 
-#: exhibition/forms.py:67
+#: forms.py:72
 #, python-format
 msgid "Times are in the event timezone: %(tz)s."
 msgstr ""
 
-#: exhibition/forms.py:128 exhibition/forms.py:139 exhibition/forms.py:933
-#: exhibition/forms.py:944
+#: forms.py:133 forms.py:144 forms.py:934 forms.py:945
 msgid "— No selection —"
 msgstr ""
 
-#: exhibition/forms.py:211
+#: forms.py:216
 msgid "Can view voucher redemptions"
 msgstr ""
 
-#: exhibition/forms.py:213 exhibition/forms.py:397
+#: forms.py:218 forms.py:402
 msgid ""
 "Lets this exhibitor or sponsor retrieve the attendees who redeemed vouchers "
 "issued to them. Separate from lead scanning, which covers attendees scanned "
 "at the booth."
 msgstr ""
 
-#: exhibition/forms.py:219
+#: forms.py:224
 msgid "Can view and export collected leads"
 msgstr ""
 
-#: exhibition/forms.py:221
+#: forms.py:226
 msgid ""
 "Lets this exhibitor retrieve the full list of leads they have already "
 "scanned. Turn this off to let them keep scanning without seeing the "
 "collected attendee data."
 msgstr ""
 
-#: exhibition/forms.py:226
+#: forms.py:231
 msgid "Lead scanning behavior"
 msgstr ""
 
-#: exhibition/forms.py:231
+#: forms.py:236
 msgid ""
 "Every attendee is one lead, even when scanned from multiple devices. Notes "
 "and ratings are shared between devices."
 msgstr ""
 
-#: exhibition/forms.py:238
+#: forms.py:243
 msgid ""
 "Every attendee is a new lead when scanned from a new device. Notes and "
 "ratings are specific to the device."
 msgstr ""
 
-#: exhibition/forms.py:251
+#: forms.py:256
 msgid "Comment"
 msgstr ""
 
-#: exhibition/forms.py:253
+#: forms.py:258
 msgid ""
 "The text entered in this field will not be visible to the user and is "
 "available for your convenience."
 msgstr ""
 
-#: exhibition/forms.py:258 exhibition/forms.py:1427 exhibition/views.py:505
+#: forms.py:263 forms.py:1428 views.py:544
 msgid "Booth ID"
 msgstr ""
 
-#: exhibition/forms.py:291 exhibition/forms.py:1027 exhibition/forms.py:1076
-#: exhibition/models.py:130
+#: forms.py:296 forms.py:1028 forms.py:1077 models.py:130
 msgid "Organization name"
 msgstr ""
 
-#: exhibition/forms.py:292 exhibition/forms.py:1030 exhibition/forms.py:1077
-#: exhibition/models.py:136
+#: forms.py:297 forms.py:1031 forms.py:1078 models.py:136
 msgid "Organization description"
 msgstr ""
 
-#: exhibition/forms.py:293 exhibition/forms.py:1078
+#: forms.py:298 forms.py:1079
 msgid "E-mail"
 msgstr ""
 
-#: exhibition/forms.py:294 exhibition/forms.py:1079 exhibition/models.py:139
+#: forms.py:299 forms.py:1080 models.py:139
 msgid "Contact page URL"
 msgstr ""
 
-#: exhibition/forms.py:295 exhibition/forms.py:1080 exhibition/models.py:140
+#: forms.py:300 forms.py:1081 models.py:140
 msgid "Promotional video URL"
 msgstr ""
 
-#: exhibition/forms.py:296 exhibition/forms.py:1081 exhibition/models.py:141
+#: forms.py:301 forms.py:1082 models.py:141
 msgid "Promotional slides"
 msgstr ""
 
-#: exhibition/forms.py:297 exhibition/forms.py:1082 exhibition/models.py:142
-#: exhibition/models.py:520
-#: exhibition/templates/exhibitors/proposal_detail.html:111
+#: forms.py:302 forms.py:1083 models.py:142 models.py:568
+#: templates/exhibitors/proposal_detail.html:111
 msgid "Logo"
 msgstr ""
 
-#: exhibition/forms.py:298 exhibition/forms.py:1083 exhibition/models.py:145
-#: exhibition/templates/exhibitors/proposal_detail.html:113
+#: forms.py:303 forms.py:1084 models.py:145
+#: templates/exhibitors/proposal_detail.html:113
 msgid "Header image"
 msgstr ""
 
-#: exhibition/forms.py:299 exhibition/forms.py:1084 exhibition/models.py:138
+#: forms.py:304 forms.py:1085 models.py:138
 msgid "Organization website"
 msgstr ""
 
-#: exhibition/forms.py:300
+#: forms.py:305
 msgid "Mark this partner as an exhibitor"
 msgstr ""
 
-#: exhibition/forms.py:301
+#: forms.py:306
 msgid "Mark this partner as an event sponsor"
 msgstr ""
 
-#: exhibition/forms.py:302 exhibition/forms.py:1036 exhibition/forms.py:1085
-#: exhibition/models.py:148 exhibition/models.py:522
+#: forms.py:307 forms.py:1037 forms.py:1086 models.py:148 models.py:570
 msgid "Preferred booth name"
 msgstr ""
 
-#: exhibition/forms.py:303
+#: forms.py:308
 msgid "Can scan attendee badges"
 msgstr ""
 
-#: exhibition/forms.py:307
+#: forms.py:312
 msgid ""
 "Lets this exhibitor sign in to the lead scanning app and scan attendees at "
 "their booth. Turn this off to block scanning entirely."
 msgstr ""
 
-#: exhibition/forms.py:348 exhibition/forms.py:1441
+#: forms.py:353 forms.py:1442
 msgid "No sponsor group"
 msgstr ""
 
-#: exhibition/forms.py:385
+#: forms.py:390
 msgid ""
 "Lets this exhibitor retrieve the attendees who redeemed vouchers issued to "
 "them. Separate from lead scanning, which covers attendees scanned at the "
 "booth."
 msgstr ""
 
-#: exhibition/forms.py:389
+#: forms.py:394
 msgid ""
 "Lets this sponsor retrieve the attendees who redeemed vouchers issued to "
 "them. Separate from lead scanning, which covers attendees scanned at the "
 "booth."
 msgstr ""
 
-#: exhibition/forms.py:393
+#: forms.py:398
 msgid ""
 "Lets this exhibitor and sponsor retrieve the attendees who redeemed vouchers "
 "issued to them. Separate from lead scanning, which covers attendees scanned "
 "at the booth."
 msgstr ""
 
-#: exhibition/forms.py:466 exhibition/forms.py:553 exhibition/forms.py:1361
-#: exhibition/forms.py:1375
+#: forms.py:471 forms.py:558 forms.py:1362 forms.py:1376 forms.py:1855
+#: forms.py:1924 forms.py:1930 forms.py:1932 forms.py:1934
 msgid "This field is required."
 msgstr ""
 
-#: exhibition/forms.py:511 exhibition/forms.py:516
+#: forms.py:516 forms.py:521
 msgid "Slides upload must be a PDF file."
 msgstr ""
 
-#: exhibition/forms.py:540
+#: forms.py:545
 msgid "A partner must be marked as an exhibitor, a sponsor, or both."
 msgstr ""
 
-#: exhibition/forms.py:615
+#: forms.py:620
 msgid "Devices to add"
 msgstr ""
 
-#: exhibition/forms.py:617
+#: forms.py:622
 msgid ""
 "How many new devices to provision now, in addition to any already listed "
 "above. Each device gets its own single-use setup token and QR code."
 msgstr ""
 
-#: exhibition/forms.py:627
-msgid "Select a product…"
+#: forms.py:635
+msgid "Vouchers to take from the pool"
 msgstr ""
 
-#: exhibition/forms.py:628
-msgid "Ticket product"
+#: forms.py:636
+msgid ""
+"Set to 0 to email the codes this partner already has without taking any more."
 msgstr ""
 
-#: exhibition/forms.py:629
-msgid "The product a redeemed voucher applies to."
-msgstr ""
-
-#: exhibition/forms.py:635
-msgid "Number of vouchers"
-msgstr ""
-
-#: exhibition/forms.py:640
-msgid "Maximum usages per voucher"
-msgstr ""
-
-#: exhibition/forms.py:645 exhibition/templates/exhibitors/vouchers.html:33
-#: exhibition/views.py:1995
-msgid "Price effect"
-msgstr ""
-
-#: exhibition/forms.py:651 exhibition/views.py:1996
-msgid "Value"
-msgstr ""
-
-#: exhibition/forms.py:652
-msgid "Amount or percentage, depending on the selected price effect."
-msgstr ""
-
-#: exhibition/forms.py:657 exhibition/templates/exhibitors/vouchers.html:35
-#: exhibition/views.py:1997
-msgid "Valid until"
-msgstr ""
-
-#: exhibition/forms.py:673
-msgid "Enter a value for the selected price effect."
-msgstr ""
-
-#: exhibition/forms.py:678 exhibition/models.py:295
-#: exhibition/templates/exhibitors/settings.html:205
+#: forms.py:647 models.py:326 templates/exhibitors/settings.html:289
 msgid "Level"
 msgstr ""
 
-#: exhibition/forms.py:685 exhibition/models.py:294
+#: forms.py:654 models.py:325
 msgid "Group name"
 msgstr ""
 
-#: exhibition/forms.py:718
+#: forms.py:677 models.py:225
+msgid "Exhibitor voucher pool"
+msgstr ""
+
+#: forms.py:678 models.py:232
+msgid "Sponsor voucher pool"
+msgstr ""
+
+#: forms.py:698
+msgid "— No pool selected —"
+msgstr ""
+
+#: forms.py:699
+msgid "— Use the exhibitor pool —"
+msgstr ""
+
+#: forms.py:719
 msgid "Enable call"
 msgstr ""
 
-#: exhibition/forms.py:719
+#: forms.py:720
 msgid "Hide call page after the deadline"
 msgstr ""
 
-#: exhibition/forms.py:720
+#: forms.py:721
 msgid "Make this call private (accessible only via a secret link)"
 msgstr ""
 
-#: exhibition/forms.py:724
+#: forms.py:725
 msgid ""
 "Turn the call on. Keep it enabled for private calls too, otherwise the "
 "secret link stops working."
 msgstr ""
 
-#: exhibition/forms.py:727
+#: forms.py:728
 msgid ""
 "The call page is not linked anywhere public and can only be opened with the "
 "secret link shown below."
 msgstr ""
 
-#: exhibition/forms.py:868
+#: forms.py:869
 msgid "Your answer"
 msgstr ""
 
-#: exhibition/forms.py:1024 exhibition/models.py:563
-#: exhibition/templates/exhibitors/proposal_detail.html:88
+#: forms.py:1025 models.py:611 templates/exhibitors/proposal_detail.html:88
 msgid "Language"
 msgstr ""
 
-#: exhibition/forms.py:1025
+#: forms.py:1026
 msgid "The language you are filling in this form with."
 msgstr ""
 
-#: exhibition/forms.py:1086 exhibition/models.py:151 exhibition/models.py:523
-#: exhibition/models.py:602
+#: forms.py:1087 models.py:151 models.py:571 models.py:650
 msgid "Message to the organizers"
 msgstr ""
 
-#: exhibition/forms.py:1149
+#: forms.py:1150
 msgid ""
 "The organization name is locked after acceptance. Contact the organizers to "
 "change it."
 msgstr ""
 
-#: exhibition/forms.py:1425
+#: forms.py:1426
 msgid "Approve as exhibitor"
 msgstr ""
 
-#: exhibition/forms.py:1426
+#: forms.py:1427
 msgid "Approve as sponsor"
 msgstr ""
 
-#: exhibition/forms.py:1428 exhibition/models.py:352 exhibition/models.py:596
-#: exhibition/models.py:966 exhibition/views.py:505
+#: forms.py:1429 models.py:383 models.py:644 models.py:1014 views.py:544
 msgid "Booth name"
 msgstr ""
 
-#: exhibition/forms.py:1429 exhibition/forms.py:1459 exhibition/models.py:607
+#: forms.py:1430 forms.py:1460 models.py:655
 msgid "Internal review notes"
 msgstr ""
 
-#: exhibition/forms.py:1470
+#: forms.py:1471
 msgid "Field label"
 msgstr ""
 
-#: exhibition/forms.py:1475 exhibition/forms.py:1510
+#: forms.py:1476 forms.py:1551
 msgid "Help text"
 msgstr ""
 
-#: exhibition/forms.py:1476
+#: forms.py:1477
 msgid "Shown below the field on the exhibitor form."
 msgstr ""
 
-#: exhibition/forms.py:1483
+#: forms.py:1484
 #, python-format
 msgid "Leave empty to use the default: %(label)s"
 msgstr ""
 
-#: exhibition/forms.py:1492
-msgid "Options"
-msgstr ""
-
-#: exhibition/forms.py:1493
-msgid "For choice fields, enter one option per line."
-msgstr ""
-
-#: exhibition/forms.py:1508
-msgid "Field type"
-msgstr ""
-
-#: exhibition/forms.py:1509 exhibition/models.py:878
-msgid "Custom question"
-msgstr ""
-
-#: exhibition/forms.py:1511
-#: exhibition/templates/exhibitors/call_questions.html:31
-#: exhibition/templates/exhibitors/call_questions.html:63
-msgid "Required"
-msgstr ""
-
-#: exhibition/forms.py:1535
+#: forms.py:1523
 msgid "Please provide at least one option for this question type."
 msgstr ""
 
-#: exhibition/forms.py:1576 exhibition/forms.py:1665
+#: forms.py:1549
+msgid "Field type"
+msgstr ""
+
+#: forms.py:1550 models.py:926
+msgid "Custom question"
+msgstr ""
+
+#: forms.py:1552 templates/exhibitors/call_questions.html:31
+#: templates/exhibitors/call_questions.html:63
+msgid "Required"
+msgstr ""
+
+#: forms.py:1583 forms.py:1672
 msgid "Choose social platform"
 msgstr ""
 
-#: exhibition/forms.py:1578 exhibition/forms.py:1667
+#: forms.py:1585 forms.py:1674
 msgid "Social platform"
 msgstr ""
 
-#: exhibition/forms.py:1582 exhibition/forms.py:1671
+#: forms.py:1589 forms.py:1678
 msgid "Profile or path"
 msgstr ""
 
-#: exhibition/forms.py:1596 exhibition/forms.py:1685
+#: forms.py:1603 forms.py:1692
 msgid "Profile, handle, or full URL"
 msgstr ""
 
-#: exhibition/forms.py:1616 exhibition/forms.py:1705
+#: forms.py:1623 forms.py:1712
 msgid "Please enter a profile, handle, or URL or remove this row."
 msgstr ""
 
-#: exhibition/forms.py:1622 exhibition/forms.py:1711
+#: forms.py:1629 forms.py:1718
 msgid "Please choose a social platform."
 msgstr ""
 
-#: exhibition/forms.py:1626 exhibition/forms.py:1715
+#: forms.py:1633 forms.py:1722
 msgid "Please enter a profile, handle, or URL."
 msgstr ""
 
-#: exhibition/forms.py:1648 exhibition/forms.py:1737
+#: forms.py:1655 forms.py:1744
 msgid "Link label"
 msgstr ""
 
-#: exhibition/forms.py:1654 exhibition/forms.py:1743
+#: forms.py:1661 forms.py:1750
 msgid "https://example.com"
 msgstr ""
 
-#: exhibition/forms.py:1807
+#: forms.py:1848
 msgid ""
 "Leave empty to keep this in the outbox until sent manually. Time is "
 "interpreted in the event timezone."
 msgstr ""
 
-#: exhibition/forms.py:1814 exhibition/forms.py:1877
+#: forms.py:1861 forms.py:1940
 msgid "The scheduled time must be in the future."
 msgstr ""
 
-#: exhibition/forms.py:1822
+#: forms.py:1869
 msgid "Exhibitors and sponsors"
 msgstr ""
 
-#: exhibition/forms.py:1823
+#: forms.py:1870
 msgid "Exhibitors only"
 msgstr ""
 
-#: exhibition/forms.py:1824
+#: forms.py:1871
 msgid "Sponsors only"
 msgstr ""
 
-#: exhibition/forms.py:1828
+#: forms.py:1875
 msgid "Application state"
 msgstr ""
 
-#: exhibition/forms.py:1836
+#: forms.py:1883
 msgid "Partner type"
 msgstr ""
 
-#: exhibition/forms.py:1844
+#: forms.py:1891
 msgid "Any sponsor group"
 msgstr ""
 
-#: exhibition/forms.py:1846 exhibition/models.py:1035 exhibition/models.py:1089
-#: exhibition/templates/exhibitors/_email_outbox_body.html:6
-#: exhibition/templates/exhibitors/_email_sent_body.html:6
+#: forms.py:1893 forms.py:1953 models.py:1084 models.py:1146
+#: templates/exhibitors/_email_outbox_body.html:6
+#: templates/exhibitors/_email_sent_body.html:6
 msgid "Subject"
 msgstr ""
 
-#: exhibition/forms.py:1848
+#: forms.py:1895
 msgid "Send at"
 msgstr ""
 
-#: exhibition/forms.py:1851
+#: forms.py:1898
 msgid "Leave empty to send immediately or save to the outbox."
 msgstr ""
 
-#: exhibition/forms.py:1859 exhibition/models.py:1036 exhibition/models.py:1090
+#: forms.py:1906 forms.py:1960 models.py:1085 models.py:1147
 msgid "Body"
 msgstr ""
 
-#: exhibition/forms.py:1885 exhibition/views.py:2576
-msgid "Request received (confirmation)"
-msgstr ""
-
-#: exhibition/forms.py:1886 exhibition/views.py:2577
-msgid "Request accepted"
-msgstr ""
-
-#: exhibition/forms.py:1887 exhibition/views.py:2578
-msgid "Request rejected"
-msgstr ""
-
-#: exhibition/forms.py:1888 exhibition/views.py:2579
-msgid "Exhibitor lead scanning key"
-msgstr ""
-
-#: exhibition/forms.py:1897
-#, python-format
-msgid "%(role)s — subject"
-msgstr ""
-
-#: exhibition/forms.py:1904
-#, python-format
-msgid "%(role)s — body"
-msgstr ""
-
-#: exhibition/mail.py:57
+#: mail.py:59
 #, python-brace-format
 msgid "We received your request for {event_name}"
 msgstr ""
 
-#: exhibition/mail.py:59
+#: mail.py:61
 #, python-brace-format
 msgid ""
 "Hello,\n"
@@ -621,12 +557,12 @@ msgid ""
 "The {event_name} team"
 msgstr ""
 
-#: exhibition/mail.py:69
+#: mail.py:71
 #, python-brace-format
 msgid "Your request for {event_name} has been accepted"
 msgstr ""
 
-#: exhibition/mail.py:71
+#: mail.py:73
 #, python-brace-format
 msgid ""
 "Hello,\n"
@@ -638,12 +574,12 @@ msgid ""
 "The {event_name} team"
 msgstr ""
 
-#: exhibition/mail.py:80
+#: mail.py:82
 #, python-brace-format
 msgid "Update on your request for {event_name}"
 msgstr ""
 
-#: exhibition/mail.py:82
+#: mail.py:84
 #, python-brace-format
 msgid ""
 "Hello,\n"
@@ -657,12 +593,12 @@ msgid ""
 "The {event_name} team"
 msgstr ""
 
-#: exhibition/mail.py:91
+#: mail.py:93
 #, python-brace-format
 msgid "Lead Scanning Access for {event_name}"
 msgstr ""
 
-#: exhibition/mail.py:93
+#: mail.py:95
 #, python-brace-format
 msgid ""
 "Hello {exhibitor_name},\n"
@@ -688,983 +624,1080 @@ msgid ""
 "The {event_name} Team"
 msgstr ""
 
-#: exhibition/mail.py:174
+#: mail.py:110
+#, python-brace-format
+msgid "Your vouchers for {event_name} — {exhibitor_name}"
+msgstr ""
+
+#: mail.py:112
+#, python-brace-format
+msgid ""
+"Dear {exhibitor_name},\n"
+"\n"
+"Thank you for participating in {event_name}. Please share the voucher codes "
+"below with your audience — anyone who uses one gets credited to you as a "
+"lead.\n"
+"\n"
+"{voucher_list}\n"
+"\n"
+"They can redeem a code on the event ticket shop at checkout.\n"
+"\n"
+"If you have any questions, please don't hesitate to reach out.\n"
+"\n"
+"Best regards,\n"
+"The {event_name} Team"
+msgstr ""
+
+#: mail.py:190
 msgid "This value will be replaced based on dynamic parameters."
 msgstr ""
 
-#: exhibition/models.py:137 exhibition/models.py:515
+#: mail.py:312
+#, python-format
+msgid "…and %(count)d more voucher code in the attached CSV file."
+msgid_plural "…and %(count)d more voucher codes in the attached CSV file."
+msgstr[0] ""
+msgstr[1] ""
+
+#: models.py:137 models.py:563
 msgid "Contact email"
 msgstr ""
 
-#: exhibition/models.py:156
-#: exhibition/templates/exhibitors/proposal_detail.html:132
+#: models.py:156 templates/exhibitors/proposal_detail.html:132
 msgid "Social media"
 msgstr ""
 
-#: exhibition/models.py:161
-#: exhibition/templates/exhibitors/proposal_detail.html:140
+#: models.py:161 templates/exhibitors/proposal_detail.html:140
 msgid "Extra links"
 msgstr ""
 
-#: exhibition/models.py:216
+#: models.py:212
+msgid "Vouchers per exhibitor"
+msgstr ""
+
+#: models.py:226
+msgid ""
+"The voucher tag created under Tickets → Vouchers that exhibitors draw their "
+"codes from."
+msgstr ""
+
+#: models.py:233
+msgid "Leave empty to draw sponsor codes from the exhibitor pool as well."
+msgstr ""
+
+#: models.py:239
+msgid "Attach voucher list as CSV"
+msgstr ""
+
+#: models.py:240
+msgid ""
+"Adds a spreadsheet of the recipient's own voucher codes to the voucher email."
+msgstr ""
+
+#: models.py:247
 msgid "Call headline"
 msgstr ""
 
-#: exhibition/models.py:220
+#: models.py:251
 msgid "Call text"
 msgstr ""
 
-#: exhibition/models.py:225
+#: models.py:256
 msgid "Submission deadline"
 msgstr ""
 
-#: exhibition/models.py:298
+#: models.py:329
 msgid "Show this sponsor group on the front page."
 msgstr ""
 
-#: exhibition/models.py:314 exhibition/models.py:558
-#: exhibition/templates/exhibitors/dashboard.html:73
-#: exhibition/templates/exhibitors/exhibitor_info.html:69
-#: exhibition/templates/exhibitors/proposal_list.html:19
-#: exhibition/templates/exhibitors/public_proposal_list.html:11
-#: exhibition/views.py:505
+#: models.py:345 models.py:606 templates/exhibitors/dashboard.html:73
+#: templates/exhibitors/exhibitor_info.html:79
+#: templates/exhibitors/proposal_list.html:19
+#: templates/exhibitors/public_proposal_list.html:11 views.py:544
 msgid "Name"
 msgstr ""
 
-#: exhibition/models.py:315 exhibition/models.py:559
-#: exhibition/templates/exhibitors/proposal_detail.html:117
+#: models.py:346 models.py:607 templates/exhibitors/proposal_detail.html:117
 msgid "Description"
 msgstr ""
 
-#: exhibition/models.py:316 exhibition/models.py:419 exhibition/models.py:435
-#: exhibition/models.py:565 exhibition/models.py:815 exhibition/models.py:831
-#: exhibition/models.py:844
-#: exhibition/templates/exhibitors/proposal_detail.html:103
+#: models.py:347 models.py:467 models.py:483 models.py:613 models.py:863
+#: models.py:879 models.py:892 templates/exhibitors/proposal_detail.html:103
 msgid "URL"
 msgstr ""
 
-#: exhibition/models.py:317 exhibition/models.py:566
-#: exhibition/templates/exhibitors/proposal_detail.html:77
-#: exhibition/views.py:505
+#: models.py:348 models.py:614 templates/exhibitors/proposal_detail.html:77
+#: views.py:544
 msgid "Email"
 msgstr ""
 
-#: exhibition/models.py:318 exhibition/models.py:567
-#: exhibition/templates/exhibitors/proposal_detail.html:105
+#: models.py:349 models.py:615 templates/exhibitors/proposal_detail.html:105
 msgid "Contact URL"
 msgstr ""
 
-#: exhibition/models.py:319 exhibition/models.py:568
-#: exhibition/templates/exhibitors/proposal_detail.html:107
+#: models.py:350 models.py:616 templates/exhibitors/proposal_detail.html:107
 msgid "Video URL"
 msgstr ""
 
-#: exhibition/models.py:322 exhibition/models.py:571
-#: exhibition/templates/exhibitors/proposal_detail.html:109
+#: models.py:353 models.py:619 templates/exhibitors/proposal_detail.html:109
 msgid "Slides"
 msgstr ""
 
-#: exhibition/models.py:326 exhibition/models.py:575
+#: models.py:357 models.py:623
 msgid "Slides URL"
 msgstr ""
 
-#: exhibition/models.py:328 exhibition/models.py:577
+#: models.py:359 models.py:625
 msgid "Logo URL"
 msgstr ""
 
-#: exhibition/models.py:330 exhibition/models.py:579
+#: models.py:361 models.py:627
 msgid "Header image URL"
 msgstr ""
 
-#: exhibition/models.py:434 exhibition/models.py:830
+#: models.py:482 models.py:878
 msgid "Label"
 msgstr ""
 
-#: exhibition/models.py:445
+#: models.py:493
 msgid "draft"
 msgstr ""
 
-#: exhibition/models.py:446
+#: models.py:494
 msgid "submitted"
 msgstr ""
 
-#: exhibition/models.py:447
+#: models.py:495
 msgid "accepted"
 msgstr ""
 
-#: exhibition/models.py:448
+#: models.py:496
 msgid "rejected"
 msgstr ""
 
-#: exhibition/models.py:449
+#: models.py:497
 msgid "withdrawn"
 msgstr ""
 
-#: exhibition/models.py:514
+#: models.py:562
 msgid "Organization Description"
 msgstr ""
 
-#: exhibition/models.py:516
+#: models.py:564
 msgid "Organization Website"
 msgstr ""
 
-#: exhibition/models.py:517
+#: models.py:565
 msgid "Contact Page URL"
 msgstr ""
 
-#: exhibition/models.py:518
+#: models.py:566
 msgid "Promotional Video URL"
 msgstr ""
 
-#: exhibition/models.py:519
+#: models.py:567
 msgid "Promotional Slides"
 msgstr ""
 
-#: exhibition/models.py:521
+#: models.py:569
 msgid "Header Image"
 msgstr ""
 
-#: exhibition/models.py:524 exhibition/templates/exhibitors/add.html:29
-#: exhibition/templates/exhibitors/public_proposal_form.html:38
+#: models.py:572 templates/exhibitors/add.html:29
+#: templates/exhibitors/public_proposal_form.html:38
 msgid "Social Media"
 msgstr ""
 
-#: exhibition/models.py:525 exhibition/templates/exhibitors/add.html:92
-#: exhibition/templates/exhibitors/public_proposal_form.html:91
+#: models.py:573 templates/exhibitors/add.html:92
+#: templates/exhibitors/public_proposal_form.html:91
 msgid "Extra Links"
 msgstr ""
 
-#: exhibition/models.py:841
+#: models.py:889
 msgid "Number"
 msgstr ""
 
-#: exhibition/models.py:842
+#: models.py:890
 msgid "Text (one line)"
 msgstr ""
 
-#: exhibition/models.py:843
+#: models.py:891
 msgid "Multiline text"
 msgstr ""
 
-#: exhibition/models.py:845
+#: models.py:893
 msgid "Email address"
 msgstr ""
 
-#: exhibition/models.py:846
+#: models.py:894
 msgid "Confirm Checkbox"
 msgstr ""
 
-#: exhibition/models.py:847
+#: models.py:895
 msgid "Radio button (Choose one option)"
 msgstr ""
 
-#: exhibition/models.py:848
+#: models.py:896
 msgid "Dropdown (Choose one option)"
 msgstr ""
 
-#: exhibition/models.py:849
+#: models.py:897
 msgid "Checkbox (Choose one or several options)"
 msgstr ""
 
-#: exhibition/models.py:850
+#: models.py:898
 msgid "File upload"
 msgstr ""
 
-#: exhibition/models.py:851
+#: models.py:899
 msgid "Date"
 msgstr ""
 
-#: exhibition/models.py:852
+#: models.py:900
 msgid "Time"
 msgstr ""
 
-#: exhibition/models.py:853
+#: models.py:901
 msgid "Date and time"
 msgstr ""
 
-#: exhibition/models.py:854
+#: models.py:902
 msgid "Country code (ISO 3166-1 alpha-2)"
 msgstr ""
 
-#: exhibition/models.py:855
+#: models.py:903
 msgid "Phone number"
 msgstr ""
 
-#: exhibition/models.py:883
+#: models.py:931
 msgid "help text"
 msgstr ""
 
-#: exhibition/models.py:885 exhibition/templates/exhibitors/add.html:29
-#: exhibition/templates/exhibitors/add.html:92
-#: exhibition/templates/exhibitors/public_proposal_form.html:38
-#: exhibition/templates/exhibitors/public_proposal_form.html:91
+#: models.py:933 templates/exhibitors/add.html:29
+#: templates/exhibitors/add.html:92
+#: templates/exhibitors/public_proposal_form.html:38
+#: templates/exhibitors/public_proposal_form.html:91
 msgid "required"
 msgstr ""
 
-#: exhibition/models.py:886
+#: models.py:934
 msgid "active"
 msgstr ""
 
-#: exhibition/models.py:906
+#: models.py:954
 msgid "Response"
 msgstr ""
 
-#: exhibition/models.py:938
+#: models.py:986
 msgid "Yes"
 msgstr ""
 
-#: exhibition/models.py:940
+#: models.py:988
 msgid "No"
 msgstr ""
 
-#: exhibition/models.py:1034
-#: exhibition/templates/exhibitors/_email_outbox_body.html:5
-#: exhibition/templates/exhibitors/_email_sent_body.html:5
+#: models.py:1083 templates/exhibitors/_email_outbox_body.html:5
+#: templates/exhibitors/_email_sent_body.html:5
 msgid "Recipient"
 msgstr ""
 
-#: exhibition/models.py:1045
+#: models.py:1101
 msgid "Queued email"
 msgstr ""
 
-#: exhibition/models.py:1046
+#: models.py:1102
 msgid "Queued emails"
 msgstr ""
 
-#: exhibition/models.py:1088
+#: models.py:1145
 msgid "Template name"
 msgstr ""
 
-#: exhibition/models.py:1095
+#: models.py:1152
 msgid "Custom email template"
 msgstr ""
 
-#: exhibition/models.py:1096
+#: models.py:1153
 msgid "Custom email templates"
 msgstr ""
 
-#: exhibition/signals.py:75
+#: signals.py:81
 msgid "Screen and evaluate exhibitor and sponsor requests for the event."
 msgstr ""
 
-#: exhibition/signals.py:76
+#: signals.py:82
 msgid "Request Review Dashboard"
 msgstr ""
 
-#: exhibition/signals.py:80
+#: signals.py:86
 msgid ""
 "Manage exhibitors and sponsors, maintain booth details, and create partner "
 "profiles for the event."
 msgstr ""
 
-#: exhibition/signals.py:82
+#: signals.py:88
 msgid "Exhibitors & Sponsors Dashboard"
 msgstr ""
 
-#: exhibition/signals.py:88 exhibition/templates/exhibitors/base.html:5
-#: exhibition/templates/exhibitors/base.html:125
-#: exhibition/templates/exhibitors/exhibitor_info.html:4
-#: exhibition/templates/exhibitors/exhibitor_info.html:15
+#: signals.py:94 templates/exhibitors/base.html:6
+#: templates/exhibitors/base.html:136
+#: templates/exhibitors/exhibitor_info.html:4
+#: templates/exhibitors/exhibitor_info.html:15
 msgid "Exhibitors & Sponsors"
 msgstr ""
 
-#: exhibition/signals.py:90
+#: signals.py:96
 msgid "Go to"
 msgstr ""
 
-#: exhibition/signals.py:166 exhibition/templates/exhibitors/call_base.html:4
-#: exhibition/templates/exhibitors/call_base.html:7
-#: exhibition/templates/exhibitors/public_call.html:7
-#: exhibition/templates/exhibitors/settings.html:8
-#: exhibition/templates/exhibitors/settings.html:25
+#: signals.py:172 templates/exhibitors/call_base.html:4
+#: templates/exhibitors/call_base.html:7
+#: templates/exhibitors/public_call.html:7 templates/exhibitors/settings.html:8
+#: templates/exhibitors/settings.html:27
 msgid "Call for Exhibitors"
 msgstr ""
 
-#: exhibition/signals.py:207 exhibition/signals.py:231
+#: signals.py:213 signals.py:237
 msgid "Acme Corp"
 msgstr ""
 
-#: exhibition/signals.py:225
+#: signals.py:231
 msgid "Jane Doe"
 msgstr ""
 
-#: exhibition/signals.py:293 exhibition/templates/exhibitors/base.html:62
-#: exhibition/templates/exhibitors/proposal_list.html:5
-#: exhibition/templates/exhibitors/proposal_list.html:15
+#: signals.py:305 templates/exhibitors/base.html:73
+#: templates/exhibitors/proposal_list.html:5
+#: templates/exhibitors/proposal_list.html:15
 msgid "Exhibition requests"
 msgstr ""
 
-#: exhibition/signals.py:298
+#: signals.py:310
 msgid "Exhibition request approved."
 msgstr ""
 
-#: exhibition/signals.py:299
+#: signals.py:311
 msgid "Exhibition request rejected."
 msgstr ""
 
-#: exhibition/signals.py:300
+#: signals.py:312
 msgid "Exhibition request withdrawn."
 msgstr ""
 
-#: exhibition/signals.py:301
+#: signals.py:313
 msgid "Exhibition request reopened for review."
 msgstr ""
 
-#: exhibition/signals.py:302
+#: signals.py:314
 msgid "Exhibition request changed."
 msgstr ""
 
-#: exhibition/signals.py:303
+#: signals.py:315
 msgid "Organization profile created from an approved request."
 msgstr ""
 
-#: exhibition/signals.py:304
+#: signals.py:316
 msgid "Organization profile reactivated after re-approval."
 msgstr ""
 
-#: exhibition/signals.py:305
+#: signals.py:317
 msgid "Organization profile updated from the submitter's changes."
 msgstr ""
 
-#: exhibition/signals.py:306
+#: signals.py:318
 msgid "Organization profile created."
 msgstr ""
 
-#: exhibition/signals.py:307
+#: signals.py:319
 msgid "Organization profile changed."
 msgstr ""
 
-#: exhibition/signals.py:308
+#: signals.py:320
 msgid "Organization profile deleted."
 msgstr ""
 
-#: exhibition/signals.py:309
+#: signals.py:321
 msgid "Exhibition settings changed."
 msgstr ""
 
-#: exhibition/signals.py:310
+#: signals.py:322
 msgid "Call for exhibitors settings changed."
 msgstr ""
 
-#: exhibition/signals.py:311
+#: signals.py:323
 msgid "Private call link regenerated."
 msgstr ""
 
-#: exhibition/signals.py:312
+#: signals.py:324
 msgid "Sponsor group created."
 msgstr ""
 
-#: exhibition/signals.py:313
+#: signals.py:325
 msgid "Sponsor group changed."
 msgstr ""
 
-#: exhibition/signals.py:314 exhibition/views.py:457
+#: signals.py:326 views.py:496
 msgid "Sponsor group deleted."
 msgstr ""
 
-#: exhibition/signals.py:315
+#: signals.py:327
 msgid "Exhibitor form question created."
 msgstr ""
 
-#: exhibition/signals.py:316
+#: signals.py:328
 msgid "Exhibitor form question changed."
 msgstr ""
 
-#: exhibition/signals.py:317
+#: signals.py:329
 msgid "Exhibitor form question deleted."
 msgstr ""
 
-#: exhibition/signals.py:318
+#: signals.py:330
 msgid "Email sent."
 msgstr ""
 
-#: exhibition/signals.py:337
+#: signals.py:349
 #, python-brace-format
 msgid "Updated: {fields}."
 msgstr ""
 
-#: exhibition/signals.py:360
+#: signals.py:372
 #, python-brace-format
 msgid "State changed from {old} to {new}."
 msgstr ""
 
-#: exhibition/signals.py:382
+#: signals.py:394
 #, python-brace-format
 msgid "Exhibition request {val}"
 msgstr ""
 
-#: exhibition/signals.py:391
+#: signals.py:403
 #, python-brace-format
 msgid "Organization profile {val}"
 msgstr ""
 
-#: exhibition/signals.py:400
+#: signals.py:412
 #, python-brace-format
 msgid "Exhibitor form question {val}"
 msgstr ""
 
-#: exhibition/signals.py:409
+#: signals.py:421
 #, python-brace-format
 msgid "Sponsor group {val}"
 msgstr ""
 
-#: exhibition/social_links.py:36
+#: social_links.py:36
 msgid "Facebook"
 msgstr ""
 
-#: exhibition/social_links.py:43
+#: social_links.py:43
 msgid "Flickr"
 msgstr ""
 
-#: exhibition/social_links.py:50
+#: social_links.py:50
 msgid "GitHub"
 msgstr ""
 
-#: exhibition/social_links.py:57
+#: social_links.py:57
 msgid "GitLab"
 msgstr ""
 
-#: exhibition/social_links.py:64
+#: social_links.py:64
 msgid "Gitter"
 msgstr ""
 
-#: exhibition/social_links.py:71
+#: social_links.py:71
 msgid "Google Groups"
 msgstr ""
 
-#: exhibition/social_links.py:78
+#: social_links.py:78
 msgid "Instagram"
 msgstr ""
 
-#: exhibition/social_links.py:85
+#: social_links.py:85
 msgid "LinkedIn"
 msgstr ""
 
-#: exhibition/social_links.py:92
+#: social_links.py:92
 msgid "Mastodon"
 msgstr ""
 
-#: exhibition/social_links.py:99
+#: social_links.py:99
 msgid "Patreon"
 msgstr ""
 
-#: exhibition/social_links.py:106
+#: social_links.py:106
 msgid "Telegram"
 msgstr ""
 
-#: exhibition/social_links.py:113
+#: social_links.py:113
 msgid "Vimeo"
 msgstr ""
 
-#: exhibition/social_links.py:120
+#: social_links.py:120
 msgid "VK"
 msgstr ""
 
-#: exhibition/social_links.py:127
+#: social_links.py:127
 msgid "Weibo"
 msgstr ""
 
-#: exhibition/social_links.py:134
+#: social_links.py:134
 msgid "X"
 msgstr ""
 
-#: exhibition/social_links.py:141
+#: social_links.py:141
 msgid "Xing"
 msgstr ""
 
-#: exhibition/social_links.py:148
+#: social_links.py:148
 msgid "YouTube"
 msgstr ""
 
-#: exhibition/social_links.py:155
+#: social_links.py:155
 msgid "YouTube Privacy"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:7
+#: templates/exhibitors/_email_outbox_body.html:7
 msgid "Created"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:14
+#: templates/exhibitors/_email_outbox_body.html:14
 msgid "Send selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:17
+#: templates/exhibitors/_email_outbox_body.html:17
 msgid "Discard selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:20
+#: templates/exhibitors/_email_outbox_body.html:20
 msgid "Send all"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:23
+#: templates/exhibitors/_email_outbox_body.html:23
 msgid "Discard all"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:35
+#: templates/exhibitors/_email_outbox_body.html:35
 msgid "Scheduled"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:36
-#: exhibition/templates/exhibitors/proposal_list.html:65
+#: templates/exhibitors/_email_outbox_body.html:36
+#: templates/exhibitors/proposal_list.html:65
 msgid "Actions"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:67
-msgid "Send this email"
+#: templates/exhibitors/_email_outbox_body.html:68
+msgid "Send"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:73
-msgid "Edit this email"
+#: templates/exhibitors/_email_outbox_body.html:75
+#: templates/exhibitors/_partner_row.html:54
+#: templates/exhibitors/call_questions.html:73
+#: templates/exhibitors/call_questions.html:76
+#: templates/exhibitors/dashboard.html:120
+#: templates/exhibitors/email_compose.html:55
+#: templates/exhibitors/email_custom_template_form.html:30
+#: templates/exhibitors/email_templates.html:50
+#: templates/exhibitors/email_templates.html:97
+#: templates/exhibitors/public_proposal_list.html:32
+#: templates/exhibitors/settings.html:59
+msgid "Edit"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:79
-msgid "Discard this email"
+#: templates/exhibitors/_email_outbox_body.html:82
+#: templates/exhibitors/email_bulk_discard.html:30
+#: templates/exhibitors/email_delete.html:31
+msgid "Discard"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:91
-#: exhibition/templates/exhibitors/_email_sent_body.html:34
+#: templates/exhibitors/_email_outbox_body.html:95
+#: templates/exhibitors/_email_sent_body.html:35
 msgid "No emails match your search."
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:93
+#: templates/exhibitors/_email_outbox_body.html:97
 msgid "The outbox is empty."
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_sent_body.html:7
-#: exhibition/templates/exhibitors/base.html:105
+#: templates/exhibitors/_email_sent_body.html:7
+#: templates/exhibitors/_partner_row.html:45 templates/exhibitors/base.html:116
 msgid "Sent"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_sent_body.html:36
+#: templates/exhibitors/_email_sent_body.html:37
 msgid "No emails have been sent yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:12
-#: exhibition/templates/exhibitors/public_list.html:29
+#: templates/exhibitors/_filter_form.html:12
+#: templates/exhibitors/public_list.html:29
 msgid "Search"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:18
-#: exhibition/templates/exhibitors/_filter_form.html:20
+#: templates/exhibitors/_filter_form.html:18
+#: templates/exhibitors/_filter_form.html:21
 msgid "Clear filters"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:29
+#: templates/exhibitors/_filter_form.html:30
 msgid "Filters"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:50
+#: templates/exhibitors/_filter_form.html:51
 msgid "Apply filters"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:5
+#: templates/exhibitors/_image_preview_dialog.html:11
+msgid "Close preview"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:5
 #, python-format
 msgid "Select %(name)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:33
+#: templates/exhibitors/_partner_row.html:33
 msgid "Untitled"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:40
+#: templates/exhibitors/_partner_row.html:40
+msgid "Waiting in the outbox"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:41
+msgid "In outbox"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:44
+#, python-format
+msgid "Last sent %(sent)s"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:48
+msgid "Not sent"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:55
 msgid "Copied!"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:40
+#: templates/exhibitors/_partner_row.html:55
 msgid "Copy failed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:40
+#: templates/exhibitors/_partner_row.html:55
 msgid "Key"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:41
-#: exhibition/templates/exhibitors/add.html:231
-#: exhibition/templates/exhibitors/vouchers.html:5
+#: templates/exhibitors/_partner_row.html:56 templates/exhibitors/add.html:235
+#: templates/exhibitors/base.html:42
+#: templates/exhibitors/exhibitor_info.html:95
+#: templates/exhibitors/exhibitor_info.html:125
+#: templates/exhibitors/vouchers.html:5 views.py:2933
 msgid "Vouchers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:42
-#: exhibition/templates/exhibitors/devices.html:5
+#: templates/exhibitors/_partner_row.html:57
+#: templates/exhibitors/devices.html:5
 msgid "Lead-scanning devices"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:45
+#: templates/exhibitors/_partner_row.html:58
+#: templates/exhibitors/call_question_delete.html:19
+#: templates/exhibitors/call_questions.html:74
+#: templates/exhibitors/delete.html:19
+#: templates/exhibitors/email_custom_template_delete.html:19
+#: templates/exhibitors/settings.html:335
+msgid "Delete"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:60
 msgid "Move"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_sort_header.html:7
+#: templates/exhibitors/_sort_header.html:7
 msgid "Sort ascending"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_sort_header.html:10
+#: templates/exhibitors/_sort_header.html:10
 msgid "Sort descending"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:24
+#: templates/exhibitors/add.html:24
 msgid "Profile"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:29
-#: exhibition/templates/exhibitors/add.html:92
-#: exhibition/templates/exhibitors/call_questions.html:62
-#: exhibition/templates/exhibitors/settings.html:50
+#: templates/exhibitors/add.html:29 templates/exhibitors/add.html:92
+#: templates/exhibitors/call_questions.html:62
+#: templates/exhibitors/settings.html:54
 msgid "Optional"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:80
-#: exhibition/templates/exhibitors/public_proposal_form.html:79
+#: templates/exhibitors/add.html:80
+#: templates/exhibitors/public_proposal_form.html:79
 msgid "Add social media link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:137
-#: exhibition/templates/exhibitors/public_proposal_form.html:120
+#: templates/exhibitors/add.html:137
+#: templates/exhibitors/public_proposal_form.html:120
 msgid "Add extra link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:157
-#: exhibition/templates/exhibitors/add.html:160
-#: exhibition/templates/exhibitors/public_proposal_form.html:140
-#: exhibition/templates/exhibitors/public_proposal_form.html:143
+#: templates/exhibitors/add.html:157 templates/exhibitors/add.html:161
+#: templates/exhibitors/public_proposal_form.html:140
+#: templates/exhibitors/public_proposal_form.html:144
 msgid "Logo preview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:162
-#: exhibition/templates/exhibitors/add.html:180
-#: exhibition/templates/exhibitors/public_proposal_form.html:145
-#: exhibition/templates/exhibitors/public_proposal_form.html:163
+#: templates/exhibitors/add.html:164 templates/exhibitors/add.html:184
+#: templates/exhibitors/public_proposal_form.html:147
+#: templates/exhibitors/public_proposal_form.html:167
 msgid "We could not load this image preview."
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:175
-#: exhibition/templates/exhibitors/add.html:178
-#: exhibition/templates/exhibitors/public_proposal_form.html:158
-#: exhibition/templates/exhibitors/public_proposal_form.html:161
+#: templates/exhibitors/add.html:177 templates/exhibitors/add.html:181
+#: templates/exhibitors/public_proposal_form.html:160
+#: templates/exhibitors/public_proposal_form.html:164
 msgid "Header image preview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:196
+#: templates/exhibitors/add.html:200
 msgid "Organizer only"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:237
+#: templates/exhibitors/add.html:241
 msgid "Internal notes"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:244
-#: exhibition/templates/exhibitors/email_edit.html:38
-#: exhibition/templates/exhibitors/public_proposal_form.html:182
-#: exhibition/templates/exhibitors/public_proposal_form.html:186
+#: templates/exhibitors/add.html:248 templates/exhibitors/email_edit.html:38
+#: templates/exhibitors/public_proposal_form.html:186
+#: templates/exhibitors/public_proposal_form.html:190
 msgid "Save changes"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:246
-#: exhibition/templates/exhibitors/call_default_field_form.html:21
-#: exhibition/templates/exhibitors/call_question_form.html:30
-#: exhibition/templates/exhibitors/call_questions.html:96
-#: exhibition/templates/exhibitors/email_custom_template_form.html:51
-#: exhibition/templates/exhibitors/email_templates.html:123
-#: exhibition/templates/exhibitors/proposal_detail.html:188
-#: exhibition/templates/exhibitors/settings.html:85
-#: exhibition/templates/exhibitors/settings.html:170
-#: exhibition/templates/exhibitors/settings.html:269
+#: templates/exhibitors/add.html:250
+#: templates/exhibitors/call_default_field_form.html:21
+#: templates/exhibitors/call_question_form.html:114
+#: templates/exhibitors/call_questions.html:96
+#: templates/exhibitors/email_custom_template_form.html:51
+#: templates/exhibitors/email_templates.html:123
+#: templates/exhibitors/proposal_detail.html:188
+#: templates/exhibitors/settings.html:89 templates/exhibitors/settings.html:217
+#: templates/exhibitors/settings.html:250
+#: templates/exhibitors/settings.html:359
 msgid "Save"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:255
-#: exhibition/templates/exhibitors/call_default_field_form.html:23
-#: exhibition/templates/exhibitors/call_default_field_reset.html:24
-#: exhibition/templates/exhibitors/call_question_delete.html:21
-#: exhibition/templates/exhibitors/call_question_form.html:32
-#: exhibition/templates/exhibitors/delete.html:24
-#: exhibition/templates/exhibitors/email_bulk_discard.html:27
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:21
-#: exhibition/templates/exhibitors/email_custom_template_form.html:53
-#: exhibition/templates/exhibitors/email_delete.html:28
-#: exhibition/templates/exhibitors/proposal_list.html:174
-#: exhibition/templates/exhibitors/public_proposal_form.html:176
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:16
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:21
-#: exhibition/templates/exhibitors/settings.html:194
-#: exhibition/templates/exhibitors/settings.html:270
+#: templates/exhibitors/add.html:259
+#: templates/exhibitors/call_default_field_form.html:23
+#: templates/exhibitors/call_default_field_reset.html:24
+#: templates/exhibitors/call_question_delete.html:21
+#: templates/exhibitors/call_question_form.html:116
+#: templates/exhibitors/delete.html:24
+#: templates/exhibitors/email_bulk_discard.html:27
+#: templates/exhibitors/email_custom_template_delete.html:21
+#: templates/exhibitors/email_custom_template_form.html:53
+#: templates/exhibitors/email_delete.html:28
+#: templates/exhibitors/proposal_list.html:175
+#: templates/exhibitors/public_proposal_form.html:180
+#: templates/exhibitors/public_proposal_reinstate.html:16
+#: templates/exhibitors/public_proposal_withdraw.html:21
+#: templates/exhibitors/settings.html:278
+#: templates/exhibitors/settings.html:360
+#: templates/exhibitors/voucher_bulk_send.html:96
 msgid "Cancel"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:262
-#: exhibition/templates/exhibitors/proposal_detail.html:208
+#: templates/exhibitors/add.html:266
+#: templates/exhibitors/proposal_detail.html:208
 msgid "History"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:11
+#: templates/exhibitors/base.html:17
 msgid "Overview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:18
-#: exhibition/templates/exhibitors/call_questions.html:33
+#: templates/exhibitors/base.html:24
+#: templates/exhibitors/call_questions.html:33
 msgid "Settings"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:26
-#: exhibition/templates/exhibitors/base.html:70
-#: exhibition/templates/exhibitors/dashboard.html:21
-#: exhibition/templates/exhibitors/exhibitor_info.html:4
-#: exhibition/templates/exhibitors/exhibitor_info.html:15
+#: templates/exhibitors/base.html:32 templates/exhibitors/base.html:81
+#: templates/exhibitors/dashboard.html:21
+#: templates/exhibitors/exhibitor_info.html:4
+#: templates/exhibitors/exhibitor_info.html:15
 msgid "Exhibitors"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:31
-#: exhibition/templates/exhibitors/base.html:76
-#: exhibition/templates/exhibitors/dashboard.html:29
-#: exhibition/templates/exhibitors/exhibitor_info.html:4
-#: exhibition/templates/exhibitors/exhibitor_info.html:15
+#: templates/exhibitors/base.html:37 templates/exhibitors/base.html:87
+#: templates/exhibitors/dashboard.html:29
+#: templates/exhibitors/exhibitor_info.html:4
+#: templates/exhibitors/exhibitor_info.html:15
 msgid "Sponsors"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:39
-#: exhibition/templates/exhibitors/dashboard.html:117
+#: templates/exhibitors/base.html:50 templates/exhibitors/dashboard.html:117
 msgid "Call for exhibitors"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:47
+#: templates/exhibitors/base.html:58
 msgid "Content"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:52
-#: exhibition/templates/exhibitors/call_questions.html:5
-#: exhibition/templates/exhibitors/call_questions.html:16
+#: templates/exhibitors/base.html:63 templates/exhibitors/call_questions.html:5
+#: templates/exhibitors/call_questions.html:16
 msgid "Exhibitor form"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:85
+#: templates/exhibitors/base.html:96
 msgid "Message center"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:94
+#: templates/exhibitors/base.html:105
 msgid "Compose"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:99
+#: templates/exhibitors/base.html:110
 msgid "Outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:111
+#: templates/exhibitors/base.html:122
 msgid "Templates"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:130
+#: templates/exhibitors/base.html:141
 msgid "Home"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:134
+#: templates/exhibitors/base.html:145
 msgid "Tickets"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:138
+#: templates/exhibitors/base.html:149
 msgid "Talks"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:143
+#: templates/exhibitors/base.html:154
 msgid "Access videos related to this event"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:144
+#: templates/exhibitors/base.html:155
 msgid "Videos"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_form.html:5
-#: exhibition/templates/exhibitors/call_default_field_form.html:8
-#: exhibition/templates/exhibitors/call_question_form.html:11
-#: exhibition/templates/exhibitors/call_question_form.html:14
+#: templates/exhibitors/call_default_field_form.html:5
+#: templates/exhibitors/call_default_field_form.html:8
+#: templates/exhibitors/call_question_form.html:14
+#: templates/exhibitors/call_question_form.html:17
 msgid "Form field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:4
-#: exhibition/templates/exhibitors/call_default_field_reset.html:7
+#: templates/exhibitors/call_default_field_reset.html:4
+#: templates/exhibitors/call_default_field_reset.html:7
 msgid "Reset form field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:14
+#: templates/exhibitors/call_default_field_reset.html:14
 #, python-format
 msgid ""
 "Are you sure you want to reset \"%(label)s\" back to the default "
 "\"%(default_label)s\"?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:19
+#: templates/exhibitors/call_default_field_reset.html:19
 msgid ""
 "This clears the custom label and help text. Default fields are part of the "
 "form and cannot be deleted; turn the field off with the Active toggle to "
 "hide it."
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:22
-#: exhibition/templates/exhibitors/public_list.html:32
+#: templates/exhibitors/call_default_field_reset.html:22
 msgid "Reset"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_question_delete.html:4
-#: exhibition/templates/exhibitors/call_question_delete.html:7
+#: templates/exhibitors/call_question_delete.html:4
+#: templates/exhibitors/call_question_delete.html:7
 msgid "Delete form field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_question_delete.html:14
+#: templates/exhibitors/call_question_delete.html:14
 #, python-format
 msgid "Are you sure you want to delete the question \"%(question)s\"?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_question_delete.html:19
-#: exhibition/templates/exhibitors/call_questions.html:74
-#: exhibition/templates/exhibitors/delete.html:19
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:19
-msgid "Delete"
+#: templates/exhibitors/call_question_form.html:31
+msgid "Answer options"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:23
+#: templates/exhibitors/call_question_form.html:34
+msgid "Only applicable if you choose a choice field type above."
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:48
+#, python-format
+msgid "Answer option %(id)s"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:56
+#: templates/exhibitors/call_question_form.html:58
+#: templates/exhibitors/call_question_form.html:87
+#: templates/exhibitors/call_question_form.html:89
+msgid "Move option up"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:60
+#: templates/exhibitors/call_question_form.html:62
+#: templates/exhibitors/call_question_form.html:91
+#: templates/exhibitors/call_question_form.html:93
+msgid "Move option down"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:64
+#: templates/exhibitors/call_question_form.html:66
+#: templates/exhibitors/call_question_form.html:95
+#: templates/exhibitors/call_question_form.html:97
+msgid "Delete option"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:81
+msgid "New answer option"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:106
+msgid "Add a new option"
+msgstr ""
+
+#: templates/exhibitors/call_questions.html:23
 msgid "Form fields"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:24
+#: templates/exhibitors/call_questions.html:24
 msgid ""
 "Choose which fields are shown on the exhibitor form and drag any row to "
 "reorder it."
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:29
-#: exhibition/templates/exhibitors/proposal_detail.html:38
+#: templates/exhibitors/call_questions.html:29
+#: templates/exhibitors/proposal_detail.html:38
 msgid "Field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:32
+#: templates/exhibitors/call_questions.html:32
 msgid "Answers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:42
+#: templates/exhibitors/call_questions.html:42
 msgid "Custom"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:48
+#: templates/exhibitors/call_questions.html:48
 #, python-format
 msgid "Toggle active state for %(field)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:61
+#: templates/exhibitors/call_questions.html:61
 #, python-format
 msgid "Required status for %(field)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:73
-#: exhibition/templates/exhibitors/call_questions.html:76
-#: exhibition/templates/exhibitors/dashboard.html:120
-#: exhibition/templates/exhibitors/email_compose.html:55
-#: exhibition/templates/exhibitors/email_custom_template_form.html:30
-#: exhibition/templates/exhibitors/email_templates.html:50
-#: exhibition/templates/exhibitors/email_templates.html:97
-#: exhibition/templates/exhibitors/public_proposal_list.html:32
-#: exhibition/templates/exhibitors/settings.html:55
-msgid "Edit"
-msgstr ""
-
-#: exhibition/templates/exhibitors/call_questions.html:77
+#: templates/exhibitors/call_questions.html:77
 msgid "Reset to default"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:79
+#: templates/exhibitors/call_questions.html:79
 msgid "Move field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:90
+#: templates/exhibitors/call_questions.html:90
 msgid "New custom field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:5
-#: exhibition/templates/exhibitors/dashboard.html:9
+#: templates/exhibitors/dashboard.html:5 templates/exhibitors/dashboard.html:9
 msgid "Exhibition overview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:39
+#: templates/exhibitors/dashboard.html:39
 msgid "Requests awaiting review"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:48
+#: templates/exhibitors/dashboard.html:48
 msgid "Emails in outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:61
+#: templates/exhibitors/dashboard.html:61
 msgid "Recent requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:64
+#: templates/exhibitors/dashboard.html:64
 msgid "View all"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:76
+#: templates/exhibitors/dashboard.html:76
 msgid "Submitted"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:91
-#: exhibition/templates/exhibitors/proposal_detail.html:97
-#: exhibition/templates/exhibitors/proposal_list.html:97
+#: templates/exhibitors/dashboard.html:91
+#: templates/exhibitors/proposal_detail.html:97
+#: templates/exhibitors/proposal_list.html:97
 msgid "Sponsor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:93
-#: exhibition/templates/exhibitors/proposal_detail.html:99
-#: exhibition/templates/exhibitors/proposal_list.html:99
+#: templates/exhibitors/dashboard.html:93
+#: templates/exhibitors/proposal_detail.html:99
+#: templates/exhibitors/proposal_list.html:99
 msgid "Exhibitor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:105
+#: templates/exhibitors/dashboard.html:105
 msgid "No requests have been submitted yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:128
+#: templates/exhibitors/dashboard.html:128
 msgid "The call is not published, so nobody can submit a request."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:131
+#: templates/exhibitors/dashboard.html:131
 msgid "Open"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:134
+#: templates/exhibitors/dashboard.html:134
 #, python-format
 msgid "Closes on %(deadline)s."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:139
+#: templates/exhibitors/dashboard.html:139
 msgid "No deadline set."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:142
+#: templates/exhibitors/dashboard.html:142
 msgid "Closed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:144
+#: templates/exhibitors/dashboard.html:144
 #, python-format
 msgid "The deadline passed on %(deadline)s."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:151
+#: templates/exhibitors/dashboard.html:151
 msgid "Private — reachable only with the secret link."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:157
-#: exhibition/templates/exhibitors/settings.html:90
-#: exhibition/templates/exhibitors/settings.html:94
+#: templates/exhibitors/dashboard.html:157
+#: templates/exhibitors/settings.html:94 templates/exhibitors/settings.html:98
 msgid "View call page"
 msgstr ""
 
-#: exhibition/templates/exhibitors/delete.html:11
+#: templates/exhibitors/delete.html:11
 #, python-format
 msgid ""
 "Are you sure you want to delete “%(name)s”? This action cannot be undone."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:8
+#: templates/exhibitors/devices.html:8
 #, python-format
 msgid "Lead-scanning devices for %(name)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:13
+#: templates/exhibitors/devices.html:13
 #, python-brace-format
 msgid ""
 "Provision check-in app devices for this partner. Each device gets its own "
@@ -1672,66 +1705,64 @@ msgid ""
 "through the {device_tokens} placeholder."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:21
+#: templates/exhibitors/devices.html:21
 msgid ""
 "Provisioning devices requires organizer-level permissions. Ask an organizer "
 "admin to create the devices for this partner."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:29
+#: templates/exhibitors/devices.html:29
 msgid "Provisioned devices"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:35
+#: templates/exhibitors/devices.html:35
 msgid "Device"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:36
+#: templates/exhibitors/devices.html:36
 msgid "Setup token"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:37
+#: templates/exhibitors/devices.html:37
 msgid "Status"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:47
+#: templates/exhibitors/devices.html:47
 msgid "Connected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:49
+#: templates/exhibitors/devices.html:49
 msgid "Awaiting setup"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:60
+#: templates/exhibitors/devices.html:60
 msgid ""
 "Generate new setup tokens? Any device that is already scanning will be "
 "disconnected and must be set up again."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:65
+#: templates/exhibitors/devices.html:65
 msgid "Generate new setup tokens"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:70
+#: templates/exhibitors/devices.html:70
 msgid "No devices have been provisioned for this partner yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:80
-#: exhibition/templates/exhibitors/devices.html:85
+#: templates/exhibitors/devices.html:80 templates/exhibitors/devices.html:85
 msgid "Add devices"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:87
-#: exhibition/templates/exhibitors/vouchers.html:88
+#: templates/exhibitors/devices.html:87 templates/exhibitors/vouchers.html:133
 msgid "Back"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_bulk_discard.html:4
-#: exhibition/templates/exhibitors/email_bulk_discard.html:7
+#: templates/exhibitors/email_bulk_discard.html:4
+#: templates/exhibitors/email_bulk_discard.html:7
 msgid "Discard emails"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_bulk_discard.html:19
+#: templates/exhibitors/email_bulk_discard.html:19
 #, python-format
 msgid ""
 "Are you sure you want to discard %(counter)s queued email? This cannot be "
@@ -1742,80 +1773,80 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/templates/exhibitors/email_bulk_discard.html:30
-#: exhibition/templates/exhibitors/email_delete.html:31
-msgid "Discard"
-msgstr ""
-
-#: exhibition/templates/exhibitors/email_compose.html:7
-#: exhibition/templates/exhibitors/email_compose.html:16
+#: templates/exhibitors/email_compose.html:7
+#: templates/exhibitors/email_compose.html:16
 msgid "Compose email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:21
+#: templates/exhibitors/email_compose.html:21
 msgid ""
 "Send an update to a group of applicants. One email is queued per recipient, "
 "with placeholders resolved individually."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:26
+#: templates/exhibitors/email_compose.html:26
 msgid "Load from template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:28
+#: templates/exhibitors/email_compose.html:28
 msgid "Select a saved template…"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:33
+#: templates/exhibitors/email_compose.html:33
 msgid "Load"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:41
-#: exhibition/templates/exhibitors/email_edit.html:23
+#: templates/exhibitors/email_compose.html:41
+#: templates/exhibitors/email_edit.html:23
 msgid "Recipients"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:47
+#: templates/exhibitors/email_compose.html:47
 msgid "Message"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:58
-#: exhibition/templates/exhibitors/email_custom_template_form.html:33
-#: exhibition/templates/exhibitors/email_templates.html:53
-#: exhibition/templates/exhibitors/email_templates.html:100
-#: exhibition/templates/exhibitors/settings.html:58
+#: templates/exhibitors/email_compose.html:51
+msgctxt "form"
+msgid "required"
+msgstr ""
+
+#: templates/exhibitors/email_compose.html:58
+#: templates/exhibitors/email_custom_template_form.html:33
+#: templates/exhibitors/email_templates.html:53
+#: templates/exhibitors/email_templates.html:100
+#: templates/exhibitors/settings.html:62
 msgid "Preview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:80
+#: templates/exhibitors/email_compose.html:80
 msgid "Save to outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:83
+#: templates/exhibitors/email_compose.html:83
 msgid "Send / Schedule"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:4
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:7
+#: templates/exhibitors/email_custom_template_delete.html:4
+#: templates/exhibitors/email_custom_template_delete.html:7
 msgid "Delete custom template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:14
+#: templates/exhibitors/email_custom_template_delete.html:14
 #, python-format
 msgid "Are you sure you want to delete the custom template \"%(name)s\"?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_custom_template_form.html:7
-#: exhibition/templates/exhibitors/email_custom_template_form.html:15
+#: templates/exhibitors/email_custom_template_form.html:7
+#: templates/exhibitors/email_custom_template_form.html:15
 msgid "Custom template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_delete.html:4
-#: exhibition/templates/exhibitors/email_delete.html:7
+#: templates/exhibitors/email_delete.html:4
+#: templates/exhibitors/email_delete.html:7
 msgid "Discard email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_delete.html:15
+#: templates/exhibitors/email_delete.html:15
 #, python-format
 msgid ""
 "Are you sure you want to discard the email “%(subject)s” to %(counter)s "
@@ -1826,908 +1857,1170 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/templates/exhibitors/email_delete.html:21
+#: templates/exhibitors/email_delete.html:21
 #, python-format
 msgid ""
 "Are you sure you want to discard the email “%(subject)s” to %(to)s? This "
 "cannot be undone."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:5
+#: templates/exhibitors/email_edit.html:5
 msgid "Edit email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:8
+#: templates/exhibitors/email_edit.html:8
 msgid "Preview / edit email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:14
+#: templates/exhibitors/email_edit.html:14
 msgid "Back to outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:41
+#: templates/exhibitors/email_edit.html:41
 msgid "Save & send"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_outbox.html:12
-#: exhibition/templates/exhibitors/email_outbox.html:15
+#: templates/exhibitors/email_outbox.html:12
+#: templates/exhibitors/email_outbox.html:15
 msgid "Email outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_outbox.html:20
+#: templates/exhibitors/email_outbox.html:20
 msgid ""
 "Emails waiting to be sent. Review, edit, or discard them before sending."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_sent.html:12
-#: exhibition/templates/exhibitors/email_sent.html:15
+#: templates/exhibitors/email_sent.html:12
+#: templates/exhibitors/email_sent.html:15
 msgid "Sent emails"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:7
-#: exhibition/templates/exhibitors/email_templates.html:16
+#: templates/exhibitors/email_templates.html:7
+#: templates/exhibitors/email_templates.html:16
 msgid "Email templates"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:22
+#: templates/exhibitors/email_templates.html:22
 msgid "New template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:27
+#: templates/exhibitors/email_templates.html:27
 msgid ""
 "These templates are used for the confirmation email sent when an applicant "
 "submits a request, and for the accept/reject emails you send from the outbox."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:81
+#: templates/exhibitors/email_templates.html:81
 msgid "Discard this template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:31
+#: templates/exhibitors/exhibitor_info.html:31
 msgid "No organizations match your filters."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:33
+#: templates/exhibitors/exhibitor_info.html:33
 msgid "You don't have any sponsors yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:35
+#: templates/exhibitors/exhibitor_info.html:35
 msgid "You don't have any exhibitors yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:37
+#: templates/exhibitors/exhibitor_info.html:37
 msgid "You don't have any exhibitors or sponsors yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:43
-#: exhibition/templates/exhibitors/exhibitor_info.html:52
-#: exhibition/views.py:1837
+#: templates/exhibitors/exhibitor_info.html:43
+#: templates/exhibitors/exhibitor_info.html:57 views.py:1979
 msgid "Add a Sponsor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:43
-#: exhibition/templates/exhibitors/exhibitor_info.html:52
-#: exhibition/views.py:1838
+#: templates/exhibitors/exhibitor_info.html:43
+#: templates/exhibitors/exhibitor_info.html:57 views.py:1980
 msgid "Add an Exhibitor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:43
-#: exhibition/templates/exhibitors/exhibitor_info.html:52
-#: exhibition/views.py:1839
+#: templates/exhibitors/exhibitor_info.html:43
+#: templates/exhibitors/exhibitor_info.html:57 views.py:1981
 msgid "Add an Exhibitor or Sponsor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:48
-#: exhibition/templates/exhibitors/proposal_list.html:169
+#: templates/exhibitors/exhibitor_info.html:48
+#: templates/exhibitors/proposal_list.html:170
 msgid "selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:54
+#: templates/exhibitors/exhibitor_info.html:59
 msgid "Download access keys as CSV"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:56
+#: templates/exhibitors/exhibitor_info.html:61
 msgid "Download sponsor keys"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:56
+#: templates/exhibitors/exhibitor_info.html:61
 msgid "Download exhibitor keys"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:56
+#: templates/exhibitors/exhibitor_info.html:61
 msgid "Download access keys"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:65
+#: templates/exhibitors/exhibitor_info.html:64
+msgid "Queue a voucher email for everyone in this list"
+msgstr ""
+
+#: templates/exhibitors/exhibitor_info.html:65
+msgid "Send vouchers to all"
+msgstr ""
+
+#: templates/exhibitors/exhibitor_info.html:75
 msgid ""
 "Drag-and-drop ordering is available only on the unfiltered, single-page list."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:70
+#: templates/exhibitors/exhibitor_info.html:80
 msgid "Booth"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:78
-#: exhibition/templates/exhibitors/exhibitor_info.html:106
+#: templates/exhibitors/exhibitor_info.html:88
+#: templates/exhibitors/exhibitor_info.html:117
 msgid "Select all partners"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:84
-#: exhibition/templates/exhibitors/exhibitor_info.html:112
+#: templates/exhibitors/exhibitor_info.html:94
+#: templates/exhibitors/exhibitor_info.html:123
 msgid "Group"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:12
-#: exhibition/templates/exhibitors/proposal_detail.html:15
+#: templates/exhibitors/proposal_detail.html:12
+#: templates/exhibitors/proposal_detail.html:15
 msgid "Review exhibition request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:21
+#: templates/exhibitors/proposal_detail.html:21
 msgid "Back to exhibition requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:29
+#: templates/exhibitors/proposal_detail.html:29
 #, python-format
 msgid "Changes made by the applicant after acceptance (%(when)s)"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:39
+#: templates/exhibitors/proposal_detail.html:39
 msgid "Before acceptance"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:40
+#: templates/exhibitors/proposal_detail.html:40
 msgid "After edit"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:55
+#: templates/exhibitors/proposal_detail.html:55
 msgid "The applicant edited the profile, but the tracked fields are unchanged."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:57
+#: templates/exhibitors/proposal_detail.html:57
 msgid ""
 "This profile was edited before change tracking was available, so the "
 "original values are not recorded."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:69
-#: exhibition/templates/exhibitors/proposal_list.html:20
+#: templates/exhibitors/proposal_detail.html:69
+#: templates/exhibitors/proposal_list.html:20
 msgid "Submitter"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:80
+#: templates/exhibitors/proposal_detail.html:80
 msgid "Hidden"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:121
+#: templates/exhibitors/proposal_detail.html:121
 msgid "Message to organizers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:129
+#: templates/exhibitors/proposal_detail.html:129
 msgid "Links"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:152
+#: templates/exhibitors/proposal_detail.html:152
 msgid "Download"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:154
+#: templates/exhibitors/proposal_detail.html:154
 msgid "Custom answers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:176
+#: templates/exhibitors/proposal_detail.html:176
 msgid "Review"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:192
-#: exhibition/templates/exhibitors/proposal_list.html:117
-#: exhibition/templates/exhibitors/proposal_list.html:164
+#: templates/exhibitors/proposal_detail.html:192
+#: templates/exhibitors/proposal_list.html:118
+#: templates/exhibitors/proposal_list.html:165
 msgid "Approve"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:195
-#: exhibition/templates/exhibitors/proposal_list.html:122
-#: exhibition/templates/exhibitors/proposal_list.html:165
+#: templates/exhibitors/proposal_detail.html:195
+#: templates/exhibitors/proposal_list.html:123
+#: templates/exhibitors/proposal_list.html:166
 msgid "Reject"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:200
+#: templates/exhibitors/proposal_detail.html:200
 msgid "Open profile"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:22
+#: templates/exhibitors/proposal_list.html:22
 msgid "Updated"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:33
+#: templates/exhibitors/proposal_list.html:33
 msgid "Select at least one request."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:34
+#: templates/exhibitors/proposal_list.html:34
 msgid "None of the selected requests can be approved."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:35
+#: templates/exhibitors/proposal_list.html:35
 msgid "None of the selected requests can be rejected."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:36
+#: templates/exhibitors/proposal_list.html:36
 #, python-brace-format
 msgid "{count} selected requests cannot be approved and will be skipped."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:37
+#: templates/exhibitors/proposal_list.html:37
 #, python-brace-format
 msgid "{count} selected requests cannot be rejected and will be skipped."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:41
+#: templates/exhibitors/proposal_list.html:41
 msgid "Approve selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:44
+#: templates/exhibitors/proposal_list.html:44
 msgid "Reject selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:55
+#: templates/exhibitors/proposal_list.html:55
 msgid "Select all matching requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:75
+#: templates/exhibitors/proposal_list.html:75
 msgid "Select request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:106
+#: templates/exhibitors/proposal_list.html:106
 msgid "Edited after acceptance, see detail view for changes."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:127
-#: exhibition/templates/exhibitors/proposal_list.html:166
-#: exhibition/templates/exhibitors/public_proposal_list.html:39
+#: templates/exhibitors/proposal_list.html:128
+#: templates/exhibitors/proposal_list.html:167
+#: templates/exhibitors/public_proposal_list.html:39
 msgid "Withdraw"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:132
-#: exhibition/templates/exhibitors/proposal_list.html:167
+#: templates/exhibitors/proposal_list.html:133
+#: templates/exhibitors/proposal_list.html:168
 msgid "Reopen for review"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:137
-#: exhibition/templates/exhibitors/public_proposal_list.html:34
+#: templates/exhibitors/proposal_list.html:138
+#: templates/exhibitors/public_proposal_list.html:34
 msgid "View"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:149
+#: templates/exhibitors/proposal_list.html:150
 msgid "No exhibition requests match your filters."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:151
+#: templates/exhibitors/proposal_list.html:152
 msgid "No exhibition requests have been submitted yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:159
+#: templates/exhibitors/proposal_list.html:160
 msgid "Approve the selected requests and create their partner profiles?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:160
+#: templates/exhibitors/proposal_list.html:161
 msgid "Reject the selected requests?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:161
+#: templates/exhibitors/proposal_list.html:162
 msgid "Reject this request?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:162
+#: templates/exhibitors/proposal_list.html:163
 msgid "Withdraw this request?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:163
+#: templates/exhibitors/proposal_list.html:164
 msgid "Reopen this request for review?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:168
+#: templates/exhibitors/proposal_list.html:169
 msgid "The action could not be completed. Please try again."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:170
+#: templates/exhibitors/proposal_list.html:171
 msgid ""
 "Approve every request matching the current filters, including those on other "
 "pages?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:171
+#: templates/exhibitors/proposal_list.html:172
 msgid ""
 "Reject every request matching the current filters, including those on other "
 "pages?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:172
+#: templates/exhibitors/proposal_list.html:173
 msgid "Please confirm"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:173
+#: templates/exhibitors/proposal_list.html:174
 msgid "Confirm"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:14
+#: templates/exhibitors/public_call.html:14
 msgid "Submit a request to become an exhibitor for this event."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:20
+#: templates/exhibitors/public_call.html:20
 #, python-format
 msgid "You can submit requests until %(deadline)s (%(timezone)s)."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:24
+#: templates/exhibitors/public_call.html:24
 #, python-format
 msgid "This call closed on %(deadline)s (%(timezone)s)."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:34
+#: templates/exhibitors/public_call.html:34
 msgid "View your requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:40
-#: exhibition/templates/exhibitors/public_proposal_form.html:18
-#: exhibition/templates/exhibitors/public_proposal_list.html:65
+#: templates/exhibitors/public_call.html:40
+#: templates/exhibitors/public_proposal_form.html:18
+#: templates/exhibitors/public_proposal_list.html:65
 msgid "Submit a request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:42
+#: templates/exhibitors/public_call.html:42
 msgid "Requests are closed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:21
-#: exhibition/templates/exhibitors/public_detail.html:94
+#: templates/exhibitors/public_detail.html:21
+#: templates/exhibitors/public_detail.html:93
 msgid "Previous"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:24
-#: exhibition/templates/exhibitors/public_detail.html:98
+#: templates/exhibitors/public_detail.html:24
+#: templates/exhibitors/public_detail.html:97
 msgid "Next"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:47
+#: templates/exhibitors/public_detail.html:47
 msgid "Get In Touch"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:87
-#: exhibition/templates/exhibitors/public_detail.html:103
+#: templates/exhibitors/public_detail.html:87
+#: templates/exhibitors/public_detail.html:102
 msgid "Open slides PDF"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:88
-#, python-brace-format
-msgid "Slide {current} of {total}"
-msgstr ""
-
-#: exhibition/templates/exhibitors/public_detail.html:112
+#: templates/exhibitors/public_detail.html:111
 msgid "Send email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:126
+#: templates/exhibitors/public_detail.html:125
 msgid "Visit website"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_list.html:54
+#: templates/exhibitors/public_list.html:32
+msgid "Clear"
+msgstr ""
+
+#: templates/exhibitors/public_list.html:54
 msgid "No exhibitors match your search."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_list.html:56
+#: templates/exhibitors/public_list.html:56
 msgid "No exhibitors are currently available."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:16
+#: templates/exhibitors/public_proposal_form.html:16
 msgid "Edit request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:23
-#: exhibition/views.py:883
+#: templates/exhibitors/public_proposal_form.html:23 views.py:958
 msgid "This request can no longer be edited."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:186
+#: templates/exhibitors/public_proposal_form.html:190
 msgid "Submit request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:189
+#: templates/exhibitors/public_proposal_form.html:193
 msgid "or save as draft for now"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:199
+#: templates/exhibitors/public_proposal_form.html:203
 msgid "Back to your requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:5
+#: templates/exhibitors/public_proposal_list.html:5
 msgid "Your exhibition requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:13
+#: templates/exhibitors/public_proposal_list.html:13
 msgid "Last modified"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:23
+#: templates/exhibitors/public_proposal_list.html:23
 msgid "Withdrawn"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:44
+#: templates/exhibitors/public_proposal_list.html:44
 msgid "Reinstate"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:56
+#: templates/exhibitors/public_proposal_list.html:56
 msgid "Create a new request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:61
+#: templates/exhibitors/public_proposal_list.html:61
 msgid "You have not submitted an exhibition request yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:5
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:21
+#: templates/exhibitors/public_proposal_reinstate.html:5
+#: templates/exhibitors/public_proposal_reinstate.html:21
 msgid "Reinstate request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:7
+#: templates/exhibitors/public_proposal_reinstate.html:7
 #, python-format
 msgid ""
 "Do you want to reinstate your withdrawn request “%(name)s”? It will be "
 "pending review again."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:5
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:26
+#: templates/exhibitors/public_proposal_withdraw.html:5
+#: templates/exhibitors/public_proposal_withdraw.html:26
 msgid "Withdraw request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:7
+#: templates/exhibitors/public_proposal_withdraw.html:7
 #, python-format
 msgid "Are you sure you want to withdraw your request “%(name)s”?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:13
+#: templates/exhibitors/public_proposal_withdraw.html:13
 msgid ""
 "This request has already been approved. Withdrawing it will hide the "
 "exhibitor or sponsor profile created from it from public listings."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:10
-#: exhibition/templates/exhibitors/settings.html:27
+#: templates/exhibitors/settings.html:10 templates/exhibitors/settings.html:29
 msgid "Sponsor Settings"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:12
-#: exhibition/templates/exhibitors/settings.html:29
+#: templates/exhibitors/settings.html:12 templates/exhibitors/settings.html:31
+msgid "Voucher Settings"
+msgstr ""
+
+#: templates/exhibitors/settings.html:14 templates/exhibitors/settings.html:33
 msgid "Exhibitor Settings"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:42
+#: templates/exhibitors/settings.html:46
 msgid "Publish your call"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:43
+#: templates/exhibitors/settings.html:47
 msgid "Publish a login-required application form for exhibitors."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:72
+#: templates/exhibitors/settings.html:76
 msgid ""
 "This panel renders unsaved draft text using the same styling as the live "
 "public call page."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:104
+#: templates/exhibitors/settings.html:108
 msgid "Secret call link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:107
+#: templates/exhibitors/settings.html:111
 msgid ""
 "This call is private: it is not linked anywhere public. Share the link below "
 "with the organizations you want to invite. Anyone who has it can open the "
 "call and apply."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:113
+#: templates/exhibitors/settings.html:117
 msgid "Copied"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:113
+#: templates/exhibitors/settings.html:117
 msgid "Copy to clipboard"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:114
+#: templates/exhibitors/settings.html:118
 msgid "Copy"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:119
+#: templates/exhibitors/settings.html:123
 msgid ""
 "Regenerate the secret link? The current link will stop working immediately."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:125
+#: templates/exhibitors/settings.html:129
 msgid "Regenerate link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:127
+#: templates/exhibitors/settings.html:131
 msgid "Regenerating immediately invalidates the current link."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:138
+#: templates/exhibitors/settings.html:143
+msgid "Voucher pools"
+msgstr ""
+
+#: templates/exhibitors/settings.html:147
+msgid ""
+"Create the voucher codes under Tickets → Vouchers and give them a tag, then "
+"pick that tag here. Exhibitors and sponsors are handed codes from the pool "
+"you choose. Reload this page to pick up a tag you just created."
+msgstr ""
+
+#: templates/exhibitors/settings.html:157
+msgid "Create vouchers pool"
+msgstr ""
+
+#: templates/exhibitors/settings.html:159
+msgid "(opens in a new tab)"
+msgstr ""
+
+#: templates/exhibitors/settings.html:168
+#: templates/exhibitors/settings.html:182
+#, python-format
+msgid "%(counter)s voucher in this pool is not assigned to anyone yet."
+msgid_plural ""
+"%(counter)s vouchers in this pool are not assigned to anyone yet."
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/exhibitors/settings.html:194
+msgid "How many each one gets"
+msgstr ""
+
+#: templates/exhibitors/settings.html:196
+msgid ""
+"Applies to any exhibitor or sponsor that does not belong to a sponsor group. "
+"Sponsor groups set their own number on the Sponsors page, and an individual "
+"exhibitor or sponsor can be given a different number on their own voucher "
+"page."
+msgstr ""
+
+#: templates/exhibitors/settings.html:206
+msgid "Voucher email"
+msgstr ""
+
+#: templates/exhibitors/settings.html:208
+msgid "Applies to the voucher email sent to exhibitors and sponsors alike."
+msgstr ""
+
+#: templates/exhibitors/settings.html:228
 msgid "Data access"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:139
+#: templates/exhibitors/settings.html:229
 msgid ""
 "In this section, you can control which attendee data is shared with "
 "exhibitors when an exhibitor voucher is used or when the exhibitor uses the "
 "lead scanning app."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:142
+#: templates/exhibitors/settings.html:232
 msgid "Exhibitor vouchers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:158
-msgid "Exhibitor login"
-msgstr ""
-
-#: exhibition/templates/exhibitors/settings.html:160
-msgid ""
-"The access-code email sent to exhibitors is now edited together with the "
-"plugin's other email templates."
-msgstr ""
-
-#: exhibition/templates/exhibitors/settings.html:162
-msgid "Edit email templates"
-msgstr ""
-
-#: exhibition/templates/exhibitors/settings.html:177
+#: templates/exhibitors/settings.html:257
 msgid "Group List"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:180
+#: templates/exhibitors/settings.html:260
 msgid "Add a Group"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:193
+#: templates/exhibitors/settings.html:272
+#: templates/exhibitors/settings.html:354
+msgid "Voucher defaults for this group"
+msgstr ""
+
+#: templates/exhibitors/settings.html:277
 msgid "Add"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:204
+#: templates/exhibitors/settings.html:288
 msgid "Group Name"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:206
+#: templates/exhibitors/settings.html:290
 msgid "Partners"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:207
+#: templates/exhibitors/settings.html:291
 msgid "Front Page"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:220
-#: exhibition/templates/exhibitors/settings.html:226
+#: templates/exhibitors/settings.html:304
+#: templates/exhibitors/settings.html:310
 msgid "Show this sponsor group in the Supported By section on the front page."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:251
+#: templates/exhibitors/settings.html:326
+msgid "Edit sponsor group"
+msgstr ""
+
+#: templates/exhibitors/settings.html:337
 msgid "Reorder sponsor group"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:281
+#: templates/exhibitors/settings.html:371
 msgid "You do not have any sponsor groups yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:8
+#: templates/exhibitors/voucher_bulk_send.html:4
+#: templates/exhibitors/voucher_bulk_send.html:7
+msgid "Send vouchers"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:18
+#, python-format
+msgid "A voucher email will be placed in the outbox for %(counter)s sponsor."
+msgid_plural ""
+"A voucher email will be placed in the outbox for %(counter)s sponsors."
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:24
+#, python-format
+msgid "A voucher email will be placed in the outbox for %(counter)s exhibitor."
+msgid_plural ""
+"A voucher email will be placed in the outbox for %(counter)s exhibitors."
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:37
+#, python-format
+msgid "&mdash; %(counter)s voucher will be created"
+msgid_plural "&mdash; %(counter)s vouchers will be created"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:45
+#, python-format
+msgid "&mdash; %(counter)s existing voucher"
+msgid_plural "&mdash; %(counter)s existing vouchers"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:58
+msgid "None of the sponsors in this list can be emailed yet."
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:60
+msgid "None of the exhibitors in this list can be emailed yet."
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:66
+msgid "Skipped: no email address"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:75
+msgid "Skipped: voucher count is set to 0"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:84
+msgid "Skipped: no vouchers available from their pool"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:86
+msgid ""
+"Check that a voucher pool is selected under Settings → Vouchers and that it "
+"still has unassigned codes."
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:99
+msgid "Queue emails"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:8
 #, python-format
 msgid "Vouchers for %(name)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:13
+#: templates/exhibitors/vouchers.html:13
 msgid ""
-"Issue ticket vouchers for this partner to hand out. Whoever redeems one on "
-"the ticket shop becomes a lead this partner can retrieve, as long as voucher "
+"Hand this exhibitor or sponsor codes from the voucher pool. Whoever redeems "
+"one on the ticket shop becomes a lead they can retrieve, as long as voucher "
 "data access is enabled for them."
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:20
-msgid "Issued vouchers"
+#: templates/exhibitors/vouchers.html:20
+msgid "Assigned vouchers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:24
+#: templates/exhibitors/vouchers.html:24
 msgid "Download codes (CSV)"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:31
+#: templates/exhibitors/vouchers.html:31
 msgid "Code"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:32 exhibition/views.py:1994
+#: templates/exhibitors/vouchers.html:32 utils.py:495
 msgid "Product"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:34 exhibition/views.py:1998
+#: templates/exhibitors/vouchers.html:33 utils.py:496
+msgid "Price effect"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:34 utils.py:499
 msgid "Redeemed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:56
+#: templates/exhibitors/vouchers.html:35 utils.py:498
+msgid "Valid until"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:56
 msgid "Already redeemed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:67
-msgid "No vouchers have been issued for this partner yet."
+#: templates/exhibitors/vouchers.html:62
+msgid "Return to pool"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:76
-msgid "Issue new vouchers"
+#: templates/exhibitors/vouchers.html:74
+msgid "No vouchers have been assigned to this partner yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:86
-msgid "Create vouchers"
+#: templates/exhibitors/vouchers.html:82
+msgid "Take more from the pool"
 msgstr ""
 
-#: exhibition/templates/sponsors/presale_supported_by.html:4
+#: templates/exhibitors/vouchers.html:84
+msgid ""
+"Codes come from the voucher pool chosen under Settings. The email always "
+"carries this partner's complete list of codes, so you can assign some now "
+"and send them together with more later. It is placed in the outbox for you "
+"to review before it goes out."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:92
+#, python-format
+msgid "%(counter)s voucher is left unassigned in the pool."
+msgid_plural "%(counter)s vouchers are left unassigned in the pool."
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/exhibitors/vouchers.html:100 views.py:2230
+msgid "No voucher pool is selected yet. Choose one under Settings → Vouchers."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:106
+msgid "A voucher email for this partner is waiting in the outbox."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:108
+msgid "Go to outbox"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:114
+#, python-format
+msgid "Vouchers were last emailed to this partner on %(sent)s."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:120
+msgid ""
+"This partner has no email address on file, so vouchers cannot be emailed."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:127
+msgid "Assign and prepare email"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:130
+msgid "Assign without emailing"
+msgstr ""
+
+#: templates/sponsors/presale_supported_by.html:4
 msgid "Supported By"
 msgstr ""
 
-#: exhibition/views.py:324
+#: utils.py:493
+msgid "Voucher code"
+msgstr ""
+
+#: utils.py:494
+msgid "Redeem link"
+msgstr ""
+
+#: utils.py:497
+msgid "Value"
+msgstr ""
+
+#: utils.py:500
+msgid "Maximum usages"
+msgstr ""
+
+#: views.py:342
 msgid "Company name"
 msgstr ""
 
-#: exhibition/views.py:325
+#: views.py:343
 msgid "Job title"
 msgstr ""
 
-#: exhibition/views.py:326
+#: views.py:344
 msgid "Address"
 msgstr ""
 
-#: exhibition/views.py:333
+#: views.py:351
 msgid "Attendee Name"
 msgstr ""
 
-#: exhibition/views.py:338
+#: views.py:356
 msgid "Attendee Email"
 msgstr ""
 
-#: exhibition/views.py:377
+#: views.py:395 views.py:412
 msgid "Settings have been saved."
 msgstr ""
 
-#: exhibition/views.py:393
+#: views.py:428
 msgid "Call settings have been saved."
 msgstr ""
 
-#: exhibition/views.py:401
+#: views.py:436
 msgid ""
 "A new secret call link has been generated. The old link no longer works."
 msgstr ""
 
-#: exhibition/views.py:416
+#: views.py:451
 msgid "Sponsor group added."
 msgstr ""
 
-#: exhibition/views.py:437
+#: views.py:454 views.py:477 views.py:853 views.py:1169 views.py:1796
+#: views.py:1918 views.py:2564 views.py:3025
+msgid "We could not save your changes. See below for details."
+msgstr ""
+
+#: views.py:474
 msgid "Sponsor group updated."
 msgstr ""
 
-#: exhibition/views.py:452
+#: views.py:491
 msgid "This sponsor group cannot be deleted while it is assigned to partners."
 msgstr ""
 
-#: exhibition/views.py:460
+#: views.py:499
 msgid "Unknown action."
 msgstr ""
 
-#: exhibition/views.py:505
+#: views.py:544
 msgid "Access key"
 msgstr ""
 
-#: exhibition/views.py:745 exhibition/views.py:1060
+#: views.py:819 views.py:1135
 msgid "Add at least one social media link."
 msgstr ""
 
-#: exhibition/views.py:754 exhibition/views.py:1069
+#: views.py:828 views.py:1144
 msgid "Add at least one extra link."
 msgstr ""
 
-#: exhibition/views.py:809
+#: views.py:884
 msgid "The call for exhibitors is closed."
 msgstr ""
 
-#: exhibition/views.py:837
+#: views.py:912
 msgid "Your request has been saved."
 msgstr ""
 
-#: exhibition/views.py:920 exhibition/views.py:1776
+#: views.py:995 views.py:1914
 msgid "Your changes have been saved."
 msgstr ""
 
-#: exhibition/views.py:953
+#: views.py:1028
 msgid "This proposal can no longer be withdrawn."
 msgstr ""
 
-#: exhibition/views.py:961
+#: views.py:1036
 msgid "Your request has been withdrawn."
 msgstr ""
 
-#: exhibition/views.py:963
+#: views.py:1038
 msgid "This request can no longer be withdrawn."
 msgstr ""
 
-#: exhibition/views.py:989 exhibition/views.py:999
+#: views.py:1064 views.py:1074
 msgid "This request can no longer be reinstated."
 msgstr ""
 
-#: exhibition/views.py:997
+#: views.py:1072
 msgid "Your request has been reinstated and is pending review again."
 msgstr ""
 
-#: exhibition/views.py:1121
+#: views.py:1197
 msgid "Invalid request body."
 msgstr ""
 
-#: exhibition/views.py:1124 exhibition/views.py:1129
+#: views.py:1200 views.py:1205
 msgid "Invalid sponsor group IDs."
 msgstr ""
 
-#: exhibition/views.py:1133
+#: views.py:1209
 msgid "Sponsor group IDs must be unique."
 msgstr ""
 
-#: exhibition/views.py:1141
+#: views.py:1217
 msgid "Reorder request must include each sponsor group exactly once."
 msgstr ""
 
-#: exhibition/views.py:1346
+#: views.py:1422
 msgid "This request can no longer be changed to that state."
 msgstr ""
 
-#: exhibition/views.py:1350
+#: views.py:1426
 msgid "Review details saved."
 msgstr ""
 
-#: exhibition/views.py:1359
+#: views.py:1435
 msgid ""
 "Request approved and partner profile created. An acceptance email was placed "
 "in the outbox."
 msgstr ""
 
-#: exhibition/views.py:1369
+#: views.py:1445
 msgid "Request rejected. A rejection email was placed in the outbox."
 msgstr ""
 
-#: exhibition/views.py:1372
+#: views.py:1448
 msgid "Request withdrawn."
 msgstr ""
 
-#: exhibition/views.py:1375
+#: views.py:1451
 msgid "Request reopened for review."
 msgstr ""
 
-#: exhibition/views.py:1407
+#: views.py:1483
 msgid "No valid action was selected."
 msgstr ""
 
-#: exhibition/views.py:1454
+#: views.py:1530
 #, python-format
 msgid "%(count)d request was approved."
 msgid_plural "%(count)d requests were approved."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1455
+#: views.py:1531
 #, python-format
 msgid "%(count)d request was rejected."
 msgid_plural "%(count)d requests were rejected."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1456
+#: views.py:1532
 #, python-format
 msgid "%(count)d request was withdrawn."
 msgid_plural "%(count)d requests were withdrawn."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1457
+#: views.py:1533
 #, python-format
 msgid "%(count)d request was reopened."
 msgid_plural "%(count)d requests were reopened."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1461
+#: views.py:1537
 msgid "No proposals were updated."
 msgstr ""
 
-#: exhibition/views.py:1464
+#: views.py:1540
 #, python-format
 msgid "%(skipped)d was skipped because it was already processed."
 msgid_plural "%(skipped)d were skipped because they were already processed."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1605
+#: views.py:1681
 msgid "Exhibitor form settings have been saved."
 msgstr ""
 
-#: exhibition/views.py:1730
+#: views.py:1868
 msgid "The requested form field does not exist."
 msgstr ""
 
-#: exhibition/views.py:1791
+#: views.py:1933
 msgid "The field has been reset to its default."
 msgstr ""
 
-#: exhibition/views.py:1829 exhibition/views.py:1900
+#: views.py:1971 views.py:2042
 msgid "An access-credentials email was placed in the outbox."
 msgstr ""
 
-#: exhibition/views.py:1907
+#: views.py:2049
 msgid "Edit Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1908
+#: views.py:2050
 msgid "Edit Exhibitor"
 msgstr ""
 
-#: exhibition/views.py:1909
+#: views.py:2051
 msgid "Edit Exhibitor & Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1910
+#: views.py:2052
 msgid "Edit Exhibitor or Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1940
+#: views.py:2082
 msgid "Delete Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1941
+#: views.py:2083
 msgid "Delete Exhibitor"
 msgstr ""
 
-#: exhibition/views.py:1942
+#: views.py:2084
 msgid "Delete Exhibitor & Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1943
+#: views.py:2085
 msgid "Delete Exhibitor or Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1992
-msgid "Voucher code"
+#: views.py:2164
+msgid "This voucher has already been redeemed and cannot be returned."
 msgstr ""
 
-#: exhibition/views.py:1993
-msgid "Redeem link"
+#: views.py:2170
+msgid ""
+"This code was already included in a voucher email to this partner, so it "
+"cannot be returned to the pool. Delete it under Tickets → Vouchers instead."
 msgstr ""
 
-#: exhibition/views.py:1999
-msgid "Maximum usages"
+#: views.py:2176
+msgid "Voucher returned to the pool."
 msgstr ""
 
-#: exhibition/views.py:2035
-msgid "This voucher has already been redeemed and cannot be removed."
+#: views.py:2207
+msgid "Enter how many vouchers to take from the pool."
 msgstr ""
 
-#: exhibition/views.py:2040
-msgid "Voucher removed."
-msgstr ""
-
-#: exhibition/views.py:2060
+#: views.py:2215
 #, python-format
-msgid "%(count)d voucher created."
-msgid_plural "%(count)d vouchers created."
+msgid "%(count)d voucher taken from the pool."
+msgid_plural "%(count)d vouchers taken from the pool."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2112
+#: views.py:2232
+#, python-format
+msgid ""
+"The pool only has %(remaining)d voucher(s) left, so %(count)d cannot be "
+"taken."
+msgstr ""
+
+#: views.py:2244
+msgid "No email address is on file, so vouchers cannot be emailed."
+msgstr ""
+
+#: views.py:2253
+msgid "This partner holds no vouchers yet, so there is nothing to email."
+msgstr ""
+
+#: views.py:2259
+#, python-format
+msgid "An email with %(count)d voucher code was placed in the outbox."
+msgid_plural "An email with %(count)d voucher codes was placed in the outbox."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2347
+msgid "There is nobody to send vouchers to in this list."
+msgstr ""
+
+#: views.py:2354
+#, python-format
+msgid "%(count)d voucher email was placed in the outbox."
+msgid_plural "%(count)d voucher emails were placed in the outbox."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2371
+#, python-format
+msgid ""
+"%(count)d was skipped because no unassigned codes were available from their "
+"pool."
+msgid_plural ""
+"%(count)d were skipped because no unassigned codes were available from their "
+"pool."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2386
+#, python-format
+msgid "%(count)d sponsor was skipped because it has no email address."
+msgid_plural ""
+"%(count)d sponsors were skipped because they have no email address."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2392
+#, python-format
+msgid "%(count)d exhibitor was skipped because it has no email address."
+msgid_plural ""
+"%(count)d exhibitors were skipped because they have no email address."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2401
+#, python-format
+msgid "%(count)d sponsor was skipped because their voucher count is set to 0."
+msgid_plural ""
+"%(count)d sponsors were skipped because their voucher count is set to 0."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2407
+#, python-format
+msgid ""
+"%(count)d exhibitor was skipped because their voucher count is set to 0."
+msgid_plural ""
+"%(count)d exhibitors were skipped because their voucher count is set to 0."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2461
 #, python-format
 msgid "%(count)d device added."
 msgid_plural "%(count)d devices added."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2123
+#: views.py:2472
 #, python-format
 msgid ""
 "New setup tokens generated. %(count)d device that was already scanning is "
@@ -2738,79 +3031,95 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2132
+#: views.py:2481
 msgid "New setup tokens generated."
 msgstr ""
 
-#: exhibition/views.py:2194
+#: views.py:2543
 msgid "No applicants matched the selected filters."
 msgstr ""
 
-#: exhibition/views.py:2202
+#: views.py:2551
 #, python-format
 msgid "%(count)d emails have been scheduled."
 msgstr ""
 
-#: exhibition/views.py:2206
+#: views.py:2555
 #, python-format
 msgid "%(count)d emails have been sent."
 msgstr ""
 
-#: exhibition/views.py:2210
+#: views.py:2559
 #, python-format
 msgid "%(count)d emails have been placed in the outbox."
 msgstr ""
 
-#: exhibition/views.py:2385
+#: views.py:2738
 msgid "The emails have been saved and sent."
 msgstr ""
 
-#: exhibition/views.py:2389
+#: views.py:2742
 msgid "The emails have been saved."
 msgstr ""
 
-#: exhibition/views.py:2395
+#: views.py:2748
 msgid "The email has been saved and sent."
 msgstr ""
 
-#: exhibition/views.py:2399
+#: views.py:2752
 msgid "The email has been saved."
 msgstr ""
 
-#: exhibition/views.py:2423 exhibition/views.py:2497
+#: views.py:2776 views.py:2850
 #, python-format
 msgid "%(count)d email has been sent."
 msgid_plural "%(count)d emails have been sent."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2459
+#: views.py:2812
 msgid "The email has been discarded."
 msgstr ""
 
-#: exhibition/views.py:2501 exhibition/views.py:2514 exhibition/views.py:2519
+#: views.py:2854 views.py:2867 views.py:2872
 msgid "No emails were selected."
 msgstr ""
 
-#: exhibition/views.py:2510
+#: views.py:2863
 #, python-format
 msgid "%(count)d email has been discarded."
 msgid_plural "%(count)d emails have been discarded."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2594
+#: views.py:2929
+msgid "Request received (confirmation)"
+msgstr ""
+
+#: views.py:2930
+msgid "Request accepted"
+msgstr ""
+
+#: views.py:2931
+msgid "Request rejected"
+msgstr ""
+
+#: views.py:2932
+msgid "Exhibitor lead scanning key"
+msgstr ""
+
+#: views.py:2948
 msgid "Email templates have been saved."
 msgstr ""
 
-#: exhibition/views.py:2617 exhibition/views.py:2621
+#: views.py:2971 views.py:2975
 msgid "Unknown template."
 msgstr ""
 
-#: exhibition/views.py:2667
+#: views.py:3021
 msgid "Custom template has been created."
 msgstr ""
 
-#: exhibition/views.py:2683
+#: views.py:3041
 msgid "Custom template has been deleted."
 msgstr ""

--- a/exhibition/locale/de/LC_MESSAGES/django.po
+++ b/exhibition/locale/de/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-29 10:33+0000\n"
+"POT-Creation-Date: 2026-09-11 11:47+0000\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Srivatsav Auswin\n"
 "Language-Team: \n"
@@ -11,595 +11,531 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: exhibition/apps.py:14 exhibition/apps.py:17 exhibition/signals.py:157
-#: exhibition/templates/exhibitors/public_list.html:6
-#: exhibition/templates/exhibitors/public_list.html:14
-#: exhibition/templates/exhibitors/public_list.html:16
+#: apps.py:14 apps.py:17 signals.py:163 templates/exhibitors/public_list.html:6
+#: templates/exhibitors/public_list.html:14
+#: templates/exhibitors/public_list.html:16
 msgid "Exhibition"
 msgstr ""
 
-#: exhibition/apps.py:19
+#: apps.py:19
 msgid "This plugin enables to add and control exhibitors in eventyay"
 msgstr ""
 
-#: exhibition/filters.py:9
+#: filters.py:9
 msgid "Any"
 msgstr ""
 
-#: exhibition/filters.py:10
+#: filters.py:10
 msgid "Enabled"
 msgstr ""
 
-#: exhibition/filters.py:11 exhibition/templates/exhibitors/dashboard.html:127
+#: filters.py:11 templates/exhibitors/dashboard.html:127
 msgid "Disabled"
 msgstr ""
 
-#: exhibition/filters.py:15
+#: filters.py:15
 msgid "All types"
 msgstr ""
 
-#: exhibition/filters.py:16
+#: filters.py:16
 msgid "Exhibitor only"
 msgstr ""
 
-#: exhibition/filters.py:17
+#: filters.py:17
 msgid "Sponsor only"
 msgstr ""
 
-#: exhibition/filters.py:18 exhibition/templates/exhibitors/dashboard.html:89
-#: exhibition/templates/exhibitors/proposal_detail.html:95
-#: exhibition/templates/exhibitors/proposal_list.html:95
+#: filters.py:18 templates/exhibitors/dashboard.html:89
+#: templates/exhibitors/proposal_detail.html:95
+#: templates/exhibitors/proposal_list.html:95
 msgid "Exhibitor and sponsor"
 msgstr ""
 
-#: exhibition/filters.py:80 exhibition/filters.py:81
+#: filters.py:80 filters.py:81
 msgid "Search requests…"
 msgstr ""
 
-#: exhibition/filters.py:81
+#: filters.py:81
 msgid "Search requests"
 msgstr ""
 
-#: exhibition/filters.py:85 exhibition/templates/exhibitors/dashboard.html:75
-#: exhibition/templates/exhibitors/proposal_detail.html:85
-#: exhibition/templates/exhibitors/proposal_list.html:21
-#: exhibition/templates/exhibitors/public_proposal_list.html:12
+#: filters.py:85 templates/exhibitors/dashboard.html:75
+#: templates/exhibitors/proposal_detail.html:85
+#: templates/exhibitors/proposal_list.html:21
+#: templates/exhibitors/public_proposal_list.html:12
 msgid "State"
 msgstr ""
 
-#: exhibition/filters.py:86
+#: filters.py:86
 msgid "All states"
 msgstr ""
 
-#: exhibition/filters.py:90 exhibition/templates/exhibitors/dashboard.html:74
-#: exhibition/templates/exhibitors/proposal_detail.html:91
-#: exhibition/templates/exhibitors/proposal_list.html:62
+#: filters.py:90 templates/exhibitors/dashboard.html:74
+#: templates/exhibitors/proposal_detail.html:91
+#: templates/exhibitors/proposal_list.html:62
 msgid "Type"
 msgstr ""
 
-#: exhibition/filters.py:99 exhibition/filters.py:102
+#: filters.py:99 filters.py:102
 msgid "Search by name…"
 msgstr ""
 
-#: exhibition/filters.py:103
+#: filters.py:103
 msgid "Search requests by name"
 msgstr ""
 
-#: exhibition/filters.py:132 exhibition/filters.py:133
+#: filters.py:132 filters.py:133
 msgid "Search organizations…"
 msgstr ""
 
-#: exhibition/filters.py:133
+#: filters.py:133
 msgid "Search organizations"
 msgstr ""
 
-#: exhibition/filters.py:137
+#: filters.py:137
 msgid "Visibility"
 msgstr ""
 
-#: exhibition/filters.py:139
+#: filters.py:139
 msgid "All organizations"
 msgstr ""
 
-#: exhibition/filters.py:140 exhibition/forms.py:1512
-#: exhibition/templates/exhibitors/call_questions.html:30
+#: filters.py:140 forms.py:1553 templates/exhibitors/call_questions.html:30
 msgid "Active"
 msgstr ""
 
-#: exhibition/filters.py:141
+#: filters.py:141
 msgid "Inactive"
 msgstr ""
 
-#: exhibition/filters.py:146 exhibition/filters.py:207 exhibition/forms.py:207
-#: exhibition/forms.py:1410 exhibition/forms.py:1841
+#: filters.py:146 filters.py:207 forms.py:212 forms.py:1411 forms.py:1888
 msgid "Sponsor group"
 msgstr ""
 
-#: exhibition/filters.py:149 exhibition/filters.py:210
+#: filters.py:149 filters.py:210
 msgid "All groups"
 msgstr ""
 
-#: exhibition/filters.py:152 exhibition/templates/exhibitors/add.html:222
+#: filters.py:152 templates/exhibitors/add.html:226
 msgid "Lead scanning"
 msgstr ""
 
-#: exhibition/filters.py:157
+#: filters.py:157
 msgid "Lead access"
 msgstr ""
 
-#: exhibition/filters.py:162
+#: filters.py:162
 msgid "Voucher access"
 msgstr ""
 
-#: exhibition/filters.py:202 exhibition/filters.py:203
+#: filters.py:202 filters.py:203
 msgid "Search exhibitors…"
 msgstr ""
 
-#: exhibition/filters.py:203
+#: filters.py:203
 msgid "Search exhibitors"
 msgstr ""
 
-#: exhibition/filters.py:240 exhibition/filters.py:241
+#: filters.py:240 filters.py:241
 msgid "Search emails…"
 msgstr ""
 
-#: exhibition/filters.py:241
+#: filters.py:241
 msgid "Search emails"
 msgstr ""
 
-#: exhibition/forms.py:67
+#: forms.py:72
 #, python-format
 msgid "Times are in the event timezone: %(tz)s."
 msgstr ""
 
-#: exhibition/forms.py:128 exhibition/forms.py:139 exhibition/forms.py:933
-#: exhibition/forms.py:944
+#: forms.py:133 forms.py:144 forms.py:934 forms.py:945
 msgid "— No selection —"
 msgstr ""
 
-#: exhibition/forms.py:211
+#: forms.py:216
 msgid "Can view voucher redemptions"
 msgstr ""
 
-#: exhibition/forms.py:213 exhibition/forms.py:397
+#: forms.py:218 forms.py:402
 msgid ""
 "Lets this exhibitor or sponsor retrieve the attendees who redeemed vouchers "
 "issued to them. Separate from lead scanning, which covers attendees scanned "
 "at the booth."
 msgstr ""
 
-#: exhibition/forms.py:219
+#: forms.py:224
 msgid "Can view and export collected leads"
 msgstr ""
 
-#: exhibition/forms.py:221
+#: forms.py:226
 msgid ""
 "Lets this exhibitor retrieve the full list of leads they have already "
 "scanned. Turn this off to let them keep scanning without seeing the "
 "collected attendee data."
 msgstr ""
 
-#: exhibition/forms.py:226
+#: forms.py:231
 msgid "Lead scanning behavior"
 msgstr ""
 
-#: exhibition/forms.py:231
+#: forms.py:236
 msgid ""
 "Every attendee is one lead, even when scanned from multiple devices. Notes "
 "and ratings are shared between devices."
 msgstr ""
 
-#: exhibition/forms.py:238
+#: forms.py:243
 msgid ""
 "Every attendee is a new lead when scanned from a new device. Notes and "
 "ratings are specific to the device."
 msgstr ""
 
-#: exhibition/forms.py:251
+#: forms.py:256
 msgid "Comment"
 msgstr ""
 
-#: exhibition/forms.py:253
+#: forms.py:258
 msgid ""
 "The text entered in this field will not be visible to the user and is "
 "available for your convenience."
 msgstr ""
 
-#: exhibition/forms.py:258 exhibition/forms.py:1427 exhibition/views.py:505
+#: forms.py:263 forms.py:1428 views.py:544
 msgid "Booth ID"
 msgstr ""
 
-#: exhibition/forms.py:291 exhibition/forms.py:1027 exhibition/forms.py:1076
-#: exhibition/models.py:130
+#: forms.py:296 forms.py:1028 forms.py:1077 models.py:130
 msgid "Organization name"
 msgstr ""
 
-#: exhibition/forms.py:292 exhibition/forms.py:1030 exhibition/forms.py:1077
-#: exhibition/models.py:136
+#: forms.py:297 forms.py:1031 forms.py:1078 models.py:136
 msgid "Organization description"
 msgstr ""
 
-#: exhibition/forms.py:293 exhibition/forms.py:1078
+#: forms.py:298 forms.py:1079
 msgid "E-mail"
 msgstr ""
 
-#: exhibition/forms.py:294 exhibition/forms.py:1079 exhibition/models.py:139
+#: forms.py:299 forms.py:1080 models.py:139
 msgid "Contact page URL"
 msgstr ""
 
-#: exhibition/forms.py:295 exhibition/forms.py:1080 exhibition/models.py:140
+#: forms.py:300 forms.py:1081 models.py:140
 msgid "Promotional video URL"
 msgstr ""
 
-#: exhibition/forms.py:296 exhibition/forms.py:1081 exhibition/models.py:141
+#: forms.py:301 forms.py:1082 models.py:141
 msgid "Promotional slides"
 msgstr ""
 
-#: exhibition/forms.py:297 exhibition/forms.py:1082 exhibition/models.py:142
-#: exhibition/models.py:520
-#: exhibition/templates/exhibitors/proposal_detail.html:111
+#: forms.py:302 forms.py:1083 models.py:142 models.py:568
+#: templates/exhibitors/proposal_detail.html:111
 msgid "Logo"
 msgstr ""
 
-#: exhibition/forms.py:298 exhibition/forms.py:1083 exhibition/models.py:145
-#: exhibition/templates/exhibitors/proposal_detail.html:113
+#: forms.py:303 forms.py:1084 models.py:145
+#: templates/exhibitors/proposal_detail.html:113
 msgid "Header image"
 msgstr ""
 
-#: exhibition/forms.py:299 exhibition/forms.py:1084 exhibition/models.py:138
+#: forms.py:304 forms.py:1085 models.py:138
 msgid "Organization website"
 msgstr ""
 
-#: exhibition/forms.py:300
+#: forms.py:305
 msgid "Mark this partner as an exhibitor"
 msgstr ""
 
-#: exhibition/forms.py:301
+#: forms.py:306
 msgid "Mark this partner as an event sponsor"
 msgstr ""
 
-#: exhibition/forms.py:302 exhibition/forms.py:1036 exhibition/forms.py:1085
-#: exhibition/models.py:148 exhibition/models.py:522
+#: forms.py:307 forms.py:1037 forms.py:1086 models.py:148 models.py:570
 msgid "Preferred booth name"
 msgstr ""
 
-#: exhibition/forms.py:303
+#: forms.py:308
 msgid "Can scan attendee badges"
 msgstr ""
 
-#: exhibition/forms.py:307
+#: forms.py:312
 msgid ""
 "Lets this exhibitor sign in to the lead scanning app and scan attendees at "
 "their booth. Turn this off to block scanning entirely."
 msgstr ""
 
-#: exhibition/forms.py:348 exhibition/forms.py:1441
+#: forms.py:353 forms.py:1442
 msgid "No sponsor group"
 msgstr ""
 
-#: exhibition/forms.py:385
+#: forms.py:390
 msgid ""
 "Lets this exhibitor retrieve the attendees who redeemed vouchers issued to "
 "them. Separate from lead scanning, which covers attendees scanned at the "
 "booth."
 msgstr ""
 
-#: exhibition/forms.py:389
+#: forms.py:394
 msgid ""
 "Lets this sponsor retrieve the attendees who redeemed vouchers issued to "
 "them. Separate from lead scanning, which covers attendees scanned at the "
 "booth."
 msgstr ""
 
-#: exhibition/forms.py:393
+#: forms.py:398
 msgid ""
 "Lets this exhibitor and sponsor retrieve the attendees who redeemed vouchers "
 "issued to them. Separate from lead scanning, which covers attendees scanned "
 "at the booth."
 msgstr ""
 
-#: exhibition/forms.py:466 exhibition/forms.py:553 exhibition/forms.py:1361
-#: exhibition/forms.py:1375
+#: forms.py:471 forms.py:558 forms.py:1362 forms.py:1376 forms.py:1855
+#: forms.py:1924 forms.py:1930 forms.py:1932 forms.py:1934
 msgid "This field is required."
 msgstr ""
 
-#: exhibition/forms.py:511 exhibition/forms.py:516
+#: forms.py:516 forms.py:521
 msgid "Slides upload must be a PDF file."
 msgstr ""
 
-#: exhibition/forms.py:540
+#: forms.py:545
 msgid "A partner must be marked as an exhibitor, a sponsor, or both."
 msgstr ""
 
-#: exhibition/forms.py:615
+#: forms.py:620
 msgid "Devices to add"
 msgstr ""
 
-#: exhibition/forms.py:617
+#: forms.py:622
 msgid ""
 "How many new devices to provision now, in addition to any already listed "
 "above. Each device gets its own single-use setup token and QR code."
 msgstr ""
 
-#: exhibition/forms.py:627
-msgid "Select a product…"
+#: forms.py:635
+msgid "Vouchers to take from the pool"
 msgstr ""
 
-#: exhibition/forms.py:628
-msgid "Ticket product"
+#: forms.py:636
+msgid ""
+"Set to 0 to email the codes this partner already has without taking any more."
 msgstr ""
 
-#: exhibition/forms.py:629
-msgid "The product a redeemed voucher applies to."
-msgstr ""
-
-#: exhibition/forms.py:635
-msgid "Number of vouchers"
-msgstr ""
-
-#: exhibition/forms.py:640
-msgid "Maximum usages per voucher"
-msgstr ""
-
-#: exhibition/forms.py:645 exhibition/templates/exhibitors/vouchers.html:33
-#: exhibition/views.py:1995
-msgid "Price effect"
-msgstr ""
-
-#: exhibition/forms.py:651 exhibition/views.py:1996
-msgid "Value"
-msgstr ""
-
-#: exhibition/forms.py:652
-msgid "Amount or percentage, depending on the selected price effect."
-msgstr ""
-
-#: exhibition/forms.py:657 exhibition/templates/exhibitors/vouchers.html:35
-#: exhibition/views.py:1997
-msgid "Valid until"
-msgstr ""
-
-#: exhibition/forms.py:673
-msgid "Enter a value for the selected price effect."
-msgstr ""
-
-#: exhibition/forms.py:678 exhibition/models.py:295
-#: exhibition/templates/exhibitors/settings.html:205
+#: forms.py:647 models.py:326 templates/exhibitors/settings.html:289
 msgid "Level"
 msgstr ""
 
-#: exhibition/forms.py:685 exhibition/models.py:294
+#: forms.py:654 models.py:325
 msgid "Group name"
 msgstr ""
 
-#: exhibition/forms.py:718
+#: forms.py:677 models.py:225
+msgid "Exhibitor voucher pool"
+msgstr ""
+
+#: forms.py:678 models.py:232
+msgid "Sponsor voucher pool"
+msgstr ""
+
+#: forms.py:698
+msgid "— No pool selected —"
+msgstr ""
+
+#: forms.py:699
+msgid "— Use the exhibitor pool —"
+msgstr ""
+
+#: forms.py:719
 msgid "Enable call"
 msgstr ""
 
-#: exhibition/forms.py:719
+#: forms.py:720
 msgid "Hide call page after the deadline"
 msgstr ""
 
-#: exhibition/forms.py:720
+#: forms.py:721
 msgid "Make this call private (accessible only via a secret link)"
 msgstr ""
 
-#: exhibition/forms.py:724
+#: forms.py:725
 msgid ""
 "Turn the call on. Keep it enabled for private calls too, otherwise the "
 "secret link stops working."
 msgstr ""
 
-#: exhibition/forms.py:727
+#: forms.py:728
 msgid ""
 "The call page is not linked anywhere public and can only be opened with the "
 "secret link shown below."
 msgstr ""
 
-#: exhibition/forms.py:868
+#: forms.py:869
 msgid "Your answer"
 msgstr ""
 
-#: exhibition/forms.py:1024 exhibition/models.py:563
-#: exhibition/templates/exhibitors/proposal_detail.html:88
+#: forms.py:1025 models.py:611 templates/exhibitors/proposal_detail.html:88
 msgid "Language"
 msgstr ""
 
-#: exhibition/forms.py:1025
+#: forms.py:1026
 msgid "The language you are filling in this form with."
 msgstr ""
 
-#: exhibition/forms.py:1086 exhibition/models.py:151 exhibition/models.py:523
-#: exhibition/models.py:602
+#: forms.py:1087 models.py:151 models.py:571 models.py:650
 msgid "Message to the organizers"
 msgstr ""
 
-#: exhibition/forms.py:1149
+#: forms.py:1150
 msgid ""
 "The organization name is locked after acceptance. Contact the organizers to "
 "change it."
 msgstr ""
 
-#: exhibition/forms.py:1425
+#: forms.py:1426
 msgid "Approve as exhibitor"
 msgstr ""
 
-#: exhibition/forms.py:1426
+#: forms.py:1427
 msgid "Approve as sponsor"
 msgstr ""
 
-#: exhibition/forms.py:1428 exhibition/models.py:352 exhibition/models.py:596
-#: exhibition/models.py:966 exhibition/views.py:505
+#: forms.py:1429 models.py:383 models.py:644 models.py:1014 views.py:544
 msgid "Booth name"
 msgstr ""
 
-#: exhibition/forms.py:1429 exhibition/forms.py:1459 exhibition/models.py:607
+#: forms.py:1430 forms.py:1460 models.py:655
 msgid "Internal review notes"
 msgstr ""
 
-#: exhibition/forms.py:1470
+#: forms.py:1471
 msgid "Field label"
 msgstr ""
 
-#: exhibition/forms.py:1475 exhibition/forms.py:1510
+#: forms.py:1476 forms.py:1551
 msgid "Help text"
 msgstr ""
 
-#: exhibition/forms.py:1476
+#: forms.py:1477
 msgid "Shown below the field on the exhibitor form."
 msgstr ""
 
-#: exhibition/forms.py:1483
+#: forms.py:1484
 #, python-format
 msgid "Leave empty to use the default: %(label)s"
 msgstr ""
 
-#: exhibition/forms.py:1492
-msgid "Options"
-msgstr ""
-
-#: exhibition/forms.py:1493
-msgid "For choice fields, enter one option per line."
-msgstr ""
-
-#: exhibition/forms.py:1508
-msgid "Field type"
-msgstr ""
-
-#: exhibition/forms.py:1509 exhibition/models.py:878
-msgid "Custom question"
-msgstr ""
-
-#: exhibition/forms.py:1511
-#: exhibition/templates/exhibitors/call_questions.html:31
-#: exhibition/templates/exhibitors/call_questions.html:63
-msgid "Required"
-msgstr ""
-
-#: exhibition/forms.py:1535
+#: forms.py:1523
 msgid "Please provide at least one option for this question type."
 msgstr ""
 
-#: exhibition/forms.py:1576 exhibition/forms.py:1665
+#: forms.py:1549
+msgid "Field type"
+msgstr ""
+
+#: forms.py:1550 models.py:926
+msgid "Custom question"
+msgstr ""
+
+#: forms.py:1552 templates/exhibitors/call_questions.html:31
+#: templates/exhibitors/call_questions.html:63
+msgid "Required"
+msgstr ""
+
+#: forms.py:1583 forms.py:1672
 msgid "Choose social platform"
 msgstr ""
 
-#: exhibition/forms.py:1578 exhibition/forms.py:1667
+#: forms.py:1585 forms.py:1674
 msgid "Social platform"
 msgstr ""
 
-#: exhibition/forms.py:1582 exhibition/forms.py:1671
+#: forms.py:1589 forms.py:1678
 msgid "Profile or path"
 msgstr ""
 
-#: exhibition/forms.py:1596 exhibition/forms.py:1685
+#: forms.py:1603 forms.py:1692
 msgid "Profile, handle, or full URL"
 msgstr ""
 
-#: exhibition/forms.py:1616 exhibition/forms.py:1705
+#: forms.py:1623 forms.py:1712
 msgid "Please enter a profile, handle, or URL or remove this row."
 msgstr ""
 
-#: exhibition/forms.py:1622 exhibition/forms.py:1711
+#: forms.py:1629 forms.py:1718
 msgid "Please choose a social platform."
 msgstr ""
 
-#: exhibition/forms.py:1626 exhibition/forms.py:1715
+#: forms.py:1633 forms.py:1722
 msgid "Please enter a profile, handle, or URL."
 msgstr ""
 
-#: exhibition/forms.py:1648 exhibition/forms.py:1737
+#: forms.py:1655 forms.py:1744
 msgid "Link label"
 msgstr ""
 
-#: exhibition/forms.py:1654 exhibition/forms.py:1743
+#: forms.py:1661 forms.py:1750
 msgid "https://example.com"
 msgstr ""
 
-#: exhibition/forms.py:1807
+#: forms.py:1848
 msgid ""
 "Leave empty to keep this in the outbox until sent manually. Time is "
 "interpreted in the event timezone."
 msgstr ""
 
-#: exhibition/forms.py:1814 exhibition/forms.py:1877
+#: forms.py:1861 forms.py:1940
 msgid "The scheduled time must be in the future."
 msgstr ""
 
-#: exhibition/forms.py:1822
+#: forms.py:1869
 msgid "Exhibitors and sponsors"
 msgstr ""
 
-#: exhibition/forms.py:1823
+#: forms.py:1870
 msgid "Exhibitors only"
 msgstr ""
 
-#: exhibition/forms.py:1824
+#: forms.py:1871
 msgid "Sponsors only"
 msgstr ""
 
-#: exhibition/forms.py:1828
+#: forms.py:1875
 msgid "Application state"
 msgstr ""
 
-#: exhibition/forms.py:1836
+#: forms.py:1883
 msgid "Partner type"
 msgstr ""
 
-#: exhibition/forms.py:1844
+#: forms.py:1891
 msgid "Any sponsor group"
 msgstr ""
 
-#: exhibition/forms.py:1846 exhibition/models.py:1035 exhibition/models.py:1089
-#: exhibition/templates/exhibitors/_email_outbox_body.html:6
-#: exhibition/templates/exhibitors/_email_sent_body.html:6
+#: forms.py:1893 forms.py:1953 models.py:1084 models.py:1146
+#: templates/exhibitors/_email_outbox_body.html:6
+#: templates/exhibitors/_email_sent_body.html:6
 msgid "Subject"
 msgstr ""
 
-#: exhibition/forms.py:1848
+#: forms.py:1895
 msgid "Send at"
 msgstr ""
 
-#: exhibition/forms.py:1851
+#: forms.py:1898
 msgid "Leave empty to send immediately or save to the outbox."
 msgstr ""
 
-#: exhibition/forms.py:1859 exhibition/models.py:1036 exhibition/models.py:1090
+#: forms.py:1906 forms.py:1960 models.py:1085 models.py:1147
 msgid "Body"
 msgstr ""
 
-#: exhibition/forms.py:1885 exhibition/views.py:2576
-msgid "Request received (confirmation)"
-msgstr ""
-
-#: exhibition/forms.py:1886 exhibition/views.py:2577
-msgid "Request accepted"
-msgstr ""
-
-#: exhibition/forms.py:1887 exhibition/views.py:2578
-msgid "Request rejected"
-msgstr ""
-
-#: exhibition/forms.py:1888 exhibition/views.py:2579
-msgid "Exhibitor lead scanning key"
-msgstr ""
-
-#: exhibition/forms.py:1897
-#, python-format
-msgid "%(role)s — subject"
-msgstr ""
-
-#: exhibition/forms.py:1904
-#, python-format
-msgid "%(role)s — body"
-msgstr ""
-
-#: exhibition/mail.py:57
+#: mail.py:59
 #, python-brace-format
 msgid "We received your request for {event_name}"
 msgstr ""
 
-#: exhibition/mail.py:59
+#: mail.py:61
 #, python-brace-format
 msgid ""
 "Hello,\n"
@@ -614,12 +550,12 @@ msgid ""
 "The {event_name} team"
 msgstr ""
 
-#: exhibition/mail.py:69
+#: mail.py:71
 #, python-brace-format
 msgid "Your request for {event_name} has been accepted"
 msgstr ""
 
-#: exhibition/mail.py:71
+#: mail.py:73
 #, python-brace-format
 msgid ""
 "Hello,\n"
@@ -631,12 +567,12 @@ msgid ""
 "The {event_name} team"
 msgstr ""
 
-#: exhibition/mail.py:80
+#: mail.py:82
 #, python-brace-format
 msgid "Update on your request for {event_name}"
 msgstr ""
 
-#: exhibition/mail.py:82
+#: mail.py:84
 #, python-brace-format
 msgid ""
 "Hello,\n"
@@ -650,12 +586,12 @@ msgid ""
 "The {event_name} team"
 msgstr ""
 
-#: exhibition/mail.py:91
+#: mail.py:93
 #, python-brace-format
 msgid "Lead Scanning Access for {event_name}"
 msgstr ""
 
-#: exhibition/mail.py:93
+#: mail.py:95
 #, python-brace-format
 msgid ""
 "Hello {exhibitor_name},\n"
@@ -681,983 +617,1080 @@ msgid ""
 "The {event_name} Team"
 msgstr ""
 
-#: exhibition/mail.py:174
+#: mail.py:110
+#, python-brace-format
+msgid "Your vouchers for {event_name} — {exhibitor_name}"
+msgstr ""
+
+#: mail.py:112
+#, python-brace-format
+msgid ""
+"Dear {exhibitor_name},\n"
+"\n"
+"Thank you for participating in {event_name}. Please share the voucher codes "
+"below with your audience — anyone who uses one gets credited to you as a "
+"lead.\n"
+"\n"
+"{voucher_list}\n"
+"\n"
+"They can redeem a code on the event ticket shop at checkout.\n"
+"\n"
+"If you have any questions, please don't hesitate to reach out.\n"
+"\n"
+"Best regards,\n"
+"The {event_name} Team"
+msgstr ""
+
+#: mail.py:190
 msgid "This value will be replaced based on dynamic parameters."
 msgstr ""
 
-#: exhibition/models.py:137 exhibition/models.py:515
+#: mail.py:312
+#, python-format
+msgid "…and %(count)d more voucher code in the attached CSV file."
+msgid_plural "…and %(count)d more voucher codes in the attached CSV file."
+msgstr[0] ""
+msgstr[1] ""
+
+#: models.py:137 models.py:563
 msgid "Contact email"
 msgstr ""
 
-#: exhibition/models.py:156
-#: exhibition/templates/exhibitors/proposal_detail.html:132
+#: models.py:156 templates/exhibitors/proposal_detail.html:132
 msgid "Social media"
 msgstr ""
 
-#: exhibition/models.py:161
-#: exhibition/templates/exhibitors/proposal_detail.html:140
+#: models.py:161 templates/exhibitors/proposal_detail.html:140
 msgid "Extra links"
 msgstr ""
 
-#: exhibition/models.py:216
+#: models.py:212
+msgid "Vouchers per exhibitor"
+msgstr ""
+
+#: models.py:226
+msgid ""
+"The voucher tag created under Tickets → Vouchers that exhibitors draw their "
+"codes from."
+msgstr ""
+
+#: models.py:233
+msgid "Leave empty to draw sponsor codes from the exhibitor pool as well."
+msgstr ""
+
+#: models.py:239
+msgid "Attach voucher list as CSV"
+msgstr ""
+
+#: models.py:240
+msgid ""
+"Adds a spreadsheet of the recipient's own voucher codes to the voucher email."
+msgstr ""
+
+#: models.py:247
 msgid "Call headline"
 msgstr ""
 
-#: exhibition/models.py:220
+#: models.py:251
 msgid "Call text"
 msgstr ""
 
-#: exhibition/models.py:225
+#: models.py:256
 msgid "Submission deadline"
 msgstr ""
 
-#: exhibition/models.py:298
+#: models.py:329
 msgid "Show this sponsor group on the front page."
 msgstr ""
 
-#: exhibition/models.py:314 exhibition/models.py:558
-#: exhibition/templates/exhibitors/dashboard.html:73
-#: exhibition/templates/exhibitors/exhibitor_info.html:69
-#: exhibition/templates/exhibitors/proposal_list.html:19
-#: exhibition/templates/exhibitors/public_proposal_list.html:11
-#: exhibition/views.py:505
+#: models.py:345 models.py:606 templates/exhibitors/dashboard.html:73
+#: templates/exhibitors/exhibitor_info.html:79
+#: templates/exhibitors/proposal_list.html:19
+#: templates/exhibitors/public_proposal_list.html:11 views.py:544
 msgid "Name"
 msgstr ""
 
-#: exhibition/models.py:315 exhibition/models.py:559
-#: exhibition/templates/exhibitors/proposal_detail.html:117
+#: models.py:346 models.py:607 templates/exhibitors/proposal_detail.html:117
 msgid "Description"
 msgstr ""
 
-#: exhibition/models.py:316 exhibition/models.py:419 exhibition/models.py:435
-#: exhibition/models.py:565 exhibition/models.py:815 exhibition/models.py:831
-#: exhibition/models.py:844
-#: exhibition/templates/exhibitors/proposal_detail.html:103
+#: models.py:347 models.py:467 models.py:483 models.py:613 models.py:863
+#: models.py:879 models.py:892 templates/exhibitors/proposal_detail.html:103
 msgid "URL"
 msgstr ""
 
-#: exhibition/models.py:317 exhibition/models.py:566
-#: exhibition/templates/exhibitors/proposal_detail.html:77
-#: exhibition/views.py:505
+#: models.py:348 models.py:614 templates/exhibitors/proposal_detail.html:77
+#: views.py:544
 msgid "Email"
 msgstr ""
 
-#: exhibition/models.py:318 exhibition/models.py:567
-#: exhibition/templates/exhibitors/proposal_detail.html:105
+#: models.py:349 models.py:615 templates/exhibitors/proposal_detail.html:105
 msgid "Contact URL"
 msgstr ""
 
-#: exhibition/models.py:319 exhibition/models.py:568
-#: exhibition/templates/exhibitors/proposal_detail.html:107
+#: models.py:350 models.py:616 templates/exhibitors/proposal_detail.html:107
 msgid "Video URL"
 msgstr ""
 
-#: exhibition/models.py:322 exhibition/models.py:571
-#: exhibition/templates/exhibitors/proposal_detail.html:109
+#: models.py:353 models.py:619 templates/exhibitors/proposal_detail.html:109
 msgid "Slides"
 msgstr ""
 
-#: exhibition/models.py:326 exhibition/models.py:575
+#: models.py:357 models.py:623
 msgid "Slides URL"
 msgstr ""
 
-#: exhibition/models.py:328 exhibition/models.py:577
+#: models.py:359 models.py:625
 msgid "Logo URL"
 msgstr ""
 
-#: exhibition/models.py:330 exhibition/models.py:579
+#: models.py:361 models.py:627
 msgid "Header image URL"
 msgstr ""
 
-#: exhibition/models.py:434 exhibition/models.py:830
+#: models.py:482 models.py:878
 msgid "Label"
 msgstr ""
 
-#: exhibition/models.py:445
+#: models.py:493
 msgid "draft"
 msgstr ""
 
-#: exhibition/models.py:446
+#: models.py:494
 msgid "submitted"
 msgstr ""
 
-#: exhibition/models.py:447
+#: models.py:495
 msgid "accepted"
 msgstr ""
 
-#: exhibition/models.py:448
+#: models.py:496
 msgid "rejected"
 msgstr ""
 
-#: exhibition/models.py:449
+#: models.py:497
 msgid "withdrawn"
 msgstr ""
 
-#: exhibition/models.py:514
+#: models.py:562
 msgid "Organization Description"
 msgstr ""
 
-#: exhibition/models.py:516
+#: models.py:564
 msgid "Organization Website"
 msgstr ""
 
-#: exhibition/models.py:517
+#: models.py:565
 msgid "Contact Page URL"
 msgstr ""
 
-#: exhibition/models.py:518
+#: models.py:566
 msgid "Promotional Video URL"
 msgstr ""
 
-#: exhibition/models.py:519
+#: models.py:567
 msgid "Promotional Slides"
 msgstr ""
 
-#: exhibition/models.py:521
+#: models.py:569
 msgid "Header Image"
 msgstr ""
 
-#: exhibition/models.py:524 exhibition/templates/exhibitors/add.html:29
-#: exhibition/templates/exhibitors/public_proposal_form.html:38
+#: models.py:572 templates/exhibitors/add.html:29
+#: templates/exhibitors/public_proposal_form.html:38
 msgid "Social Media"
 msgstr ""
 
-#: exhibition/models.py:525 exhibition/templates/exhibitors/add.html:92
-#: exhibition/templates/exhibitors/public_proposal_form.html:91
+#: models.py:573 templates/exhibitors/add.html:92
+#: templates/exhibitors/public_proposal_form.html:91
 msgid "Extra Links"
 msgstr ""
 
-#: exhibition/models.py:841
+#: models.py:889
 msgid "Number"
 msgstr ""
 
-#: exhibition/models.py:842
+#: models.py:890
 msgid "Text (one line)"
 msgstr ""
 
-#: exhibition/models.py:843
+#: models.py:891
 msgid "Multiline text"
 msgstr ""
 
-#: exhibition/models.py:845
+#: models.py:893
 msgid "Email address"
 msgstr ""
 
-#: exhibition/models.py:846
+#: models.py:894
 msgid "Confirm Checkbox"
 msgstr ""
 
-#: exhibition/models.py:847
+#: models.py:895
 msgid "Radio button (Choose one option)"
 msgstr ""
 
-#: exhibition/models.py:848
+#: models.py:896
 msgid "Dropdown (Choose one option)"
 msgstr ""
 
-#: exhibition/models.py:849
+#: models.py:897
 msgid "Checkbox (Choose one or several options)"
 msgstr ""
 
-#: exhibition/models.py:850
+#: models.py:898
 msgid "File upload"
 msgstr ""
 
-#: exhibition/models.py:851
+#: models.py:899
 msgid "Date"
 msgstr ""
 
-#: exhibition/models.py:852
+#: models.py:900
 msgid "Time"
 msgstr ""
 
-#: exhibition/models.py:853
+#: models.py:901
 msgid "Date and time"
 msgstr ""
 
-#: exhibition/models.py:854
+#: models.py:902
 msgid "Country code (ISO 3166-1 alpha-2)"
 msgstr ""
 
-#: exhibition/models.py:855
+#: models.py:903
 msgid "Phone number"
 msgstr ""
 
-#: exhibition/models.py:883
+#: models.py:931
 msgid "help text"
 msgstr ""
 
-#: exhibition/models.py:885 exhibition/templates/exhibitors/add.html:29
-#: exhibition/templates/exhibitors/add.html:92
-#: exhibition/templates/exhibitors/public_proposal_form.html:38
-#: exhibition/templates/exhibitors/public_proposal_form.html:91
+#: models.py:933 templates/exhibitors/add.html:29
+#: templates/exhibitors/add.html:92
+#: templates/exhibitors/public_proposal_form.html:38
+#: templates/exhibitors/public_proposal_form.html:91
 msgid "required"
 msgstr ""
 
-#: exhibition/models.py:886
+#: models.py:934
 msgid "active"
 msgstr ""
 
-#: exhibition/models.py:906
+#: models.py:954
 msgid "Response"
 msgstr ""
 
-#: exhibition/models.py:938
+#: models.py:986
 msgid "Yes"
 msgstr ""
 
-#: exhibition/models.py:940
+#: models.py:988
 msgid "No"
 msgstr ""
 
-#: exhibition/models.py:1034
-#: exhibition/templates/exhibitors/_email_outbox_body.html:5
-#: exhibition/templates/exhibitors/_email_sent_body.html:5
+#: models.py:1083 templates/exhibitors/_email_outbox_body.html:5
+#: templates/exhibitors/_email_sent_body.html:5
 msgid "Recipient"
 msgstr ""
 
-#: exhibition/models.py:1045
+#: models.py:1101
 msgid "Queued email"
 msgstr ""
 
-#: exhibition/models.py:1046
+#: models.py:1102
 msgid "Queued emails"
 msgstr ""
 
-#: exhibition/models.py:1088
+#: models.py:1145
 msgid "Template name"
 msgstr ""
 
-#: exhibition/models.py:1095
+#: models.py:1152
 msgid "Custom email template"
 msgstr ""
 
-#: exhibition/models.py:1096
+#: models.py:1153
 msgid "Custom email templates"
 msgstr ""
 
-#: exhibition/signals.py:75
+#: signals.py:81
 msgid "Screen and evaluate exhibitor and sponsor requests for the event."
 msgstr ""
 
-#: exhibition/signals.py:76
+#: signals.py:82
 msgid "Request Review Dashboard"
 msgstr ""
 
-#: exhibition/signals.py:80
+#: signals.py:86
 msgid ""
 "Manage exhibitors and sponsors, maintain booth details, and create partner "
 "profiles for the event."
 msgstr ""
 
-#: exhibition/signals.py:82
+#: signals.py:88
 msgid "Exhibitors & Sponsors Dashboard"
 msgstr ""
 
-#: exhibition/signals.py:88 exhibition/templates/exhibitors/base.html:5
-#: exhibition/templates/exhibitors/base.html:125
-#: exhibition/templates/exhibitors/exhibitor_info.html:4
-#: exhibition/templates/exhibitors/exhibitor_info.html:15
+#: signals.py:94 templates/exhibitors/base.html:6
+#: templates/exhibitors/base.html:136
+#: templates/exhibitors/exhibitor_info.html:4
+#: templates/exhibitors/exhibitor_info.html:15
 msgid "Exhibitors & Sponsors"
 msgstr ""
 
-#: exhibition/signals.py:90
+#: signals.py:96
 msgid "Go to"
 msgstr ""
 
-#: exhibition/signals.py:166 exhibition/templates/exhibitors/call_base.html:4
-#: exhibition/templates/exhibitors/call_base.html:7
-#: exhibition/templates/exhibitors/public_call.html:7
-#: exhibition/templates/exhibitors/settings.html:8
-#: exhibition/templates/exhibitors/settings.html:25
+#: signals.py:172 templates/exhibitors/call_base.html:4
+#: templates/exhibitors/call_base.html:7
+#: templates/exhibitors/public_call.html:7 templates/exhibitors/settings.html:8
+#: templates/exhibitors/settings.html:27
 msgid "Call for Exhibitors"
 msgstr ""
 
-#: exhibition/signals.py:207 exhibition/signals.py:231
+#: signals.py:213 signals.py:237
 msgid "Acme Corp"
 msgstr ""
 
-#: exhibition/signals.py:225
+#: signals.py:231
 msgid "Jane Doe"
 msgstr ""
 
-#: exhibition/signals.py:293 exhibition/templates/exhibitors/base.html:62
-#: exhibition/templates/exhibitors/proposal_list.html:5
-#: exhibition/templates/exhibitors/proposal_list.html:15
+#: signals.py:305 templates/exhibitors/base.html:73
+#: templates/exhibitors/proposal_list.html:5
+#: templates/exhibitors/proposal_list.html:15
 msgid "Exhibition requests"
 msgstr ""
 
-#: exhibition/signals.py:298
+#: signals.py:310
 msgid "Exhibition request approved."
 msgstr ""
 
-#: exhibition/signals.py:299
+#: signals.py:311
 msgid "Exhibition request rejected."
 msgstr ""
 
-#: exhibition/signals.py:300
+#: signals.py:312
 msgid "Exhibition request withdrawn."
 msgstr ""
 
-#: exhibition/signals.py:301
+#: signals.py:313
 msgid "Exhibition request reopened for review."
 msgstr ""
 
-#: exhibition/signals.py:302
+#: signals.py:314
 msgid "Exhibition request changed."
 msgstr ""
 
-#: exhibition/signals.py:303
+#: signals.py:315
 msgid "Organization profile created from an approved request."
 msgstr ""
 
-#: exhibition/signals.py:304
+#: signals.py:316
 msgid "Organization profile reactivated after re-approval."
 msgstr ""
 
-#: exhibition/signals.py:305
+#: signals.py:317
 msgid "Organization profile updated from the submitter's changes."
 msgstr ""
 
-#: exhibition/signals.py:306
+#: signals.py:318
 msgid "Organization profile created."
 msgstr ""
 
-#: exhibition/signals.py:307
+#: signals.py:319
 msgid "Organization profile changed."
 msgstr ""
 
-#: exhibition/signals.py:308
+#: signals.py:320
 msgid "Organization profile deleted."
 msgstr ""
 
-#: exhibition/signals.py:309
+#: signals.py:321
 msgid "Exhibition settings changed."
 msgstr ""
 
-#: exhibition/signals.py:310
+#: signals.py:322
 msgid "Call for exhibitors settings changed."
 msgstr ""
 
-#: exhibition/signals.py:311
+#: signals.py:323
 msgid "Private call link regenerated."
 msgstr ""
 
-#: exhibition/signals.py:312
+#: signals.py:324
 msgid "Sponsor group created."
 msgstr ""
 
-#: exhibition/signals.py:313
+#: signals.py:325
 msgid "Sponsor group changed."
 msgstr ""
 
-#: exhibition/signals.py:314 exhibition/views.py:457
+#: signals.py:326 views.py:496
 msgid "Sponsor group deleted."
 msgstr ""
 
-#: exhibition/signals.py:315
+#: signals.py:327
 msgid "Exhibitor form question created."
 msgstr ""
 
-#: exhibition/signals.py:316
+#: signals.py:328
 msgid "Exhibitor form question changed."
 msgstr ""
 
-#: exhibition/signals.py:317
+#: signals.py:329
 msgid "Exhibitor form question deleted."
 msgstr ""
 
-#: exhibition/signals.py:318
+#: signals.py:330
 msgid "Email sent."
 msgstr ""
 
-#: exhibition/signals.py:337
+#: signals.py:349
 #, python-brace-format
 msgid "Updated: {fields}."
 msgstr ""
 
-#: exhibition/signals.py:360
+#: signals.py:372
 #, python-brace-format
 msgid "State changed from {old} to {new}."
 msgstr ""
 
-#: exhibition/signals.py:382
+#: signals.py:394
 #, python-brace-format
 msgid "Exhibition request {val}"
 msgstr ""
 
-#: exhibition/signals.py:391
+#: signals.py:403
 #, python-brace-format
 msgid "Organization profile {val}"
 msgstr ""
 
-#: exhibition/signals.py:400
+#: signals.py:412
 #, python-brace-format
 msgid "Exhibitor form question {val}"
 msgstr ""
 
-#: exhibition/signals.py:409
+#: signals.py:421
 #, python-brace-format
 msgid "Sponsor group {val}"
 msgstr ""
 
-#: exhibition/social_links.py:36
+#: social_links.py:36
 msgid "Facebook"
 msgstr ""
 
-#: exhibition/social_links.py:43
+#: social_links.py:43
 msgid "Flickr"
 msgstr ""
 
-#: exhibition/social_links.py:50
+#: social_links.py:50
 msgid "GitHub"
 msgstr ""
 
-#: exhibition/social_links.py:57
+#: social_links.py:57
 msgid "GitLab"
 msgstr ""
 
-#: exhibition/social_links.py:64
+#: social_links.py:64
 msgid "Gitter"
 msgstr ""
 
-#: exhibition/social_links.py:71
+#: social_links.py:71
 msgid "Google Groups"
 msgstr ""
 
-#: exhibition/social_links.py:78
+#: social_links.py:78
 msgid "Instagram"
 msgstr ""
 
-#: exhibition/social_links.py:85
+#: social_links.py:85
 msgid "LinkedIn"
 msgstr ""
 
-#: exhibition/social_links.py:92
+#: social_links.py:92
 msgid "Mastodon"
 msgstr ""
 
-#: exhibition/social_links.py:99
+#: social_links.py:99
 msgid "Patreon"
 msgstr ""
 
-#: exhibition/social_links.py:106
+#: social_links.py:106
 msgid "Telegram"
 msgstr ""
 
-#: exhibition/social_links.py:113
+#: social_links.py:113
 msgid "Vimeo"
 msgstr ""
 
-#: exhibition/social_links.py:120
+#: social_links.py:120
 msgid "VK"
 msgstr ""
 
-#: exhibition/social_links.py:127
+#: social_links.py:127
 msgid "Weibo"
 msgstr ""
 
-#: exhibition/social_links.py:134
+#: social_links.py:134
 msgid "X"
 msgstr ""
 
-#: exhibition/social_links.py:141
+#: social_links.py:141
 msgid "Xing"
 msgstr ""
 
-#: exhibition/social_links.py:148
+#: social_links.py:148
 msgid "YouTube"
 msgstr ""
 
-#: exhibition/social_links.py:155
+#: social_links.py:155
 msgid "YouTube Privacy"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:7
+#: templates/exhibitors/_email_outbox_body.html:7
 msgid "Created"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:14
+#: templates/exhibitors/_email_outbox_body.html:14
 msgid "Send selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:17
+#: templates/exhibitors/_email_outbox_body.html:17
 msgid "Discard selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:20
+#: templates/exhibitors/_email_outbox_body.html:20
 msgid "Send all"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:23
+#: templates/exhibitors/_email_outbox_body.html:23
 msgid "Discard all"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:35
+#: templates/exhibitors/_email_outbox_body.html:35
 msgid "Scheduled"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:36
-#: exhibition/templates/exhibitors/proposal_list.html:65
+#: templates/exhibitors/_email_outbox_body.html:36
+#: templates/exhibitors/proposal_list.html:65
 msgid "Actions"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:67
-msgid "Send this email"
+#: templates/exhibitors/_email_outbox_body.html:68
+msgid "Send"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:73
-msgid "Edit this email"
+#: templates/exhibitors/_email_outbox_body.html:75
+#: templates/exhibitors/_partner_row.html:54
+#: templates/exhibitors/call_questions.html:73
+#: templates/exhibitors/call_questions.html:76
+#: templates/exhibitors/dashboard.html:120
+#: templates/exhibitors/email_compose.html:55
+#: templates/exhibitors/email_custom_template_form.html:30
+#: templates/exhibitors/email_templates.html:50
+#: templates/exhibitors/email_templates.html:97
+#: templates/exhibitors/public_proposal_list.html:32
+#: templates/exhibitors/settings.html:59
+msgid "Edit"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:79
-msgid "Discard this email"
+#: templates/exhibitors/_email_outbox_body.html:82
+#: templates/exhibitors/email_bulk_discard.html:30
+#: templates/exhibitors/email_delete.html:31
+msgid "Discard"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:91
-#: exhibition/templates/exhibitors/_email_sent_body.html:34
+#: templates/exhibitors/_email_outbox_body.html:95
+#: templates/exhibitors/_email_sent_body.html:35
 msgid "No emails match your search."
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:93
+#: templates/exhibitors/_email_outbox_body.html:97
 msgid "The outbox is empty."
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_sent_body.html:7
-#: exhibition/templates/exhibitors/base.html:105
+#: templates/exhibitors/_email_sent_body.html:7
+#: templates/exhibitors/_partner_row.html:45 templates/exhibitors/base.html:116
 msgid "Sent"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_sent_body.html:36
+#: templates/exhibitors/_email_sent_body.html:37
 msgid "No emails have been sent yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:12
-#: exhibition/templates/exhibitors/public_list.html:29
+#: templates/exhibitors/_filter_form.html:12
+#: templates/exhibitors/public_list.html:29
 msgid "Search"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:18
-#: exhibition/templates/exhibitors/_filter_form.html:20
+#: templates/exhibitors/_filter_form.html:18
+#: templates/exhibitors/_filter_form.html:21
 msgid "Clear filters"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:29
+#: templates/exhibitors/_filter_form.html:30
 msgid "Filters"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:50
+#: templates/exhibitors/_filter_form.html:51
 msgid "Apply filters"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:5
+#: templates/exhibitors/_image_preview_dialog.html:11
+msgid "Close preview"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:5
 #, python-format
 msgid "Select %(name)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:33
+#: templates/exhibitors/_partner_row.html:33
 msgid "Untitled"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:40
+#: templates/exhibitors/_partner_row.html:40
+msgid "Waiting in the outbox"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:41
+msgid "In outbox"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:44
+#, python-format
+msgid "Last sent %(sent)s"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:48
+msgid "Not sent"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:55
 msgid "Copied!"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:40
+#: templates/exhibitors/_partner_row.html:55
 msgid "Copy failed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:40
+#: templates/exhibitors/_partner_row.html:55
 msgid "Key"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:41
-#: exhibition/templates/exhibitors/add.html:231
-#: exhibition/templates/exhibitors/vouchers.html:5
+#: templates/exhibitors/_partner_row.html:56 templates/exhibitors/add.html:235
+#: templates/exhibitors/base.html:42
+#: templates/exhibitors/exhibitor_info.html:95
+#: templates/exhibitors/exhibitor_info.html:125
+#: templates/exhibitors/vouchers.html:5 views.py:2933
 msgid "Vouchers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:42
-#: exhibition/templates/exhibitors/devices.html:5
+#: templates/exhibitors/_partner_row.html:57
+#: templates/exhibitors/devices.html:5
 msgid "Lead-scanning devices"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:45
+#: templates/exhibitors/_partner_row.html:58
+#: templates/exhibitors/call_question_delete.html:19
+#: templates/exhibitors/call_questions.html:74
+#: templates/exhibitors/delete.html:19
+#: templates/exhibitors/email_custom_template_delete.html:19
+#: templates/exhibitors/settings.html:335
+msgid "Delete"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:60
 msgid "Move"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_sort_header.html:7
+#: templates/exhibitors/_sort_header.html:7
 msgid "Sort ascending"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_sort_header.html:10
+#: templates/exhibitors/_sort_header.html:10
 msgid "Sort descending"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:24
+#: templates/exhibitors/add.html:24
 msgid "Profile"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:29
-#: exhibition/templates/exhibitors/add.html:92
-#: exhibition/templates/exhibitors/call_questions.html:62
-#: exhibition/templates/exhibitors/settings.html:50
+#: templates/exhibitors/add.html:29 templates/exhibitors/add.html:92
+#: templates/exhibitors/call_questions.html:62
+#: templates/exhibitors/settings.html:54
 msgid "Optional"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:80
-#: exhibition/templates/exhibitors/public_proposal_form.html:79
+#: templates/exhibitors/add.html:80
+#: templates/exhibitors/public_proposal_form.html:79
 msgid "Add social media link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:137
-#: exhibition/templates/exhibitors/public_proposal_form.html:120
+#: templates/exhibitors/add.html:137
+#: templates/exhibitors/public_proposal_form.html:120
 msgid "Add extra link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:157
-#: exhibition/templates/exhibitors/add.html:160
-#: exhibition/templates/exhibitors/public_proposal_form.html:140
-#: exhibition/templates/exhibitors/public_proposal_form.html:143
+#: templates/exhibitors/add.html:157 templates/exhibitors/add.html:161
+#: templates/exhibitors/public_proposal_form.html:140
+#: templates/exhibitors/public_proposal_form.html:144
 msgid "Logo preview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:162
-#: exhibition/templates/exhibitors/add.html:180
-#: exhibition/templates/exhibitors/public_proposal_form.html:145
-#: exhibition/templates/exhibitors/public_proposal_form.html:163
+#: templates/exhibitors/add.html:164 templates/exhibitors/add.html:184
+#: templates/exhibitors/public_proposal_form.html:147
+#: templates/exhibitors/public_proposal_form.html:167
 msgid "We could not load this image preview."
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:175
-#: exhibition/templates/exhibitors/add.html:178
-#: exhibition/templates/exhibitors/public_proposal_form.html:158
-#: exhibition/templates/exhibitors/public_proposal_form.html:161
+#: templates/exhibitors/add.html:177 templates/exhibitors/add.html:181
+#: templates/exhibitors/public_proposal_form.html:160
+#: templates/exhibitors/public_proposal_form.html:164
 msgid "Header image preview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:196
+#: templates/exhibitors/add.html:200
 msgid "Organizer only"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:237
+#: templates/exhibitors/add.html:241
 msgid "Internal notes"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:244
-#: exhibition/templates/exhibitors/email_edit.html:38
-#: exhibition/templates/exhibitors/public_proposal_form.html:182
-#: exhibition/templates/exhibitors/public_proposal_form.html:186
+#: templates/exhibitors/add.html:248 templates/exhibitors/email_edit.html:38
+#: templates/exhibitors/public_proposal_form.html:186
+#: templates/exhibitors/public_proposal_form.html:190
 msgid "Save changes"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:246
-#: exhibition/templates/exhibitors/call_default_field_form.html:21
-#: exhibition/templates/exhibitors/call_question_form.html:30
-#: exhibition/templates/exhibitors/call_questions.html:96
-#: exhibition/templates/exhibitors/email_custom_template_form.html:51
-#: exhibition/templates/exhibitors/email_templates.html:123
-#: exhibition/templates/exhibitors/proposal_detail.html:188
-#: exhibition/templates/exhibitors/settings.html:85
-#: exhibition/templates/exhibitors/settings.html:170
-#: exhibition/templates/exhibitors/settings.html:269
+#: templates/exhibitors/add.html:250
+#: templates/exhibitors/call_default_field_form.html:21
+#: templates/exhibitors/call_question_form.html:114
+#: templates/exhibitors/call_questions.html:96
+#: templates/exhibitors/email_custom_template_form.html:51
+#: templates/exhibitors/email_templates.html:123
+#: templates/exhibitors/proposal_detail.html:188
+#: templates/exhibitors/settings.html:89 templates/exhibitors/settings.html:217
+#: templates/exhibitors/settings.html:250
+#: templates/exhibitors/settings.html:359
 msgid "Save"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:255
-#: exhibition/templates/exhibitors/call_default_field_form.html:23
-#: exhibition/templates/exhibitors/call_default_field_reset.html:24
-#: exhibition/templates/exhibitors/call_question_delete.html:21
-#: exhibition/templates/exhibitors/call_question_form.html:32
-#: exhibition/templates/exhibitors/delete.html:24
-#: exhibition/templates/exhibitors/email_bulk_discard.html:27
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:21
-#: exhibition/templates/exhibitors/email_custom_template_form.html:53
-#: exhibition/templates/exhibitors/email_delete.html:28
-#: exhibition/templates/exhibitors/proposal_list.html:174
-#: exhibition/templates/exhibitors/public_proposal_form.html:176
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:16
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:21
-#: exhibition/templates/exhibitors/settings.html:194
-#: exhibition/templates/exhibitors/settings.html:270
+#: templates/exhibitors/add.html:259
+#: templates/exhibitors/call_default_field_form.html:23
+#: templates/exhibitors/call_default_field_reset.html:24
+#: templates/exhibitors/call_question_delete.html:21
+#: templates/exhibitors/call_question_form.html:116
+#: templates/exhibitors/delete.html:24
+#: templates/exhibitors/email_bulk_discard.html:27
+#: templates/exhibitors/email_custom_template_delete.html:21
+#: templates/exhibitors/email_custom_template_form.html:53
+#: templates/exhibitors/email_delete.html:28
+#: templates/exhibitors/proposal_list.html:175
+#: templates/exhibitors/public_proposal_form.html:180
+#: templates/exhibitors/public_proposal_reinstate.html:16
+#: templates/exhibitors/public_proposal_withdraw.html:21
+#: templates/exhibitors/settings.html:278
+#: templates/exhibitors/settings.html:360
+#: templates/exhibitors/voucher_bulk_send.html:96
 msgid "Cancel"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:262
-#: exhibition/templates/exhibitors/proposal_detail.html:208
+#: templates/exhibitors/add.html:266
+#: templates/exhibitors/proposal_detail.html:208
 msgid "History"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:11
+#: templates/exhibitors/base.html:17
 msgid "Overview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:18
-#: exhibition/templates/exhibitors/call_questions.html:33
+#: templates/exhibitors/base.html:24
+#: templates/exhibitors/call_questions.html:33
 msgid "Settings"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:26
-#: exhibition/templates/exhibitors/base.html:70
-#: exhibition/templates/exhibitors/dashboard.html:21
-#: exhibition/templates/exhibitors/exhibitor_info.html:4
-#: exhibition/templates/exhibitors/exhibitor_info.html:15
+#: templates/exhibitors/base.html:32 templates/exhibitors/base.html:81
+#: templates/exhibitors/dashboard.html:21
+#: templates/exhibitors/exhibitor_info.html:4
+#: templates/exhibitors/exhibitor_info.html:15
 msgid "Exhibitors"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:31
-#: exhibition/templates/exhibitors/base.html:76
-#: exhibition/templates/exhibitors/dashboard.html:29
-#: exhibition/templates/exhibitors/exhibitor_info.html:4
-#: exhibition/templates/exhibitors/exhibitor_info.html:15
+#: templates/exhibitors/base.html:37 templates/exhibitors/base.html:87
+#: templates/exhibitors/dashboard.html:29
+#: templates/exhibitors/exhibitor_info.html:4
+#: templates/exhibitors/exhibitor_info.html:15
 msgid "Sponsors"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:39
-#: exhibition/templates/exhibitors/dashboard.html:117
+#: templates/exhibitors/base.html:50 templates/exhibitors/dashboard.html:117
 msgid "Call for exhibitors"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:47
+#: templates/exhibitors/base.html:58
 msgid "Content"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:52
-#: exhibition/templates/exhibitors/call_questions.html:5
-#: exhibition/templates/exhibitors/call_questions.html:16
+#: templates/exhibitors/base.html:63 templates/exhibitors/call_questions.html:5
+#: templates/exhibitors/call_questions.html:16
 msgid "Exhibitor form"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:85
+#: templates/exhibitors/base.html:96
 msgid "Message center"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:94
+#: templates/exhibitors/base.html:105
 msgid "Compose"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:99
+#: templates/exhibitors/base.html:110
 msgid "Outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:111
+#: templates/exhibitors/base.html:122
 msgid "Templates"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:130
+#: templates/exhibitors/base.html:141
 msgid "Home"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:134
+#: templates/exhibitors/base.html:145
 msgid "Tickets"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:138
+#: templates/exhibitors/base.html:149
 msgid "Talks"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:143
+#: templates/exhibitors/base.html:154
 msgid "Access videos related to this event"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:144
+#: templates/exhibitors/base.html:155
 msgid "Videos"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_form.html:5
-#: exhibition/templates/exhibitors/call_default_field_form.html:8
-#: exhibition/templates/exhibitors/call_question_form.html:11
-#: exhibition/templates/exhibitors/call_question_form.html:14
+#: templates/exhibitors/call_default_field_form.html:5
+#: templates/exhibitors/call_default_field_form.html:8
+#: templates/exhibitors/call_question_form.html:14
+#: templates/exhibitors/call_question_form.html:17
 msgid "Form field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:4
-#: exhibition/templates/exhibitors/call_default_field_reset.html:7
+#: templates/exhibitors/call_default_field_reset.html:4
+#: templates/exhibitors/call_default_field_reset.html:7
 msgid "Reset form field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:14
+#: templates/exhibitors/call_default_field_reset.html:14
 #, python-format
 msgid ""
 "Are you sure you want to reset \"%(label)s\" back to the default "
 "\"%(default_label)s\"?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:19
+#: templates/exhibitors/call_default_field_reset.html:19
 msgid ""
 "This clears the custom label and help text. Default fields are part of the "
 "form and cannot be deleted; turn the field off with the Active toggle to "
 "hide it."
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:22
-#: exhibition/templates/exhibitors/public_list.html:32
+#: templates/exhibitors/call_default_field_reset.html:22
 msgid "Reset"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_question_delete.html:4
-#: exhibition/templates/exhibitors/call_question_delete.html:7
+#: templates/exhibitors/call_question_delete.html:4
+#: templates/exhibitors/call_question_delete.html:7
 msgid "Delete form field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_question_delete.html:14
+#: templates/exhibitors/call_question_delete.html:14
 #, python-format
 msgid "Are you sure you want to delete the question \"%(question)s\"?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_question_delete.html:19
-#: exhibition/templates/exhibitors/call_questions.html:74
-#: exhibition/templates/exhibitors/delete.html:19
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:19
-msgid "Delete"
+#: templates/exhibitors/call_question_form.html:31
+msgid "Answer options"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:23
+#: templates/exhibitors/call_question_form.html:34
+msgid "Only applicable if you choose a choice field type above."
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:48
+#, python-format
+msgid "Answer option %(id)s"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:56
+#: templates/exhibitors/call_question_form.html:58
+#: templates/exhibitors/call_question_form.html:87
+#: templates/exhibitors/call_question_form.html:89
+msgid "Move option up"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:60
+#: templates/exhibitors/call_question_form.html:62
+#: templates/exhibitors/call_question_form.html:91
+#: templates/exhibitors/call_question_form.html:93
+msgid "Move option down"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:64
+#: templates/exhibitors/call_question_form.html:66
+#: templates/exhibitors/call_question_form.html:95
+#: templates/exhibitors/call_question_form.html:97
+msgid "Delete option"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:81
+msgid "New answer option"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:106
+msgid "Add a new option"
+msgstr ""
+
+#: templates/exhibitors/call_questions.html:23
 msgid "Form fields"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:24
+#: templates/exhibitors/call_questions.html:24
 msgid ""
 "Choose which fields are shown on the exhibitor form and drag any row to "
 "reorder it."
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:29
-#: exhibition/templates/exhibitors/proposal_detail.html:38
+#: templates/exhibitors/call_questions.html:29
+#: templates/exhibitors/proposal_detail.html:38
 msgid "Field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:32
+#: templates/exhibitors/call_questions.html:32
 msgid "Answers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:42
+#: templates/exhibitors/call_questions.html:42
 msgid "Custom"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:48
+#: templates/exhibitors/call_questions.html:48
 #, python-format
 msgid "Toggle active state for %(field)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:61
+#: templates/exhibitors/call_questions.html:61
 #, python-format
 msgid "Required status for %(field)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:73
-#: exhibition/templates/exhibitors/call_questions.html:76
-#: exhibition/templates/exhibitors/dashboard.html:120
-#: exhibition/templates/exhibitors/email_compose.html:55
-#: exhibition/templates/exhibitors/email_custom_template_form.html:30
-#: exhibition/templates/exhibitors/email_templates.html:50
-#: exhibition/templates/exhibitors/email_templates.html:97
-#: exhibition/templates/exhibitors/public_proposal_list.html:32
-#: exhibition/templates/exhibitors/settings.html:55
-msgid "Edit"
-msgstr ""
-
-#: exhibition/templates/exhibitors/call_questions.html:77
+#: templates/exhibitors/call_questions.html:77
 msgid "Reset to default"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:79
+#: templates/exhibitors/call_questions.html:79
 msgid "Move field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:90
+#: templates/exhibitors/call_questions.html:90
 msgid "New custom field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:5
-#: exhibition/templates/exhibitors/dashboard.html:9
+#: templates/exhibitors/dashboard.html:5 templates/exhibitors/dashboard.html:9
 msgid "Exhibition overview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:39
+#: templates/exhibitors/dashboard.html:39
 msgid "Requests awaiting review"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:48
+#: templates/exhibitors/dashboard.html:48
 msgid "Emails in outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:61
+#: templates/exhibitors/dashboard.html:61
 msgid "Recent requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:64
+#: templates/exhibitors/dashboard.html:64
 msgid "View all"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:76
+#: templates/exhibitors/dashboard.html:76
 msgid "Submitted"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:91
-#: exhibition/templates/exhibitors/proposal_detail.html:97
-#: exhibition/templates/exhibitors/proposal_list.html:97
+#: templates/exhibitors/dashboard.html:91
+#: templates/exhibitors/proposal_detail.html:97
+#: templates/exhibitors/proposal_list.html:97
 msgid "Sponsor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:93
-#: exhibition/templates/exhibitors/proposal_detail.html:99
-#: exhibition/templates/exhibitors/proposal_list.html:99
+#: templates/exhibitors/dashboard.html:93
+#: templates/exhibitors/proposal_detail.html:99
+#: templates/exhibitors/proposal_list.html:99
 msgid "Exhibitor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:105
+#: templates/exhibitors/dashboard.html:105
 msgid "No requests have been submitted yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:128
+#: templates/exhibitors/dashboard.html:128
 msgid "The call is not published, so nobody can submit a request."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:131
+#: templates/exhibitors/dashboard.html:131
 msgid "Open"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:134
+#: templates/exhibitors/dashboard.html:134
 #, python-format
 msgid "Closes on %(deadline)s."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:139
+#: templates/exhibitors/dashboard.html:139
 msgid "No deadline set."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:142
+#: templates/exhibitors/dashboard.html:142
 msgid "Closed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:144
+#: templates/exhibitors/dashboard.html:144
 #, python-format
 msgid "The deadline passed on %(deadline)s."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:151
+#: templates/exhibitors/dashboard.html:151
 msgid "Private — reachable only with the secret link."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:157
-#: exhibition/templates/exhibitors/settings.html:90
-#: exhibition/templates/exhibitors/settings.html:94
+#: templates/exhibitors/dashboard.html:157
+#: templates/exhibitors/settings.html:94 templates/exhibitors/settings.html:98
 msgid "View call page"
 msgstr ""
 
-#: exhibition/templates/exhibitors/delete.html:11
+#: templates/exhibitors/delete.html:11
 #, python-format
 msgid ""
 "Are you sure you want to delete “%(name)s”? This action cannot be undone."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:8
+#: templates/exhibitors/devices.html:8
 #, python-format
 msgid "Lead-scanning devices for %(name)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:13
+#: templates/exhibitors/devices.html:13
 #, python-brace-format
 msgid ""
 "Provision check-in app devices for this partner. Each device gets its own "
@@ -1665,66 +1698,64 @@ msgid ""
 "through the {device_tokens} placeholder."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:21
+#: templates/exhibitors/devices.html:21
 msgid ""
 "Provisioning devices requires organizer-level permissions. Ask an organizer "
 "admin to create the devices for this partner."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:29
+#: templates/exhibitors/devices.html:29
 msgid "Provisioned devices"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:35
+#: templates/exhibitors/devices.html:35
 msgid "Device"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:36
+#: templates/exhibitors/devices.html:36
 msgid "Setup token"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:37
+#: templates/exhibitors/devices.html:37
 msgid "Status"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:47
+#: templates/exhibitors/devices.html:47
 msgid "Connected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:49
+#: templates/exhibitors/devices.html:49
 msgid "Awaiting setup"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:60
+#: templates/exhibitors/devices.html:60
 msgid ""
 "Generate new setup tokens? Any device that is already scanning will be "
 "disconnected and must be set up again."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:65
+#: templates/exhibitors/devices.html:65
 msgid "Generate new setup tokens"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:70
+#: templates/exhibitors/devices.html:70
 msgid "No devices have been provisioned for this partner yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:80
-#: exhibition/templates/exhibitors/devices.html:85
+#: templates/exhibitors/devices.html:80 templates/exhibitors/devices.html:85
 msgid "Add devices"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:87
-#: exhibition/templates/exhibitors/vouchers.html:88
+#: templates/exhibitors/devices.html:87 templates/exhibitors/vouchers.html:133
 msgid "Back"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_bulk_discard.html:4
-#: exhibition/templates/exhibitors/email_bulk_discard.html:7
+#: templates/exhibitors/email_bulk_discard.html:4
+#: templates/exhibitors/email_bulk_discard.html:7
 msgid "Discard emails"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_bulk_discard.html:19
+#: templates/exhibitors/email_bulk_discard.html:19
 #, python-format
 msgid ""
 "Are you sure you want to discard %(counter)s queued email? This cannot be "
@@ -1735,80 +1766,80 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/templates/exhibitors/email_bulk_discard.html:30
-#: exhibition/templates/exhibitors/email_delete.html:31
-msgid "Discard"
-msgstr ""
-
-#: exhibition/templates/exhibitors/email_compose.html:7
-#: exhibition/templates/exhibitors/email_compose.html:16
+#: templates/exhibitors/email_compose.html:7
+#: templates/exhibitors/email_compose.html:16
 msgid "Compose email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:21
+#: templates/exhibitors/email_compose.html:21
 msgid ""
 "Send an update to a group of applicants. One email is queued per recipient, "
 "with placeholders resolved individually."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:26
+#: templates/exhibitors/email_compose.html:26
 msgid "Load from template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:28
+#: templates/exhibitors/email_compose.html:28
 msgid "Select a saved template…"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:33
+#: templates/exhibitors/email_compose.html:33
 msgid "Load"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:41
-#: exhibition/templates/exhibitors/email_edit.html:23
+#: templates/exhibitors/email_compose.html:41
+#: templates/exhibitors/email_edit.html:23
 msgid "Recipients"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:47
+#: templates/exhibitors/email_compose.html:47
 msgid "Message"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:58
-#: exhibition/templates/exhibitors/email_custom_template_form.html:33
-#: exhibition/templates/exhibitors/email_templates.html:53
-#: exhibition/templates/exhibitors/email_templates.html:100
-#: exhibition/templates/exhibitors/settings.html:58
+#: templates/exhibitors/email_compose.html:51
+msgctxt "form"
+msgid "required"
+msgstr ""
+
+#: templates/exhibitors/email_compose.html:58
+#: templates/exhibitors/email_custom_template_form.html:33
+#: templates/exhibitors/email_templates.html:53
+#: templates/exhibitors/email_templates.html:100
+#: templates/exhibitors/settings.html:62
 msgid "Preview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:80
+#: templates/exhibitors/email_compose.html:80
 msgid "Save to outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:83
+#: templates/exhibitors/email_compose.html:83
 msgid "Send / Schedule"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:4
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:7
+#: templates/exhibitors/email_custom_template_delete.html:4
+#: templates/exhibitors/email_custom_template_delete.html:7
 msgid "Delete custom template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:14
+#: templates/exhibitors/email_custom_template_delete.html:14
 #, python-format
 msgid "Are you sure you want to delete the custom template \"%(name)s\"?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_custom_template_form.html:7
-#: exhibition/templates/exhibitors/email_custom_template_form.html:15
+#: templates/exhibitors/email_custom_template_form.html:7
+#: templates/exhibitors/email_custom_template_form.html:15
 msgid "Custom template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_delete.html:4
-#: exhibition/templates/exhibitors/email_delete.html:7
+#: templates/exhibitors/email_delete.html:4
+#: templates/exhibitors/email_delete.html:7
 msgid "Discard email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_delete.html:15
+#: templates/exhibitors/email_delete.html:15
 #, python-format
 msgid ""
 "Are you sure you want to discard the email “%(subject)s” to %(counter)s "
@@ -1819,908 +1850,1170 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/templates/exhibitors/email_delete.html:21
+#: templates/exhibitors/email_delete.html:21
 #, python-format
 msgid ""
 "Are you sure you want to discard the email “%(subject)s” to %(to)s? This "
 "cannot be undone."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:5
+#: templates/exhibitors/email_edit.html:5
 msgid "Edit email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:8
+#: templates/exhibitors/email_edit.html:8
 msgid "Preview / edit email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:14
+#: templates/exhibitors/email_edit.html:14
 msgid "Back to outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:41
+#: templates/exhibitors/email_edit.html:41
 msgid "Save & send"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_outbox.html:12
-#: exhibition/templates/exhibitors/email_outbox.html:15
+#: templates/exhibitors/email_outbox.html:12
+#: templates/exhibitors/email_outbox.html:15
 msgid "Email outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_outbox.html:20
+#: templates/exhibitors/email_outbox.html:20
 msgid ""
 "Emails waiting to be sent. Review, edit, or discard them before sending."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_sent.html:12
-#: exhibition/templates/exhibitors/email_sent.html:15
+#: templates/exhibitors/email_sent.html:12
+#: templates/exhibitors/email_sent.html:15
 msgid "Sent emails"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:7
-#: exhibition/templates/exhibitors/email_templates.html:16
+#: templates/exhibitors/email_templates.html:7
+#: templates/exhibitors/email_templates.html:16
 msgid "Email templates"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:22
+#: templates/exhibitors/email_templates.html:22
 msgid "New template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:27
+#: templates/exhibitors/email_templates.html:27
 msgid ""
 "These templates are used for the confirmation email sent when an applicant "
 "submits a request, and for the accept/reject emails you send from the outbox."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:81
+#: templates/exhibitors/email_templates.html:81
 msgid "Discard this template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:31
+#: templates/exhibitors/exhibitor_info.html:31
 msgid "No organizations match your filters."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:33
+#: templates/exhibitors/exhibitor_info.html:33
 msgid "You don't have any sponsors yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:35
+#: templates/exhibitors/exhibitor_info.html:35
 msgid "You don't have any exhibitors yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:37
+#: templates/exhibitors/exhibitor_info.html:37
 msgid "You don't have any exhibitors or sponsors yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:43
-#: exhibition/templates/exhibitors/exhibitor_info.html:52
-#: exhibition/views.py:1837
+#: templates/exhibitors/exhibitor_info.html:43
+#: templates/exhibitors/exhibitor_info.html:57 views.py:1979
 msgid "Add a Sponsor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:43
-#: exhibition/templates/exhibitors/exhibitor_info.html:52
-#: exhibition/views.py:1838
+#: templates/exhibitors/exhibitor_info.html:43
+#: templates/exhibitors/exhibitor_info.html:57 views.py:1980
 msgid "Add an Exhibitor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:43
-#: exhibition/templates/exhibitors/exhibitor_info.html:52
-#: exhibition/views.py:1839
+#: templates/exhibitors/exhibitor_info.html:43
+#: templates/exhibitors/exhibitor_info.html:57 views.py:1981
 msgid "Add an Exhibitor or Sponsor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:48
-#: exhibition/templates/exhibitors/proposal_list.html:169
+#: templates/exhibitors/exhibitor_info.html:48
+#: templates/exhibitors/proposal_list.html:170
 msgid "selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:54
+#: templates/exhibitors/exhibitor_info.html:59
 msgid "Download access keys as CSV"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:56
+#: templates/exhibitors/exhibitor_info.html:61
 msgid "Download sponsor keys"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:56
+#: templates/exhibitors/exhibitor_info.html:61
 msgid "Download exhibitor keys"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:56
+#: templates/exhibitors/exhibitor_info.html:61
 msgid "Download access keys"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:65
+#: templates/exhibitors/exhibitor_info.html:64
+msgid "Queue a voucher email for everyone in this list"
+msgstr ""
+
+#: templates/exhibitors/exhibitor_info.html:65
+msgid "Send vouchers to all"
+msgstr ""
+
+#: templates/exhibitors/exhibitor_info.html:75
 msgid ""
 "Drag-and-drop ordering is available only on the unfiltered, single-page list."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:70
+#: templates/exhibitors/exhibitor_info.html:80
 msgid "Booth"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:78
-#: exhibition/templates/exhibitors/exhibitor_info.html:106
+#: templates/exhibitors/exhibitor_info.html:88
+#: templates/exhibitors/exhibitor_info.html:117
 msgid "Select all partners"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:84
-#: exhibition/templates/exhibitors/exhibitor_info.html:112
+#: templates/exhibitors/exhibitor_info.html:94
+#: templates/exhibitors/exhibitor_info.html:123
 msgid "Group"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:12
-#: exhibition/templates/exhibitors/proposal_detail.html:15
+#: templates/exhibitors/proposal_detail.html:12
+#: templates/exhibitors/proposal_detail.html:15
 msgid "Review exhibition request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:21
+#: templates/exhibitors/proposal_detail.html:21
 msgid "Back to exhibition requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:29
+#: templates/exhibitors/proposal_detail.html:29
 #, python-format
 msgid "Changes made by the applicant after acceptance (%(when)s)"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:39
+#: templates/exhibitors/proposal_detail.html:39
 msgid "Before acceptance"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:40
+#: templates/exhibitors/proposal_detail.html:40
 msgid "After edit"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:55
+#: templates/exhibitors/proposal_detail.html:55
 msgid "The applicant edited the profile, but the tracked fields are unchanged."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:57
+#: templates/exhibitors/proposal_detail.html:57
 msgid ""
 "This profile was edited before change tracking was available, so the "
 "original values are not recorded."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:69
-#: exhibition/templates/exhibitors/proposal_list.html:20
+#: templates/exhibitors/proposal_detail.html:69
+#: templates/exhibitors/proposal_list.html:20
 msgid "Submitter"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:80
+#: templates/exhibitors/proposal_detail.html:80
 msgid "Hidden"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:121
+#: templates/exhibitors/proposal_detail.html:121
 msgid "Message to organizers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:129
+#: templates/exhibitors/proposal_detail.html:129
 msgid "Links"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:152
+#: templates/exhibitors/proposal_detail.html:152
 msgid "Download"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:154
+#: templates/exhibitors/proposal_detail.html:154
 msgid "Custom answers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:176
+#: templates/exhibitors/proposal_detail.html:176
 msgid "Review"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:192
-#: exhibition/templates/exhibitors/proposal_list.html:117
-#: exhibition/templates/exhibitors/proposal_list.html:164
+#: templates/exhibitors/proposal_detail.html:192
+#: templates/exhibitors/proposal_list.html:118
+#: templates/exhibitors/proposal_list.html:165
 msgid "Approve"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:195
-#: exhibition/templates/exhibitors/proposal_list.html:122
-#: exhibition/templates/exhibitors/proposal_list.html:165
+#: templates/exhibitors/proposal_detail.html:195
+#: templates/exhibitors/proposal_list.html:123
+#: templates/exhibitors/proposal_list.html:166
 msgid "Reject"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:200
+#: templates/exhibitors/proposal_detail.html:200
 msgid "Open profile"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:22
+#: templates/exhibitors/proposal_list.html:22
 msgid "Updated"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:33
+#: templates/exhibitors/proposal_list.html:33
 msgid "Select at least one request."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:34
+#: templates/exhibitors/proposal_list.html:34
 msgid "None of the selected requests can be approved."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:35
+#: templates/exhibitors/proposal_list.html:35
 msgid "None of the selected requests can be rejected."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:36
+#: templates/exhibitors/proposal_list.html:36
 #, python-brace-format
 msgid "{count} selected requests cannot be approved and will be skipped."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:37
+#: templates/exhibitors/proposal_list.html:37
 #, python-brace-format
 msgid "{count} selected requests cannot be rejected and will be skipped."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:41
+#: templates/exhibitors/proposal_list.html:41
 msgid "Approve selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:44
+#: templates/exhibitors/proposal_list.html:44
 msgid "Reject selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:55
+#: templates/exhibitors/proposal_list.html:55
 msgid "Select all matching requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:75
+#: templates/exhibitors/proposal_list.html:75
 msgid "Select request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:106
+#: templates/exhibitors/proposal_list.html:106
 msgid "Edited after acceptance, see detail view for changes."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:127
-#: exhibition/templates/exhibitors/proposal_list.html:166
-#: exhibition/templates/exhibitors/public_proposal_list.html:39
+#: templates/exhibitors/proposal_list.html:128
+#: templates/exhibitors/proposal_list.html:167
+#: templates/exhibitors/public_proposal_list.html:39
 msgid "Withdraw"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:132
-#: exhibition/templates/exhibitors/proposal_list.html:167
+#: templates/exhibitors/proposal_list.html:133
+#: templates/exhibitors/proposal_list.html:168
 msgid "Reopen for review"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:137
-#: exhibition/templates/exhibitors/public_proposal_list.html:34
+#: templates/exhibitors/proposal_list.html:138
+#: templates/exhibitors/public_proposal_list.html:34
 msgid "View"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:149
+#: templates/exhibitors/proposal_list.html:150
 msgid "No exhibition requests match your filters."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:151
+#: templates/exhibitors/proposal_list.html:152
 msgid "No exhibition requests have been submitted yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:159
+#: templates/exhibitors/proposal_list.html:160
 msgid "Approve the selected requests and create their partner profiles?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:160
+#: templates/exhibitors/proposal_list.html:161
 msgid "Reject the selected requests?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:161
+#: templates/exhibitors/proposal_list.html:162
 msgid "Reject this request?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:162
+#: templates/exhibitors/proposal_list.html:163
 msgid "Withdraw this request?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:163
+#: templates/exhibitors/proposal_list.html:164
 msgid "Reopen this request for review?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:168
+#: templates/exhibitors/proposal_list.html:169
 msgid "The action could not be completed. Please try again."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:170
+#: templates/exhibitors/proposal_list.html:171
 msgid ""
 "Approve every request matching the current filters, including those on other "
 "pages?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:171
+#: templates/exhibitors/proposal_list.html:172
 msgid ""
 "Reject every request matching the current filters, including those on other "
 "pages?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:172
+#: templates/exhibitors/proposal_list.html:173
 msgid "Please confirm"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:173
+#: templates/exhibitors/proposal_list.html:174
 msgid "Confirm"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:14
+#: templates/exhibitors/public_call.html:14
 msgid "Submit a request to become an exhibitor for this event."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:20
+#: templates/exhibitors/public_call.html:20
 #, python-format
 msgid "You can submit requests until %(deadline)s (%(timezone)s)."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:24
+#: templates/exhibitors/public_call.html:24
 #, python-format
 msgid "This call closed on %(deadline)s (%(timezone)s)."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:34
+#: templates/exhibitors/public_call.html:34
 msgid "View your requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:40
-#: exhibition/templates/exhibitors/public_proposal_form.html:18
-#: exhibition/templates/exhibitors/public_proposal_list.html:65
+#: templates/exhibitors/public_call.html:40
+#: templates/exhibitors/public_proposal_form.html:18
+#: templates/exhibitors/public_proposal_list.html:65
 msgid "Submit a request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:42
+#: templates/exhibitors/public_call.html:42
 msgid "Requests are closed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:21
-#: exhibition/templates/exhibitors/public_detail.html:94
+#: templates/exhibitors/public_detail.html:21
+#: templates/exhibitors/public_detail.html:93
 msgid "Previous"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:24
-#: exhibition/templates/exhibitors/public_detail.html:98
+#: templates/exhibitors/public_detail.html:24
+#: templates/exhibitors/public_detail.html:97
 msgid "Next"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:47
+#: templates/exhibitors/public_detail.html:47
 msgid "Get In Touch"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:87
-#: exhibition/templates/exhibitors/public_detail.html:103
+#: templates/exhibitors/public_detail.html:87
+#: templates/exhibitors/public_detail.html:102
 msgid "Open slides PDF"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:88
-#, python-brace-format
-msgid "Slide {current} of {total}"
-msgstr ""
-
-#: exhibition/templates/exhibitors/public_detail.html:112
+#: templates/exhibitors/public_detail.html:111
 msgid "Send email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:126
+#: templates/exhibitors/public_detail.html:125
 msgid "Visit website"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_list.html:54
+#: templates/exhibitors/public_list.html:32
+msgid "Clear"
+msgstr ""
+
+#: templates/exhibitors/public_list.html:54
 msgid "No exhibitors match your search."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_list.html:56
+#: templates/exhibitors/public_list.html:56
 msgid "No exhibitors are currently available."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:16
+#: templates/exhibitors/public_proposal_form.html:16
 msgid "Edit request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:23
-#: exhibition/views.py:883
+#: templates/exhibitors/public_proposal_form.html:23 views.py:958
 msgid "This request can no longer be edited."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:186
+#: templates/exhibitors/public_proposal_form.html:190
 msgid "Submit request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:189
+#: templates/exhibitors/public_proposal_form.html:193
 msgid "or save as draft for now"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:199
+#: templates/exhibitors/public_proposal_form.html:203
 msgid "Back to your requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:5
+#: templates/exhibitors/public_proposal_list.html:5
 msgid "Your exhibition requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:13
+#: templates/exhibitors/public_proposal_list.html:13
 msgid "Last modified"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:23
+#: templates/exhibitors/public_proposal_list.html:23
 msgid "Withdrawn"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:44
+#: templates/exhibitors/public_proposal_list.html:44
 msgid "Reinstate"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:56
+#: templates/exhibitors/public_proposal_list.html:56
 msgid "Create a new request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:61
+#: templates/exhibitors/public_proposal_list.html:61
 msgid "You have not submitted an exhibition request yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:5
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:21
+#: templates/exhibitors/public_proposal_reinstate.html:5
+#: templates/exhibitors/public_proposal_reinstate.html:21
 msgid "Reinstate request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:7
+#: templates/exhibitors/public_proposal_reinstate.html:7
 #, python-format
 msgid ""
 "Do you want to reinstate your withdrawn request “%(name)s”? It will be "
 "pending review again."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:5
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:26
+#: templates/exhibitors/public_proposal_withdraw.html:5
+#: templates/exhibitors/public_proposal_withdraw.html:26
 msgid "Withdraw request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:7
+#: templates/exhibitors/public_proposal_withdraw.html:7
 #, python-format
 msgid "Are you sure you want to withdraw your request “%(name)s”?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:13
+#: templates/exhibitors/public_proposal_withdraw.html:13
 msgid ""
 "This request has already been approved. Withdrawing it will hide the "
 "exhibitor or sponsor profile created from it from public listings."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:10
-#: exhibition/templates/exhibitors/settings.html:27
+#: templates/exhibitors/settings.html:10 templates/exhibitors/settings.html:29
 msgid "Sponsor Settings"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:12
-#: exhibition/templates/exhibitors/settings.html:29
+#: templates/exhibitors/settings.html:12 templates/exhibitors/settings.html:31
+msgid "Voucher Settings"
+msgstr ""
+
+#: templates/exhibitors/settings.html:14 templates/exhibitors/settings.html:33
 msgid "Exhibitor Settings"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:42
+#: templates/exhibitors/settings.html:46
 msgid "Publish your call"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:43
+#: templates/exhibitors/settings.html:47
 msgid "Publish a login-required application form for exhibitors."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:72
+#: templates/exhibitors/settings.html:76
 msgid ""
 "This panel renders unsaved draft text using the same styling as the live "
 "public call page."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:104
+#: templates/exhibitors/settings.html:108
 msgid "Secret call link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:107
+#: templates/exhibitors/settings.html:111
 msgid ""
 "This call is private: it is not linked anywhere public. Share the link below "
 "with the organizations you want to invite. Anyone who has it can open the "
 "call and apply."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:113
+#: templates/exhibitors/settings.html:117
 msgid "Copied"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:113
+#: templates/exhibitors/settings.html:117
 msgid "Copy to clipboard"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:114
+#: templates/exhibitors/settings.html:118
 msgid "Copy"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:119
+#: templates/exhibitors/settings.html:123
 msgid ""
 "Regenerate the secret link? The current link will stop working immediately."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:125
+#: templates/exhibitors/settings.html:129
 msgid "Regenerate link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:127
+#: templates/exhibitors/settings.html:131
 msgid "Regenerating immediately invalidates the current link."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:138
+#: templates/exhibitors/settings.html:143
+msgid "Voucher pools"
+msgstr ""
+
+#: templates/exhibitors/settings.html:147
+msgid ""
+"Create the voucher codes under Tickets → Vouchers and give them a tag, then "
+"pick that tag here. Exhibitors and sponsors are handed codes from the pool "
+"you choose. Reload this page to pick up a tag you just created."
+msgstr ""
+
+#: templates/exhibitors/settings.html:157
+msgid "Create vouchers pool"
+msgstr ""
+
+#: templates/exhibitors/settings.html:159
+msgid "(opens in a new tab)"
+msgstr ""
+
+#: templates/exhibitors/settings.html:168
+#: templates/exhibitors/settings.html:182
+#, python-format
+msgid "%(counter)s voucher in this pool is not assigned to anyone yet."
+msgid_plural ""
+"%(counter)s vouchers in this pool are not assigned to anyone yet."
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/exhibitors/settings.html:194
+msgid "How many each one gets"
+msgstr ""
+
+#: templates/exhibitors/settings.html:196
+msgid ""
+"Applies to any exhibitor or sponsor that does not belong to a sponsor group. "
+"Sponsor groups set their own number on the Sponsors page, and an individual "
+"exhibitor or sponsor can be given a different number on their own voucher "
+"page."
+msgstr ""
+
+#: templates/exhibitors/settings.html:206
+msgid "Voucher email"
+msgstr ""
+
+#: templates/exhibitors/settings.html:208
+msgid "Applies to the voucher email sent to exhibitors and sponsors alike."
+msgstr ""
+
+#: templates/exhibitors/settings.html:228
 msgid "Data access"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:139
+#: templates/exhibitors/settings.html:229
 msgid ""
 "In this section, you can control which attendee data is shared with "
 "exhibitors when an exhibitor voucher is used or when the exhibitor uses the "
 "lead scanning app."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:142
+#: templates/exhibitors/settings.html:232
 msgid "Exhibitor vouchers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:158
-msgid "Exhibitor login"
-msgstr ""
-
-#: exhibition/templates/exhibitors/settings.html:160
-msgid ""
-"The access-code email sent to exhibitors is now edited together with the "
-"plugin's other email templates."
-msgstr ""
-
-#: exhibition/templates/exhibitors/settings.html:162
-msgid "Edit email templates"
-msgstr ""
-
-#: exhibition/templates/exhibitors/settings.html:177
+#: templates/exhibitors/settings.html:257
 msgid "Group List"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:180
+#: templates/exhibitors/settings.html:260
 msgid "Add a Group"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:193
+#: templates/exhibitors/settings.html:272
+#: templates/exhibitors/settings.html:354
+msgid "Voucher defaults for this group"
+msgstr ""
+
+#: templates/exhibitors/settings.html:277
 msgid "Add"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:204
+#: templates/exhibitors/settings.html:288
 msgid "Group Name"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:206
+#: templates/exhibitors/settings.html:290
 msgid "Partners"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:207
+#: templates/exhibitors/settings.html:291
 msgid "Front Page"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:220
-#: exhibition/templates/exhibitors/settings.html:226
+#: templates/exhibitors/settings.html:304
+#: templates/exhibitors/settings.html:310
 msgid "Show this sponsor group in the Supported By section on the front page."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:251
+#: templates/exhibitors/settings.html:326
+msgid "Edit sponsor group"
+msgstr ""
+
+#: templates/exhibitors/settings.html:337
 msgid "Reorder sponsor group"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:281
+#: templates/exhibitors/settings.html:371
 msgid "You do not have any sponsor groups yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:8
+#: templates/exhibitors/voucher_bulk_send.html:4
+#: templates/exhibitors/voucher_bulk_send.html:7
+msgid "Send vouchers"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:18
+#, python-format
+msgid "A voucher email will be placed in the outbox for %(counter)s sponsor."
+msgid_plural ""
+"A voucher email will be placed in the outbox for %(counter)s sponsors."
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:24
+#, python-format
+msgid "A voucher email will be placed in the outbox for %(counter)s exhibitor."
+msgid_plural ""
+"A voucher email will be placed in the outbox for %(counter)s exhibitors."
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:37
+#, python-format
+msgid "&mdash; %(counter)s voucher will be created"
+msgid_plural "&mdash; %(counter)s vouchers will be created"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:45
+#, python-format
+msgid "&mdash; %(counter)s existing voucher"
+msgid_plural "&mdash; %(counter)s existing vouchers"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:58
+msgid "None of the sponsors in this list can be emailed yet."
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:60
+msgid "None of the exhibitors in this list can be emailed yet."
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:66
+msgid "Skipped: no email address"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:75
+msgid "Skipped: voucher count is set to 0"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:84
+msgid "Skipped: no vouchers available from their pool"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:86
+msgid ""
+"Check that a voucher pool is selected under Settings → Vouchers and that it "
+"still has unassigned codes."
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:99
+msgid "Queue emails"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:8
 #, python-format
 msgid "Vouchers for %(name)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:13
+#: templates/exhibitors/vouchers.html:13
 msgid ""
-"Issue ticket vouchers for this partner to hand out. Whoever redeems one on "
-"the ticket shop becomes a lead this partner can retrieve, as long as voucher "
+"Hand this exhibitor or sponsor codes from the voucher pool. Whoever redeems "
+"one on the ticket shop becomes a lead they can retrieve, as long as voucher "
 "data access is enabled for them."
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:20
-msgid "Issued vouchers"
+#: templates/exhibitors/vouchers.html:20
+msgid "Assigned vouchers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:24
+#: templates/exhibitors/vouchers.html:24
 msgid "Download codes (CSV)"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:31
+#: templates/exhibitors/vouchers.html:31
 msgid "Code"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:32 exhibition/views.py:1994
+#: templates/exhibitors/vouchers.html:32 utils.py:495
 msgid "Product"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:34 exhibition/views.py:1998
+#: templates/exhibitors/vouchers.html:33 utils.py:496
+msgid "Price effect"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:34 utils.py:499
 msgid "Redeemed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:56
+#: templates/exhibitors/vouchers.html:35 utils.py:498
+msgid "Valid until"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:56
 msgid "Already redeemed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:67
-msgid "No vouchers have been issued for this partner yet."
+#: templates/exhibitors/vouchers.html:62
+msgid "Return to pool"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:76
-msgid "Issue new vouchers"
+#: templates/exhibitors/vouchers.html:74
+msgid "No vouchers have been assigned to this partner yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:86
-msgid "Create vouchers"
+#: templates/exhibitors/vouchers.html:82
+msgid "Take more from the pool"
 msgstr ""
 
-#: exhibition/templates/sponsors/presale_supported_by.html:4
+#: templates/exhibitors/vouchers.html:84
+msgid ""
+"Codes come from the voucher pool chosen under Settings. The email always "
+"carries this partner's complete list of codes, so you can assign some now "
+"and send them together with more later. It is placed in the outbox for you "
+"to review before it goes out."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:92
+#, python-format
+msgid "%(counter)s voucher is left unassigned in the pool."
+msgid_plural "%(counter)s vouchers are left unassigned in the pool."
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/exhibitors/vouchers.html:100 views.py:2230
+msgid "No voucher pool is selected yet. Choose one under Settings → Vouchers."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:106
+msgid "A voucher email for this partner is waiting in the outbox."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:108
+msgid "Go to outbox"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:114
+#, python-format
+msgid "Vouchers were last emailed to this partner on %(sent)s."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:120
+msgid ""
+"This partner has no email address on file, so vouchers cannot be emailed."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:127
+msgid "Assign and prepare email"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:130
+msgid "Assign without emailing"
+msgstr ""
+
+#: templates/sponsors/presale_supported_by.html:4
 msgid "Supported By"
 msgstr ""
 
-#: exhibition/views.py:324
+#: utils.py:493
+msgid "Voucher code"
+msgstr ""
+
+#: utils.py:494
+msgid "Redeem link"
+msgstr ""
+
+#: utils.py:497
+msgid "Value"
+msgstr ""
+
+#: utils.py:500
+msgid "Maximum usages"
+msgstr ""
+
+#: views.py:342
 msgid "Company name"
 msgstr ""
 
-#: exhibition/views.py:325
+#: views.py:343
 msgid "Job title"
 msgstr ""
 
-#: exhibition/views.py:326
+#: views.py:344
 msgid "Address"
 msgstr ""
 
-#: exhibition/views.py:333
+#: views.py:351
 msgid "Attendee Name"
 msgstr ""
 
-#: exhibition/views.py:338
+#: views.py:356
 msgid "Attendee Email"
 msgstr ""
 
-#: exhibition/views.py:377
+#: views.py:395 views.py:412
 msgid "Settings have been saved."
 msgstr ""
 
-#: exhibition/views.py:393
+#: views.py:428
 msgid "Call settings have been saved."
 msgstr ""
 
-#: exhibition/views.py:401
+#: views.py:436
 msgid ""
 "A new secret call link has been generated. The old link no longer works."
 msgstr ""
 
-#: exhibition/views.py:416
+#: views.py:451
 msgid "Sponsor group added."
 msgstr ""
 
-#: exhibition/views.py:437
+#: views.py:454 views.py:477 views.py:853 views.py:1169 views.py:1796
+#: views.py:1918 views.py:2564 views.py:3025
+msgid "We could not save your changes. See below for details."
+msgstr ""
+
+#: views.py:474
 msgid "Sponsor group updated."
 msgstr ""
 
-#: exhibition/views.py:452
+#: views.py:491
 msgid "This sponsor group cannot be deleted while it is assigned to partners."
 msgstr ""
 
-#: exhibition/views.py:460
+#: views.py:499
 msgid "Unknown action."
 msgstr ""
 
-#: exhibition/views.py:505
+#: views.py:544
 msgid "Access key"
 msgstr ""
 
-#: exhibition/views.py:745 exhibition/views.py:1060
+#: views.py:819 views.py:1135
 msgid "Add at least one social media link."
 msgstr ""
 
-#: exhibition/views.py:754 exhibition/views.py:1069
+#: views.py:828 views.py:1144
 msgid "Add at least one extra link."
 msgstr ""
 
-#: exhibition/views.py:809
+#: views.py:884
 msgid "The call for exhibitors is closed."
 msgstr ""
 
-#: exhibition/views.py:837
+#: views.py:912
 msgid "Your request has been saved."
 msgstr ""
 
-#: exhibition/views.py:920 exhibition/views.py:1776
+#: views.py:995 views.py:1914
 msgid "Your changes have been saved."
 msgstr ""
 
-#: exhibition/views.py:953
+#: views.py:1028
 msgid "This proposal can no longer be withdrawn."
 msgstr ""
 
-#: exhibition/views.py:961
+#: views.py:1036
 msgid "Your request has been withdrawn."
 msgstr ""
 
-#: exhibition/views.py:963
+#: views.py:1038
 msgid "This request can no longer be withdrawn."
 msgstr ""
 
-#: exhibition/views.py:989 exhibition/views.py:999
+#: views.py:1064 views.py:1074
 msgid "This request can no longer be reinstated."
 msgstr ""
 
-#: exhibition/views.py:997
+#: views.py:1072
 msgid "Your request has been reinstated and is pending review again."
 msgstr ""
 
-#: exhibition/views.py:1121
+#: views.py:1197
 msgid "Invalid request body."
 msgstr ""
 
-#: exhibition/views.py:1124 exhibition/views.py:1129
+#: views.py:1200 views.py:1205
 msgid "Invalid sponsor group IDs."
 msgstr ""
 
-#: exhibition/views.py:1133
+#: views.py:1209
 msgid "Sponsor group IDs must be unique."
 msgstr ""
 
-#: exhibition/views.py:1141
+#: views.py:1217
 msgid "Reorder request must include each sponsor group exactly once."
 msgstr ""
 
-#: exhibition/views.py:1346
+#: views.py:1422
 msgid "This request can no longer be changed to that state."
 msgstr ""
 
-#: exhibition/views.py:1350
+#: views.py:1426
 msgid "Review details saved."
 msgstr ""
 
-#: exhibition/views.py:1359
+#: views.py:1435
 msgid ""
 "Request approved and partner profile created. An acceptance email was placed "
 "in the outbox."
 msgstr ""
 
-#: exhibition/views.py:1369
+#: views.py:1445
 msgid "Request rejected. A rejection email was placed in the outbox."
 msgstr ""
 
-#: exhibition/views.py:1372
+#: views.py:1448
 msgid "Request withdrawn."
 msgstr ""
 
-#: exhibition/views.py:1375
+#: views.py:1451
 msgid "Request reopened for review."
 msgstr ""
 
-#: exhibition/views.py:1407
+#: views.py:1483
 msgid "No valid action was selected."
 msgstr ""
 
-#: exhibition/views.py:1454
+#: views.py:1530
 #, python-format
 msgid "%(count)d request was approved."
 msgid_plural "%(count)d requests were approved."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1455
+#: views.py:1531
 #, python-format
 msgid "%(count)d request was rejected."
 msgid_plural "%(count)d requests were rejected."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1456
+#: views.py:1532
 #, python-format
 msgid "%(count)d request was withdrawn."
 msgid_plural "%(count)d requests were withdrawn."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1457
+#: views.py:1533
 #, python-format
 msgid "%(count)d request was reopened."
 msgid_plural "%(count)d requests were reopened."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1461
+#: views.py:1537
 msgid "No proposals were updated."
 msgstr ""
 
-#: exhibition/views.py:1464
+#: views.py:1540
 #, python-format
 msgid "%(skipped)d was skipped because it was already processed."
 msgid_plural "%(skipped)d were skipped because they were already processed."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1605
+#: views.py:1681
 msgid "Exhibitor form settings have been saved."
 msgstr ""
 
-#: exhibition/views.py:1730
+#: views.py:1868
 msgid "The requested form field does not exist."
 msgstr ""
 
-#: exhibition/views.py:1791
+#: views.py:1933
 msgid "The field has been reset to its default."
 msgstr ""
 
-#: exhibition/views.py:1829 exhibition/views.py:1900
+#: views.py:1971 views.py:2042
 msgid "An access-credentials email was placed in the outbox."
 msgstr ""
 
-#: exhibition/views.py:1907
+#: views.py:2049
 msgid "Edit Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1908
+#: views.py:2050
 msgid "Edit Exhibitor"
 msgstr ""
 
-#: exhibition/views.py:1909
+#: views.py:2051
 msgid "Edit Exhibitor & Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1910
+#: views.py:2052
 msgid "Edit Exhibitor or Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1940
+#: views.py:2082
 msgid "Delete Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1941
+#: views.py:2083
 msgid "Delete Exhibitor"
 msgstr ""
 
-#: exhibition/views.py:1942
+#: views.py:2084
 msgid "Delete Exhibitor & Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1943
+#: views.py:2085
 msgid "Delete Exhibitor or Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1992
-msgid "Voucher code"
+#: views.py:2164
+msgid "This voucher has already been redeemed and cannot be returned."
 msgstr ""
 
-#: exhibition/views.py:1993
-msgid "Redeem link"
+#: views.py:2170
+msgid ""
+"This code was already included in a voucher email to this partner, so it "
+"cannot be returned to the pool. Delete it under Tickets → Vouchers instead."
 msgstr ""
 
-#: exhibition/views.py:1999
-msgid "Maximum usages"
+#: views.py:2176
+msgid "Voucher returned to the pool."
 msgstr ""
 
-#: exhibition/views.py:2035
-msgid "This voucher has already been redeemed and cannot be removed."
+#: views.py:2207
+msgid "Enter how many vouchers to take from the pool."
 msgstr ""
 
-#: exhibition/views.py:2040
-msgid "Voucher removed."
-msgstr ""
-
-#: exhibition/views.py:2060
+#: views.py:2215
 #, python-format
-msgid "%(count)d voucher created."
-msgid_plural "%(count)d vouchers created."
+msgid "%(count)d voucher taken from the pool."
+msgid_plural "%(count)d vouchers taken from the pool."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2112
+#: views.py:2232
+#, python-format
+msgid ""
+"The pool only has %(remaining)d voucher(s) left, so %(count)d cannot be "
+"taken."
+msgstr ""
+
+#: views.py:2244
+msgid "No email address is on file, so vouchers cannot be emailed."
+msgstr ""
+
+#: views.py:2253
+msgid "This partner holds no vouchers yet, so there is nothing to email."
+msgstr ""
+
+#: views.py:2259
+#, python-format
+msgid "An email with %(count)d voucher code was placed in the outbox."
+msgid_plural "An email with %(count)d voucher codes was placed in the outbox."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2347
+msgid "There is nobody to send vouchers to in this list."
+msgstr ""
+
+#: views.py:2354
+#, python-format
+msgid "%(count)d voucher email was placed in the outbox."
+msgid_plural "%(count)d voucher emails were placed in the outbox."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2371
+#, python-format
+msgid ""
+"%(count)d was skipped because no unassigned codes were available from their "
+"pool."
+msgid_plural ""
+"%(count)d were skipped because no unassigned codes were available from their "
+"pool."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2386
+#, python-format
+msgid "%(count)d sponsor was skipped because it has no email address."
+msgid_plural ""
+"%(count)d sponsors were skipped because they have no email address."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2392
+#, python-format
+msgid "%(count)d exhibitor was skipped because it has no email address."
+msgid_plural ""
+"%(count)d exhibitors were skipped because they have no email address."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2401
+#, python-format
+msgid "%(count)d sponsor was skipped because their voucher count is set to 0."
+msgid_plural ""
+"%(count)d sponsors were skipped because their voucher count is set to 0."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2407
+#, python-format
+msgid ""
+"%(count)d exhibitor was skipped because their voucher count is set to 0."
+msgid_plural ""
+"%(count)d exhibitors were skipped because their voucher count is set to 0."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2461
 #, python-format
 msgid "%(count)d device added."
 msgid_plural "%(count)d devices added."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2123
+#: views.py:2472
 #, python-format
 msgid ""
 "New setup tokens generated. %(count)d device that was already scanning is "
@@ -2731,79 +3024,95 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2132
+#: views.py:2481
 msgid "New setup tokens generated."
 msgstr ""
 
-#: exhibition/views.py:2194
+#: views.py:2543
 msgid "No applicants matched the selected filters."
 msgstr ""
 
-#: exhibition/views.py:2202
+#: views.py:2551
 #, python-format
 msgid "%(count)d emails have been scheduled."
 msgstr ""
 
-#: exhibition/views.py:2206
+#: views.py:2555
 #, python-format
 msgid "%(count)d emails have been sent."
 msgstr ""
 
-#: exhibition/views.py:2210
+#: views.py:2559
 #, python-format
 msgid "%(count)d emails have been placed in the outbox."
 msgstr ""
 
-#: exhibition/views.py:2385
+#: views.py:2738
 msgid "The emails have been saved and sent."
 msgstr ""
 
-#: exhibition/views.py:2389
+#: views.py:2742
 msgid "The emails have been saved."
 msgstr ""
 
-#: exhibition/views.py:2395
+#: views.py:2748
 msgid "The email has been saved and sent."
 msgstr ""
 
-#: exhibition/views.py:2399
+#: views.py:2752
 msgid "The email has been saved."
 msgstr ""
 
-#: exhibition/views.py:2423 exhibition/views.py:2497
+#: views.py:2776 views.py:2850
 #, python-format
 msgid "%(count)d email has been sent."
 msgid_plural "%(count)d emails have been sent."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2459
+#: views.py:2812
 msgid "The email has been discarded."
 msgstr ""
 
-#: exhibition/views.py:2501 exhibition/views.py:2514 exhibition/views.py:2519
+#: views.py:2854 views.py:2867 views.py:2872
 msgid "No emails were selected."
 msgstr ""
 
-#: exhibition/views.py:2510
+#: views.py:2863
 #, python-format
 msgid "%(count)d email has been discarded."
 msgid_plural "%(count)d emails have been discarded."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2594
+#: views.py:2929
+msgid "Request received (confirmation)"
+msgstr ""
+
+#: views.py:2930
+msgid "Request accepted"
+msgstr ""
+
+#: views.py:2931
+msgid "Request rejected"
+msgstr ""
+
+#: views.py:2932
+msgid "Exhibitor lead scanning key"
+msgstr ""
+
+#: views.py:2948
 msgid "Email templates have been saved."
 msgstr ""
 
-#: exhibition/views.py:2617 exhibition/views.py:2621
+#: views.py:2971 views.py:2975
 msgid "Unknown template."
 msgstr ""
 
-#: exhibition/views.py:2667
+#: views.py:3021
 msgid "Custom template has been created."
 msgstr ""
 
-#: exhibition/views.py:2683
+#: views.py:3041
 msgid "Custom template has been deleted."
 msgstr ""

--- a/exhibition/locale/django.pot
+++ b/exhibition/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 10:29+0000\n"
+"POT-Creation-Date: 2026-09-11 11:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,595 +18,531 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: exhibition/apps.py:14 exhibition/apps.py:17 exhibition/signals.py:157
-#: exhibition/templates/exhibitors/public_list.html:6
-#: exhibition/templates/exhibitors/public_list.html:14
-#: exhibition/templates/exhibitors/public_list.html:16
+#: apps.py:14 apps.py:17 signals.py:163 templates/exhibitors/public_list.html:6
+#: templates/exhibitors/public_list.html:14
+#: templates/exhibitors/public_list.html:16
 msgid "Exhibition"
 msgstr ""
 
-#: exhibition/apps.py:19
+#: apps.py:19
 msgid "This plugin enables to add and control exhibitors in eventyay"
 msgstr ""
 
-#: exhibition/filters.py:9
+#: filters.py:9
 msgid "Any"
 msgstr ""
 
-#: exhibition/filters.py:10
+#: filters.py:10
 msgid "Enabled"
 msgstr ""
 
-#: exhibition/filters.py:11 exhibition/templates/exhibitors/dashboard.html:127
+#: filters.py:11 templates/exhibitors/dashboard.html:127
 msgid "Disabled"
 msgstr ""
 
-#: exhibition/filters.py:15
+#: filters.py:15
 msgid "All types"
 msgstr ""
 
-#: exhibition/filters.py:16
+#: filters.py:16
 msgid "Exhibitor only"
 msgstr ""
 
-#: exhibition/filters.py:17
+#: filters.py:17
 msgid "Sponsor only"
 msgstr ""
 
-#: exhibition/filters.py:18 exhibition/templates/exhibitors/dashboard.html:89
-#: exhibition/templates/exhibitors/proposal_detail.html:95
-#: exhibition/templates/exhibitors/proposal_list.html:95
+#: filters.py:18 templates/exhibitors/dashboard.html:89
+#: templates/exhibitors/proposal_detail.html:95
+#: templates/exhibitors/proposal_list.html:95
 msgid "Exhibitor and sponsor"
 msgstr ""
 
-#: exhibition/filters.py:80 exhibition/filters.py:81
+#: filters.py:80 filters.py:81
 msgid "Search requests…"
 msgstr ""
 
-#: exhibition/filters.py:81
+#: filters.py:81
 msgid "Search requests"
 msgstr ""
 
-#: exhibition/filters.py:85 exhibition/templates/exhibitors/dashboard.html:75
-#: exhibition/templates/exhibitors/proposal_detail.html:85
-#: exhibition/templates/exhibitors/proposal_list.html:21
-#: exhibition/templates/exhibitors/public_proposal_list.html:12
+#: filters.py:85 templates/exhibitors/dashboard.html:75
+#: templates/exhibitors/proposal_detail.html:85
+#: templates/exhibitors/proposal_list.html:21
+#: templates/exhibitors/public_proposal_list.html:12
 msgid "State"
 msgstr ""
 
-#: exhibition/filters.py:86
+#: filters.py:86
 msgid "All states"
 msgstr ""
 
-#: exhibition/filters.py:90 exhibition/templates/exhibitors/dashboard.html:74
-#: exhibition/templates/exhibitors/proposal_detail.html:91
-#: exhibition/templates/exhibitors/proposal_list.html:62
+#: filters.py:90 templates/exhibitors/dashboard.html:74
+#: templates/exhibitors/proposal_detail.html:91
+#: templates/exhibitors/proposal_list.html:62
 msgid "Type"
 msgstr ""
 
-#: exhibition/filters.py:99 exhibition/filters.py:102
+#: filters.py:99 filters.py:102
 msgid "Search by name…"
 msgstr ""
 
-#: exhibition/filters.py:103
+#: filters.py:103
 msgid "Search requests by name"
 msgstr ""
 
-#: exhibition/filters.py:132 exhibition/filters.py:133
+#: filters.py:132 filters.py:133
 msgid "Search organizations…"
 msgstr ""
 
-#: exhibition/filters.py:133
+#: filters.py:133
 msgid "Search organizations"
 msgstr ""
 
-#: exhibition/filters.py:137
+#: filters.py:137
 msgid "Visibility"
 msgstr ""
 
-#: exhibition/filters.py:139
+#: filters.py:139
 msgid "All organizations"
 msgstr ""
 
-#: exhibition/filters.py:140 exhibition/forms.py:1512
-#: exhibition/templates/exhibitors/call_questions.html:30
+#: filters.py:140 forms.py:1553 templates/exhibitors/call_questions.html:30
 msgid "Active"
 msgstr ""
 
-#: exhibition/filters.py:141
+#: filters.py:141
 msgid "Inactive"
 msgstr ""
 
-#: exhibition/filters.py:146 exhibition/filters.py:207 exhibition/forms.py:207
-#: exhibition/forms.py:1410 exhibition/forms.py:1841
+#: filters.py:146 filters.py:207 forms.py:212 forms.py:1411 forms.py:1888
 msgid "Sponsor group"
 msgstr ""
 
-#: exhibition/filters.py:149 exhibition/filters.py:210
+#: filters.py:149 filters.py:210
 msgid "All groups"
 msgstr ""
 
-#: exhibition/filters.py:152 exhibition/templates/exhibitors/add.html:222
+#: filters.py:152 templates/exhibitors/add.html:226
 msgid "Lead scanning"
 msgstr ""
 
-#: exhibition/filters.py:157
+#: filters.py:157
 msgid "Lead access"
 msgstr ""
 
-#: exhibition/filters.py:162
+#: filters.py:162
 msgid "Voucher access"
 msgstr ""
 
-#: exhibition/filters.py:202 exhibition/filters.py:203
+#: filters.py:202 filters.py:203
 msgid "Search exhibitors…"
 msgstr ""
 
-#: exhibition/filters.py:203
+#: filters.py:203
 msgid "Search exhibitors"
 msgstr ""
 
-#: exhibition/filters.py:240 exhibition/filters.py:241
+#: filters.py:240 filters.py:241
 msgid "Search emails…"
 msgstr ""
 
-#: exhibition/filters.py:241
+#: filters.py:241
 msgid "Search emails"
 msgstr ""
 
-#: exhibition/forms.py:67
+#: forms.py:72
 #, python-format
 msgid "Times are in the event timezone: %(tz)s."
 msgstr ""
 
-#: exhibition/forms.py:128 exhibition/forms.py:139 exhibition/forms.py:933
-#: exhibition/forms.py:944
+#: forms.py:133 forms.py:144 forms.py:934 forms.py:945
 msgid "— No selection —"
 msgstr ""
 
-#: exhibition/forms.py:211
+#: forms.py:216
 msgid "Can view voucher redemptions"
 msgstr ""
 
-#: exhibition/forms.py:213 exhibition/forms.py:397
+#: forms.py:218 forms.py:402
 msgid ""
 "Lets this exhibitor or sponsor retrieve the attendees who redeemed vouchers "
 "issued to them. Separate from lead scanning, which covers attendees scanned "
 "at the booth."
 msgstr ""
 
-#: exhibition/forms.py:219
+#: forms.py:224
 msgid "Can view and export collected leads"
 msgstr ""
 
-#: exhibition/forms.py:221
+#: forms.py:226
 msgid ""
 "Lets this exhibitor retrieve the full list of leads they have already "
 "scanned. Turn this off to let them keep scanning without seeing the "
 "collected attendee data."
 msgstr ""
 
-#: exhibition/forms.py:226
+#: forms.py:231
 msgid "Lead scanning behavior"
 msgstr ""
 
-#: exhibition/forms.py:231
+#: forms.py:236
 msgid ""
 "Every attendee is one lead, even when scanned from multiple devices. Notes "
 "and ratings are shared between devices."
 msgstr ""
 
-#: exhibition/forms.py:238
+#: forms.py:243
 msgid ""
 "Every attendee is a new lead when scanned from a new device. Notes and "
 "ratings are specific to the device."
 msgstr ""
 
-#: exhibition/forms.py:251
+#: forms.py:256
 msgid "Comment"
 msgstr ""
 
-#: exhibition/forms.py:253
+#: forms.py:258
 msgid ""
 "The text entered in this field will not be visible to the user and is "
 "available for your convenience."
 msgstr ""
 
-#: exhibition/forms.py:258 exhibition/forms.py:1427 exhibition/views.py:505
+#: forms.py:263 forms.py:1428 views.py:544
 msgid "Booth ID"
 msgstr ""
 
-#: exhibition/forms.py:291 exhibition/forms.py:1027 exhibition/forms.py:1076
-#: exhibition/models.py:130
+#: forms.py:296 forms.py:1028 forms.py:1077 models.py:130
 msgid "Organization name"
 msgstr ""
 
-#: exhibition/forms.py:292 exhibition/forms.py:1030 exhibition/forms.py:1077
-#: exhibition/models.py:136
+#: forms.py:297 forms.py:1031 forms.py:1078 models.py:136
 msgid "Organization description"
 msgstr ""
 
-#: exhibition/forms.py:293 exhibition/forms.py:1078
+#: forms.py:298 forms.py:1079
 msgid "E-mail"
 msgstr ""
 
-#: exhibition/forms.py:294 exhibition/forms.py:1079 exhibition/models.py:139
+#: forms.py:299 forms.py:1080 models.py:139
 msgid "Contact page URL"
 msgstr ""
 
-#: exhibition/forms.py:295 exhibition/forms.py:1080 exhibition/models.py:140
+#: forms.py:300 forms.py:1081 models.py:140
 msgid "Promotional video URL"
 msgstr ""
 
-#: exhibition/forms.py:296 exhibition/forms.py:1081 exhibition/models.py:141
+#: forms.py:301 forms.py:1082 models.py:141
 msgid "Promotional slides"
 msgstr ""
 
-#: exhibition/forms.py:297 exhibition/forms.py:1082 exhibition/models.py:142
-#: exhibition/models.py:520
-#: exhibition/templates/exhibitors/proposal_detail.html:111
+#: forms.py:302 forms.py:1083 models.py:142 models.py:568
+#: templates/exhibitors/proposal_detail.html:111
 msgid "Logo"
 msgstr ""
 
-#: exhibition/forms.py:298 exhibition/forms.py:1083 exhibition/models.py:145
-#: exhibition/templates/exhibitors/proposal_detail.html:113
+#: forms.py:303 forms.py:1084 models.py:145
+#: templates/exhibitors/proposal_detail.html:113
 msgid "Header image"
 msgstr ""
 
-#: exhibition/forms.py:299 exhibition/forms.py:1084 exhibition/models.py:138
+#: forms.py:304 forms.py:1085 models.py:138
 msgid "Organization website"
 msgstr ""
 
-#: exhibition/forms.py:300
+#: forms.py:305
 msgid "Mark this partner as an exhibitor"
 msgstr ""
 
-#: exhibition/forms.py:301
+#: forms.py:306
 msgid "Mark this partner as an event sponsor"
 msgstr ""
 
-#: exhibition/forms.py:302 exhibition/forms.py:1036 exhibition/forms.py:1085
-#: exhibition/models.py:148 exhibition/models.py:522
+#: forms.py:307 forms.py:1037 forms.py:1086 models.py:148 models.py:570
 msgid "Preferred booth name"
 msgstr ""
 
-#: exhibition/forms.py:303
+#: forms.py:308
 msgid "Can scan attendee badges"
 msgstr ""
 
-#: exhibition/forms.py:307
+#: forms.py:312
 msgid ""
 "Lets this exhibitor sign in to the lead scanning app and scan attendees at "
 "their booth. Turn this off to block scanning entirely."
 msgstr ""
 
-#: exhibition/forms.py:348 exhibition/forms.py:1441
+#: forms.py:353 forms.py:1442
 msgid "No sponsor group"
 msgstr ""
 
-#: exhibition/forms.py:385
+#: forms.py:390
 msgid ""
 "Lets this exhibitor retrieve the attendees who redeemed vouchers issued to "
 "them. Separate from lead scanning, which covers attendees scanned at the "
 "booth."
 msgstr ""
 
-#: exhibition/forms.py:389
+#: forms.py:394
 msgid ""
 "Lets this sponsor retrieve the attendees who redeemed vouchers issued to "
 "them. Separate from lead scanning, which covers attendees scanned at the "
 "booth."
 msgstr ""
 
-#: exhibition/forms.py:393
+#: forms.py:398
 msgid ""
 "Lets this exhibitor and sponsor retrieve the attendees who redeemed vouchers "
 "issued to them. Separate from lead scanning, which covers attendees scanned "
 "at the booth."
 msgstr ""
 
-#: exhibition/forms.py:466 exhibition/forms.py:553 exhibition/forms.py:1361
-#: exhibition/forms.py:1375
+#: forms.py:471 forms.py:558 forms.py:1362 forms.py:1376 forms.py:1855
+#: forms.py:1924 forms.py:1930 forms.py:1932 forms.py:1934
 msgid "This field is required."
 msgstr ""
 
-#: exhibition/forms.py:511 exhibition/forms.py:516
+#: forms.py:516 forms.py:521
 msgid "Slides upload must be a PDF file."
 msgstr ""
 
-#: exhibition/forms.py:540
+#: forms.py:545
 msgid "A partner must be marked as an exhibitor, a sponsor, or both."
 msgstr ""
 
-#: exhibition/forms.py:615
+#: forms.py:620
 msgid "Devices to add"
 msgstr ""
 
-#: exhibition/forms.py:617
+#: forms.py:622
 msgid ""
 "How many new devices to provision now, in addition to any already listed "
 "above. Each device gets its own single-use setup token and QR code."
 msgstr ""
 
-#: exhibition/forms.py:627
-msgid "Select a product…"
+#: forms.py:635
+msgid "Vouchers to take from the pool"
 msgstr ""
 
-#: exhibition/forms.py:628
-msgid "Ticket product"
+#: forms.py:636
+msgid ""
+"Set to 0 to email the codes this partner already has without taking any more."
 msgstr ""
 
-#: exhibition/forms.py:629
-msgid "The product a redeemed voucher applies to."
-msgstr ""
-
-#: exhibition/forms.py:635
-msgid "Number of vouchers"
-msgstr ""
-
-#: exhibition/forms.py:640
-msgid "Maximum usages per voucher"
-msgstr ""
-
-#: exhibition/forms.py:645 exhibition/templates/exhibitors/vouchers.html:33
-#: exhibition/views.py:1995
-msgid "Price effect"
-msgstr ""
-
-#: exhibition/forms.py:651 exhibition/views.py:1996
-msgid "Value"
-msgstr ""
-
-#: exhibition/forms.py:652
-msgid "Amount or percentage, depending on the selected price effect."
-msgstr ""
-
-#: exhibition/forms.py:657 exhibition/templates/exhibitors/vouchers.html:35
-#: exhibition/views.py:1997
-msgid "Valid until"
-msgstr ""
-
-#: exhibition/forms.py:673
-msgid "Enter a value for the selected price effect."
-msgstr ""
-
-#: exhibition/forms.py:678 exhibition/models.py:295
-#: exhibition/templates/exhibitors/settings.html:205
+#: forms.py:647 models.py:326 templates/exhibitors/settings.html:289
 msgid "Level"
 msgstr ""
 
-#: exhibition/forms.py:685 exhibition/models.py:294
+#: forms.py:654 models.py:325
 msgid "Group name"
 msgstr ""
 
-#: exhibition/forms.py:718
+#: forms.py:677 models.py:225
+msgid "Exhibitor voucher pool"
+msgstr ""
+
+#: forms.py:678 models.py:232
+msgid "Sponsor voucher pool"
+msgstr ""
+
+#: forms.py:698
+msgid "— No pool selected —"
+msgstr ""
+
+#: forms.py:699
+msgid "— Use the exhibitor pool —"
+msgstr ""
+
+#: forms.py:719
 msgid "Enable call"
 msgstr ""
 
-#: exhibition/forms.py:719
+#: forms.py:720
 msgid "Hide call page after the deadline"
 msgstr ""
 
-#: exhibition/forms.py:720
+#: forms.py:721
 msgid "Make this call private (accessible only via a secret link)"
 msgstr ""
 
-#: exhibition/forms.py:724
+#: forms.py:725
 msgid ""
 "Turn the call on. Keep it enabled for private calls too, otherwise the "
 "secret link stops working."
 msgstr ""
 
-#: exhibition/forms.py:727
+#: forms.py:728
 msgid ""
 "The call page is not linked anywhere public and can only be opened with the "
 "secret link shown below."
 msgstr ""
 
-#: exhibition/forms.py:868
+#: forms.py:869
 msgid "Your answer"
 msgstr ""
 
-#: exhibition/forms.py:1024 exhibition/models.py:563
-#: exhibition/templates/exhibitors/proposal_detail.html:88
+#: forms.py:1025 models.py:611 templates/exhibitors/proposal_detail.html:88
 msgid "Language"
 msgstr ""
 
-#: exhibition/forms.py:1025
+#: forms.py:1026
 msgid "The language you are filling in this form with."
 msgstr ""
 
-#: exhibition/forms.py:1086 exhibition/models.py:151 exhibition/models.py:523
-#: exhibition/models.py:602
+#: forms.py:1087 models.py:151 models.py:571 models.py:650
 msgid "Message to the organizers"
 msgstr ""
 
-#: exhibition/forms.py:1149
+#: forms.py:1150
 msgid ""
 "The organization name is locked after acceptance. Contact the organizers to "
 "change it."
 msgstr ""
 
-#: exhibition/forms.py:1425
+#: forms.py:1426
 msgid "Approve as exhibitor"
 msgstr ""
 
-#: exhibition/forms.py:1426
+#: forms.py:1427
 msgid "Approve as sponsor"
 msgstr ""
 
-#: exhibition/forms.py:1428 exhibition/models.py:352 exhibition/models.py:596
-#: exhibition/models.py:966 exhibition/views.py:505
+#: forms.py:1429 models.py:383 models.py:644 models.py:1014 views.py:544
 msgid "Booth name"
 msgstr ""
 
-#: exhibition/forms.py:1429 exhibition/forms.py:1459 exhibition/models.py:607
+#: forms.py:1430 forms.py:1460 models.py:655
 msgid "Internal review notes"
 msgstr ""
 
-#: exhibition/forms.py:1470
+#: forms.py:1471
 msgid "Field label"
 msgstr ""
 
-#: exhibition/forms.py:1475 exhibition/forms.py:1510
+#: forms.py:1476 forms.py:1551
 msgid "Help text"
 msgstr ""
 
-#: exhibition/forms.py:1476
+#: forms.py:1477
 msgid "Shown below the field on the exhibitor form."
 msgstr ""
 
-#: exhibition/forms.py:1483
+#: forms.py:1484
 #, python-format
 msgid "Leave empty to use the default: %(label)s"
 msgstr ""
 
-#: exhibition/forms.py:1492
-msgid "Options"
-msgstr ""
-
-#: exhibition/forms.py:1493
-msgid "For choice fields, enter one option per line."
-msgstr ""
-
-#: exhibition/forms.py:1508
-msgid "Field type"
-msgstr ""
-
-#: exhibition/forms.py:1509 exhibition/models.py:878
-msgid "Custom question"
-msgstr ""
-
-#: exhibition/forms.py:1511
-#: exhibition/templates/exhibitors/call_questions.html:31
-#: exhibition/templates/exhibitors/call_questions.html:63
-msgid "Required"
-msgstr ""
-
-#: exhibition/forms.py:1535
+#: forms.py:1523
 msgid "Please provide at least one option for this question type."
 msgstr ""
 
-#: exhibition/forms.py:1576 exhibition/forms.py:1665
+#: forms.py:1549
+msgid "Field type"
+msgstr ""
+
+#: forms.py:1550 models.py:926
+msgid "Custom question"
+msgstr ""
+
+#: forms.py:1552 templates/exhibitors/call_questions.html:31
+#: templates/exhibitors/call_questions.html:63
+msgid "Required"
+msgstr ""
+
+#: forms.py:1583 forms.py:1672
 msgid "Choose social platform"
 msgstr ""
 
-#: exhibition/forms.py:1578 exhibition/forms.py:1667
+#: forms.py:1585 forms.py:1674
 msgid "Social platform"
 msgstr ""
 
-#: exhibition/forms.py:1582 exhibition/forms.py:1671
+#: forms.py:1589 forms.py:1678
 msgid "Profile or path"
 msgstr ""
 
-#: exhibition/forms.py:1596 exhibition/forms.py:1685
+#: forms.py:1603 forms.py:1692
 msgid "Profile, handle, or full URL"
 msgstr ""
 
-#: exhibition/forms.py:1616 exhibition/forms.py:1705
+#: forms.py:1623 forms.py:1712
 msgid "Please enter a profile, handle, or URL or remove this row."
 msgstr ""
 
-#: exhibition/forms.py:1622 exhibition/forms.py:1711
+#: forms.py:1629 forms.py:1718
 msgid "Please choose a social platform."
 msgstr ""
 
-#: exhibition/forms.py:1626 exhibition/forms.py:1715
+#: forms.py:1633 forms.py:1722
 msgid "Please enter a profile, handle, or URL."
 msgstr ""
 
-#: exhibition/forms.py:1648 exhibition/forms.py:1737
+#: forms.py:1655 forms.py:1744
 msgid "Link label"
 msgstr ""
 
-#: exhibition/forms.py:1654 exhibition/forms.py:1743
+#: forms.py:1661 forms.py:1750
 msgid "https://example.com"
 msgstr ""
 
-#: exhibition/forms.py:1807
+#: forms.py:1848
 msgid ""
 "Leave empty to keep this in the outbox until sent manually. Time is "
 "interpreted in the event timezone."
 msgstr ""
 
-#: exhibition/forms.py:1814 exhibition/forms.py:1877
+#: forms.py:1861 forms.py:1940
 msgid "The scheduled time must be in the future."
 msgstr ""
 
-#: exhibition/forms.py:1822
+#: forms.py:1869
 msgid "Exhibitors and sponsors"
 msgstr ""
 
-#: exhibition/forms.py:1823
+#: forms.py:1870
 msgid "Exhibitors only"
 msgstr ""
 
-#: exhibition/forms.py:1824
+#: forms.py:1871
 msgid "Sponsors only"
 msgstr ""
 
-#: exhibition/forms.py:1828
+#: forms.py:1875
 msgid "Application state"
 msgstr ""
 
-#: exhibition/forms.py:1836
+#: forms.py:1883
 msgid "Partner type"
 msgstr ""
 
-#: exhibition/forms.py:1844
+#: forms.py:1891
 msgid "Any sponsor group"
 msgstr ""
 
-#: exhibition/forms.py:1846 exhibition/models.py:1035 exhibition/models.py:1089
-#: exhibition/templates/exhibitors/_email_outbox_body.html:6
-#: exhibition/templates/exhibitors/_email_sent_body.html:6
+#: forms.py:1893 forms.py:1953 models.py:1084 models.py:1146
+#: templates/exhibitors/_email_outbox_body.html:6
+#: templates/exhibitors/_email_sent_body.html:6
 msgid "Subject"
 msgstr ""
 
-#: exhibition/forms.py:1848
+#: forms.py:1895
 msgid "Send at"
 msgstr ""
 
-#: exhibition/forms.py:1851
+#: forms.py:1898
 msgid "Leave empty to send immediately or save to the outbox."
 msgstr ""
 
-#: exhibition/forms.py:1859 exhibition/models.py:1036 exhibition/models.py:1090
+#: forms.py:1906 forms.py:1960 models.py:1085 models.py:1147
 msgid "Body"
 msgstr ""
 
-#: exhibition/forms.py:1885 exhibition/views.py:2576
-msgid "Request received (confirmation)"
-msgstr ""
-
-#: exhibition/forms.py:1886 exhibition/views.py:2577
-msgid "Request accepted"
-msgstr ""
-
-#: exhibition/forms.py:1887 exhibition/views.py:2578
-msgid "Request rejected"
-msgstr ""
-
-#: exhibition/forms.py:1888 exhibition/views.py:2579
-msgid "Exhibitor lead scanning key"
-msgstr ""
-
-#: exhibition/forms.py:1897
-#, python-format
-msgid "%(role)s — subject"
-msgstr ""
-
-#: exhibition/forms.py:1904
-#, python-format
-msgid "%(role)s — body"
-msgstr ""
-
-#: exhibition/mail.py:57
+#: mail.py:59
 #, python-brace-format
 msgid "We received your request for {event_name}"
 msgstr ""
 
-#: exhibition/mail.py:59
+#: mail.py:61
 #, python-brace-format
 msgid ""
 "Hello,\n"
@@ -621,12 +557,12 @@ msgid ""
 "The {event_name} team"
 msgstr ""
 
-#: exhibition/mail.py:69
+#: mail.py:71
 #, python-brace-format
 msgid "Your request for {event_name} has been accepted"
 msgstr ""
 
-#: exhibition/mail.py:71
+#: mail.py:73
 #, python-brace-format
 msgid ""
 "Hello,\n"
@@ -638,12 +574,12 @@ msgid ""
 "The {event_name} team"
 msgstr ""
 
-#: exhibition/mail.py:80
+#: mail.py:82
 #, python-brace-format
 msgid "Update on your request for {event_name}"
 msgstr ""
 
-#: exhibition/mail.py:82
+#: mail.py:84
 #, python-brace-format
 msgid ""
 "Hello,\n"
@@ -657,12 +593,12 @@ msgid ""
 "The {event_name} team"
 msgstr ""
 
-#: exhibition/mail.py:91
+#: mail.py:93
 #, python-brace-format
 msgid "Lead Scanning Access for {event_name}"
 msgstr ""
 
-#: exhibition/mail.py:93
+#: mail.py:95
 #, python-brace-format
 msgid ""
 "Hello {exhibitor_name},\n"
@@ -688,983 +624,1080 @@ msgid ""
 "The {event_name} Team"
 msgstr ""
 
-#: exhibition/mail.py:174
+#: mail.py:110
+#, python-brace-format
+msgid "Your vouchers for {event_name} — {exhibitor_name}"
+msgstr ""
+
+#: mail.py:112
+#, python-brace-format
+msgid ""
+"Dear {exhibitor_name},\n"
+"\n"
+"Thank you for participating in {event_name}. Please share the voucher codes "
+"below with your audience — anyone who uses one gets credited to you as a "
+"lead.\n"
+"\n"
+"{voucher_list}\n"
+"\n"
+"They can redeem a code on the event ticket shop at checkout.\n"
+"\n"
+"If you have any questions, please don't hesitate to reach out.\n"
+"\n"
+"Best regards,\n"
+"The {event_name} Team"
+msgstr ""
+
+#: mail.py:190
 msgid "This value will be replaced based on dynamic parameters."
 msgstr ""
 
-#: exhibition/models.py:137 exhibition/models.py:515
+#: mail.py:312
+#, python-format
+msgid "…and %(count)d more voucher code in the attached CSV file."
+msgid_plural "…and %(count)d more voucher codes in the attached CSV file."
+msgstr[0] ""
+msgstr[1] ""
+
+#: models.py:137 models.py:563
 msgid "Contact email"
 msgstr ""
 
-#: exhibition/models.py:156
-#: exhibition/templates/exhibitors/proposal_detail.html:132
+#: models.py:156 templates/exhibitors/proposal_detail.html:132
 msgid "Social media"
 msgstr ""
 
-#: exhibition/models.py:161
-#: exhibition/templates/exhibitors/proposal_detail.html:140
+#: models.py:161 templates/exhibitors/proposal_detail.html:140
 msgid "Extra links"
 msgstr ""
 
-#: exhibition/models.py:216
+#: models.py:212
+msgid "Vouchers per exhibitor"
+msgstr ""
+
+#: models.py:226
+msgid ""
+"The voucher tag created under Tickets → Vouchers that exhibitors draw their "
+"codes from."
+msgstr ""
+
+#: models.py:233
+msgid "Leave empty to draw sponsor codes from the exhibitor pool as well."
+msgstr ""
+
+#: models.py:239
+msgid "Attach voucher list as CSV"
+msgstr ""
+
+#: models.py:240
+msgid ""
+"Adds a spreadsheet of the recipient's own voucher codes to the voucher email."
+msgstr ""
+
+#: models.py:247
 msgid "Call headline"
 msgstr ""
 
-#: exhibition/models.py:220
+#: models.py:251
 msgid "Call text"
 msgstr ""
 
-#: exhibition/models.py:225
+#: models.py:256
 msgid "Submission deadline"
 msgstr ""
 
-#: exhibition/models.py:298
+#: models.py:329
 msgid "Show this sponsor group on the front page."
 msgstr ""
 
-#: exhibition/models.py:314 exhibition/models.py:558
-#: exhibition/templates/exhibitors/dashboard.html:73
-#: exhibition/templates/exhibitors/exhibitor_info.html:69
-#: exhibition/templates/exhibitors/proposal_list.html:19
-#: exhibition/templates/exhibitors/public_proposal_list.html:11
-#: exhibition/views.py:505
+#: models.py:345 models.py:606 templates/exhibitors/dashboard.html:73
+#: templates/exhibitors/exhibitor_info.html:79
+#: templates/exhibitors/proposal_list.html:19
+#: templates/exhibitors/public_proposal_list.html:11 views.py:544
 msgid "Name"
 msgstr ""
 
-#: exhibition/models.py:315 exhibition/models.py:559
-#: exhibition/templates/exhibitors/proposal_detail.html:117
+#: models.py:346 models.py:607 templates/exhibitors/proposal_detail.html:117
 msgid "Description"
 msgstr ""
 
-#: exhibition/models.py:316 exhibition/models.py:419 exhibition/models.py:435
-#: exhibition/models.py:565 exhibition/models.py:815 exhibition/models.py:831
-#: exhibition/models.py:844
-#: exhibition/templates/exhibitors/proposal_detail.html:103
+#: models.py:347 models.py:467 models.py:483 models.py:613 models.py:863
+#: models.py:879 models.py:892 templates/exhibitors/proposal_detail.html:103
 msgid "URL"
 msgstr ""
 
-#: exhibition/models.py:317 exhibition/models.py:566
-#: exhibition/templates/exhibitors/proposal_detail.html:77
-#: exhibition/views.py:505
+#: models.py:348 models.py:614 templates/exhibitors/proposal_detail.html:77
+#: views.py:544
 msgid "Email"
 msgstr ""
 
-#: exhibition/models.py:318 exhibition/models.py:567
-#: exhibition/templates/exhibitors/proposal_detail.html:105
+#: models.py:349 models.py:615 templates/exhibitors/proposal_detail.html:105
 msgid "Contact URL"
 msgstr ""
 
-#: exhibition/models.py:319 exhibition/models.py:568
-#: exhibition/templates/exhibitors/proposal_detail.html:107
+#: models.py:350 models.py:616 templates/exhibitors/proposal_detail.html:107
 msgid "Video URL"
 msgstr ""
 
-#: exhibition/models.py:322 exhibition/models.py:571
-#: exhibition/templates/exhibitors/proposal_detail.html:109
+#: models.py:353 models.py:619 templates/exhibitors/proposal_detail.html:109
 msgid "Slides"
 msgstr ""
 
-#: exhibition/models.py:326 exhibition/models.py:575
+#: models.py:357 models.py:623
 msgid "Slides URL"
 msgstr ""
 
-#: exhibition/models.py:328 exhibition/models.py:577
+#: models.py:359 models.py:625
 msgid "Logo URL"
 msgstr ""
 
-#: exhibition/models.py:330 exhibition/models.py:579
+#: models.py:361 models.py:627
 msgid "Header image URL"
 msgstr ""
 
-#: exhibition/models.py:434 exhibition/models.py:830
+#: models.py:482 models.py:878
 msgid "Label"
 msgstr ""
 
-#: exhibition/models.py:445
+#: models.py:493
 msgid "draft"
 msgstr ""
 
-#: exhibition/models.py:446
+#: models.py:494
 msgid "submitted"
 msgstr ""
 
-#: exhibition/models.py:447
+#: models.py:495
 msgid "accepted"
 msgstr ""
 
-#: exhibition/models.py:448
+#: models.py:496
 msgid "rejected"
 msgstr ""
 
-#: exhibition/models.py:449
+#: models.py:497
 msgid "withdrawn"
 msgstr ""
 
-#: exhibition/models.py:514
+#: models.py:562
 msgid "Organization Description"
 msgstr ""
 
-#: exhibition/models.py:516
+#: models.py:564
 msgid "Organization Website"
 msgstr ""
 
-#: exhibition/models.py:517
+#: models.py:565
 msgid "Contact Page URL"
 msgstr ""
 
-#: exhibition/models.py:518
+#: models.py:566
 msgid "Promotional Video URL"
 msgstr ""
 
-#: exhibition/models.py:519
+#: models.py:567
 msgid "Promotional Slides"
 msgstr ""
 
-#: exhibition/models.py:521
+#: models.py:569
 msgid "Header Image"
 msgstr ""
 
-#: exhibition/models.py:524 exhibition/templates/exhibitors/add.html:29
-#: exhibition/templates/exhibitors/public_proposal_form.html:38
+#: models.py:572 templates/exhibitors/add.html:29
+#: templates/exhibitors/public_proposal_form.html:38
 msgid "Social Media"
 msgstr ""
 
-#: exhibition/models.py:525 exhibition/templates/exhibitors/add.html:92
-#: exhibition/templates/exhibitors/public_proposal_form.html:91
+#: models.py:573 templates/exhibitors/add.html:92
+#: templates/exhibitors/public_proposal_form.html:91
 msgid "Extra Links"
 msgstr ""
 
-#: exhibition/models.py:841
+#: models.py:889
 msgid "Number"
 msgstr ""
 
-#: exhibition/models.py:842
+#: models.py:890
 msgid "Text (one line)"
 msgstr ""
 
-#: exhibition/models.py:843
+#: models.py:891
 msgid "Multiline text"
 msgstr ""
 
-#: exhibition/models.py:845
+#: models.py:893
 msgid "Email address"
 msgstr ""
 
-#: exhibition/models.py:846
+#: models.py:894
 msgid "Confirm Checkbox"
 msgstr ""
 
-#: exhibition/models.py:847
+#: models.py:895
 msgid "Radio button (Choose one option)"
 msgstr ""
 
-#: exhibition/models.py:848
+#: models.py:896
 msgid "Dropdown (Choose one option)"
 msgstr ""
 
-#: exhibition/models.py:849
+#: models.py:897
 msgid "Checkbox (Choose one or several options)"
 msgstr ""
 
-#: exhibition/models.py:850
+#: models.py:898
 msgid "File upload"
 msgstr ""
 
-#: exhibition/models.py:851
+#: models.py:899
 msgid "Date"
 msgstr ""
 
-#: exhibition/models.py:852
+#: models.py:900
 msgid "Time"
 msgstr ""
 
-#: exhibition/models.py:853
+#: models.py:901
 msgid "Date and time"
 msgstr ""
 
-#: exhibition/models.py:854
+#: models.py:902
 msgid "Country code (ISO 3166-1 alpha-2)"
 msgstr ""
 
-#: exhibition/models.py:855
+#: models.py:903
 msgid "Phone number"
 msgstr ""
 
-#: exhibition/models.py:883
+#: models.py:931
 msgid "help text"
 msgstr ""
 
-#: exhibition/models.py:885 exhibition/templates/exhibitors/add.html:29
-#: exhibition/templates/exhibitors/add.html:92
-#: exhibition/templates/exhibitors/public_proposal_form.html:38
-#: exhibition/templates/exhibitors/public_proposal_form.html:91
+#: models.py:933 templates/exhibitors/add.html:29
+#: templates/exhibitors/add.html:92
+#: templates/exhibitors/public_proposal_form.html:38
+#: templates/exhibitors/public_proposal_form.html:91
 msgid "required"
 msgstr ""
 
-#: exhibition/models.py:886
+#: models.py:934
 msgid "active"
 msgstr ""
 
-#: exhibition/models.py:906
+#: models.py:954
 msgid "Response"
 msgstr ""
 
-#: exhibition/models.py:938
+#: models.py:986
 msgid "Yes"
 msgstr ""
 
-#: exhibition/models.py:940
+#: models.py:988
 msgid "No"
 msgstr ""
 
-#: exhibition/models.py:1034
-#: exhibition/templates/exhibitors/_email_outbox_body.html:5
-#: exhibition/templates/exhibitors/_email_sent_body.html:5
+#: models.py:1083 templates/exhibitors/_email_outbox_body.html:5
+#: templates/exhibitors/_email_sent_body.html:5
 msgid "Recipient"
 msgstr ""
 
-#: exhibition/models.py:1045
+#: models.py:1101
 msgid "Queued email"
 msgstr ""
 
-#: exhibition/models.py:1046
+#: models.py:1102
 msgid "Queued emails"
 msgstr ""
 
-#: exhibition/models.py:1088
+#: models.py:1145
 msgid "Template name"
 msgstr ""
 
-#: exhibition/models.py:1095
+#: models.py:1152
 msgid "Custom email template"
 msgstr ""
 
-#: exhibition/models.py:1096
+#: models.py:1153
 msgid "Custom email templates"
 msgstr ""
 
-#: exhibition/signals.py:75
+#: signals.py:81
 msgid "Screen and evaluate exhibitor and sponsor requests for the event."
 msgstr ""
 
-#: exhibition/signals.py:76
+#: signals.py:82
 msgid "Request Review Dashboard"
 msgstr ""
 
-#: exhibition/signals.py:80
+#: signals.py:86
 msgid ""
 "Manage exhibitors and sponsors, maintain booth details, and create partner "
 "profiles for the event."
 msgstr ""
 
-#: exhibition/signals.py:82
+#: signals.py:88
 msgid "Exhibitors & Sponsors Dashboard"
 msgstr ""
 
-#: exhibition/signals.py:88 exhibition/templates/exhibitors/base.html:5
-#: exhibition/templates/exhibitors/base.html:125
-#: exhibition/templates/exhibitors/exhibitor_info.html:4
-#: exhibition/templates/exhibitors/exhibitor_info.html:15
+#: signals.py:94 templates/exhibitors/base.html:6
+#: templates/exhibitors/base.html:136
+#: templates/exhibitors/exhibitor_info.html:4
+#: templates/exhibitors/exhibitor_info.html:15
 msgid "Exhibitors & Sponsors"
 msgstr ""
 
-#: exhibition/signals.py:90
+#: signals.py:96
 msgid "Go to"
 msgstr ""
 
-#: exhibition/signals.py:166 exhibition/templates/exhibitors/call_base.html:4
-#: exhibition/templates/exhibitors/call_base.html:7
-#: exhibition/templates/exhibitors/public_call.html:7
-#: exhibition/templates/exhibitors/settings.html:8
-#: exhibition/templates/exhibitors/settings.html:25
+#: signals.py:172 templates/exhibitors/call_base.html:4
+#: templates/exhibitors/call_base.html:7
+#: templates/exhibitors/public_call.html:7 templates/exhibitors/settings.html:8
+#: templates/exhibitors/settings.html:27
 msgid "Call for Exhibitors"
 msgstr ""
 
-#: exhibition/signals.py:207 exhibition/signals.py:231
+#: signals.py:213 signals.py:237
 msgid "Acme Corp"
 msgstr ""
 
-#: exhibition/signals.py:225
+#: signals.py:231
 msgid "Jane Doe"
 msgstr ""
 
-#: exhibition/signals.py:293 exhibition/templates/exhibitors/base.html:62
-#: exhibition/templates/exhibitors/proposal_list.html:5
-#: exhibition/templates/exhibitors/proposal_list.html:15
+#: signals.py:305 templates/exhibitors/base.html:73
+#: templates/exhibitors/proposal_list.html:5
+#: templates/exhibitors/proposal_list.html:15
 msgid "Exhibition requests"
 msgstr ""
 
-#: exhibition/signals.py:298
+#: signals.py:310
 msgid "Exhibition request approved."
 msgstr ""
 
-#: exhibition/signals.py:299
+#: signals.py:311
 msgid "Exhibition request rejected."
 msgstr ""
 
-#: exhibition/signals.py:300
+#: signals.py:312
 msgid "Exhibition request withdrawn."
 msgstr ""
 
-#: exhibition/signals.py:301
+#: signals.py:313
 msgid "Exhibition request reopened for review."
 msgstr ""
 
-#: exhibition/signals.py:302
+#: signals.py:314
 msgid "Exhibition request changed."
 msgstr ""
 
-#: exhibition/signals.py:303
+#: signals.py:315
 msgid "Organization profile created from an approved request."
 msgstr ""
 
-#: exhibition/signals.py:304
+#: signals.py:316
 msgid "Organization profile reactivated after re-approval."
 msgstr ""
 
-#: exhibition/signals.py:305
+#: signals.py:317
 msgid "Organization profile updated from the submitter's changes."
 msgstr ""
 
-#: exhibition/signals.py:306
+#: signals.py:318
 msgid "Organization profile created."
 msgstr ""
 
-#: exhibition/signals.py:307
+#: signals.py:319
 msgid "Organization profile changed."
 msgstr ""
 
-#: exhibition/signals.py:308
+#: signals.py:320
 msgid "Organization profile deleted."
 msgstr ""
 
-#: exhibition/signals.py:309
+#: signals.py:321
 msgid "Exhibition settings changed."
 msgstr ""
 
-#: exhibition/signals.py:310
+#: signals.py:322
 msgid "Call for exhibitors settings changed."
 msgstr ""
 
-#: exhibition/signals.py:311
+#: signals.py:323
 msgid "Private call link regenerated."
 msgstr ""
 
-#: exhibition/signals.py:312
+#: signals.py:324
 msgid "Sponsor group created."
 msgstr ""
 
-#: exhibition/signals.py:313
+#: signals.py:325
 msgid "Sponsor group changed."
 msgstr ""
 
-#: exhibition/signals.py:314 exhibition/views.py:457
+#: signals.py:326 views.py:496
 msgid "Sponsor group deleted."
 msgstr ""
 
-#: exhibition/signals.py:315
+#: signals.py:327
 msgid "Exhibitor form question created."
 msgstr ""
 
-#: exhibition/signals.py:316
+#: signals.py:328
 msgid "Exhibitor form question changed."
 msgstr ""
 
-#: exhibition/signals.py:317
+#: signals.py:329
 msgid "Exhibitor form question deleted."
 msgstr ""
 
-#: exhibition/signals.py:318
+#: signals.py:330
 msgid "Email sent."
 msgstr ""
 
-#: exhibition/signals.py:337
+#: signals.py:349
 #, python-brace-format
 msgid "Updated: {fields}."
 msgstr ""
 
-#: exhibition/signals.py:360
+#: signals.py:372
 #, python-brace-format
 msgid "State changed from {old} to {new}."
 msgstr ""
 
-#: exhibition/signals.py:382
+#: signals.py:394
 #, python-brace-format
 msgid "Exhibition request {val}"
 msgstr ""
 
-#: exhibition/signals.py:391
+#: signals.py:403
 #, python-brace-format
 msgid "Organization profile {val}"
 msgstr ""
 
-#: exhibition/signals.py:400
+#: signals.py:412
 #, python-brace-format
 msgid "Exhibitor form question {val}"
 msgstr ""
 
-#: exhibition/signals.py:409
+#: signals.py:421
 #, python-brace-format
 msgid "Sponsor group {val}"
 msgstr ""
 
-#: exhibition/social_links.py:36
+#: social_links.py:36
 msgid "Facebook"
 msgstr ""
 
-#: exhibition/social_links.py:43
+#: social_links.py:43
 msgid "Flickr"
 msgstr ""
 
-#: exhibition/social_links.py:50
+#: social_links.py:50
 msgid "GitHub"
 msgstr ""
 
-#: exhibition/social_links.py:57
+#: social_links.py:57
 msgid "GitLab"
 msgstr ""
 
-#: exhibition/social_links.py:64
+#: social_links.py:64
 msgid "Gitter"
 msgstr ""
 
-#: exhibition/social_links.py:71
+#: social_links.py:71
 msgid "Google Groups"
 msgstr ""
 
-#: exhibition/social_links.py:78
+#: social_links.py:78
 msgid "Instagram"
 msgstr ""
 
-#: exhibition/social_links.py:85
+#: social_links.py:85
 msgid "LinkedIn"
 msgstr ""
 
-#: exhibition/social_links.py:92
+#: social_links.py:92
 msgid "Mastodon"
 msgstr ""
 
-#: exhibition/social_links.py:99
+#: social_links.py:99
 msgid "Patreon"
 msgstr ""
 
-#: exhibition/social_links.py:106
+#: social_links.py:106
 msgid "Telegram"
 msgstr ""
 
-#: exhibition/social_links.py:113
+#: social_links.py:113
 msgid "Vimeo"
 msgstr ""
 
-#: exhibition/social_links.py:120
+#: social_links.py:120
 msgid "VK"
 msgstr ""
 
-#: exhibition/social_links.py:127
+#: social_links.py:127
 msgid "Weibo"
 msgstr ""
 
-#: exhibition/social_links.py:134
+#: social_links.py:134
 msgid "X"
 msgstr ""
 
-#: exhibition/social_links.py:141
+#: social_links.py:141
 msgid "Xing"
 msgstr ""
 
-#: exhibition/social_links.py:148
+#: social_links.py:148
 msgid "YouTube"
 msgstr ""
 
-#: exhibition/social_links.py:155
+#: social_links.py:155
 msgid "YouTube Privacy"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:7
+#: templates/exhibitors/_email_outbox_body.html:7
 msgid "Created"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:14
+#: templates/exhibitors/_email_outbox_body.html:14
 msgid "Send selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:17
+#: templates/exhibitors/_email_outbox_body.html:17
 msgid "Discard selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:20
+#: templates/exhibitors/_email_outbox_body.html:20
 msgid "Send all"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:23
+#: templates/exhibitors/_email_outbox_body.html:23
 msgid "Discard all"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:35
+#: templates/exhibitors/_email_outbox_body.html:35
 msgid "Scheduled"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:36
-#: exhibition/templates/exhibitors/proposal_list.html:65
+#: templates/exhibitors/_email_outbox_body.html:36
+#: templates/exhibitors/proposal_list.html:65
 msgid "Actions"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:67
-msgid "Send this email"
+#: templates/exhibitors/_email_outbox_body.html:68
+msgid "Send"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:73
-msgid "Edit this email"
+#: templates/exhibitors/_email_outbox_body.html:75
+#: templates/exhibitors/_partner_row.html:54
+#: templates/exhibitors/call_questions.html:73
+#: templates/exhibitors/call_questions.html:76
+#: templates/exhibitors/dashboard.html:120
+#: templates/exhibitors/email_compose.html:55
+#: templates/exhibitors/email_custom_template_form.html:30
+#: templates/exhibitors/email_templates.html:50
+#: templates/exhibitors/email_templates.html:97
+#: templates/exhibitors/public_proposal_list.html:32
+#: templates/exhibitors/settings.html:59
+msgid "Edit"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:79
-msgid "Discard this email"
+#: templates/exhibitors/_email_outbox_body.html:82
+#: templates/exhibitors/email_bulk_discard.html:30
+#: templates/exhibitors/email_delete.html:31
+msgid "Discard"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:91
-#: exhibition/templates/exhibitors/_email_sent_body.html:34
+#: templates/exhibitors/_email_outbox_body.html:95
+#: templates/exhibitors/_email_sent_body.html:35
 msgid "No emails match your search."
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:93
+#: templates/exhibitors/_email_outbox_body.html:97
 msgid "The outbox is empty."
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_sent_body.html:7
-#: exhibition/templates/exhibitors/base.html:105
+#: templates/exhibitors/_email_sent_body.html:7
+#: templates/exhibitors/_partner_row.html:45 templates/exhibitors/base.html:116
 msgid "Sent"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_sent_body.html:36
+#: templates/exhibitors/_email_sent_body.html:37
 msgid "No emails have been sent yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:12
-#: exhibition/templates/exhibitors/public_list.html:29
+#: templates/exhibitors/_filter_form.html:12
+#: templates/exhibitors/public_list.html:29
 msgid "Search"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:18
-#: exhibition/templates/exhibitors/_filter_form.html:20
+#: templates/exhibitors/_filter_form.html:18
+#: templates/exhibitors/_filter_form.html:21
 msgid "Clear filters"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:29
+#: templates/exhibitors/_filter_form.html:30
 msgid "Filters"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:50
+#: templates/exhibitors/_filter_form.html:51
 msgid "Apply filters"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:5
+#: templates/exhibitors/_image_preview_dialog.html:11
+msgid "Close preview"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:5
 #, python-format
 msgid "Select %(name)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:33
+#: templates/exhibitors/_partner_row.html:33
 msgid "Untitled"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:40
+#: templates/exhibitors/_partner_row.html:40
+msgid "Waiting in the outbox"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:41
+msgid "In outbox"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:44
+#, python-format
+msgid "Last sent %(sent)s"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:48
+msgid "Not sent"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:55
 msgid "Copied!"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:40
+#: templates/exhibitors/_partner_row.html:55
 msgid "Copy failed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:40
+#: templates/exhibitors/_partner_row.html:55
 msgid "Key"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:41
-#: exhibition/templates/exhibitors/add.html:231
-#: exhibition/templates/exhibitors/vouchers.html:5
+#: templates/exhibitors/_partner_row.html:56 templates/exhibitors/add.html:235
+#: templates/exhibitors/base.html:42
+#: templates/exhibitors/exhibitor_info.html:95
+#: templates/exhibitors/exhibitor_info.html:125
+#: templates/exhibitors/vouchers.html:5 views.py:2933
 msgid "Vouchers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:42
-#: exhibition/templates/exhibitors/devices.html:5
+#: templates/exhibitors/_partner_row.html:57
+#: templates/exhibitors/devices.html:5
 msgid "Lead-scanning devices"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:45
+#: templates/exhibitors/_partner_row.html:58
+#: templates/exhibitors/call_question_delete.html:19
+#: templates/exhibitors/call_questions.html:74
+#: templates/exhibitors/delete.html:19
+#: templates/exhibitors/email_custom_template_delete.html:19
+#: templates/exhibitors/settings.html:335
+msgid "Delete"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:60
 msgid "Move"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_sort_header.html:7
+#: templates/exhibitors/_sort_header.html:7
 msgid "Sort ascending"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_sort_header.html:10
+#: templates/exhibitors/_sort_header.html:10
 msgid "Sort descending"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:24
+#: templates/exhibitors/add.html:24
 msgid "Profile"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:29
-#: exhibition/templates/exhibitors/add.html:92
-#: exhibition/templates/exhibitors/call_questions.html:62
-#: exhibition/templates/exhibitors/settings.html:50
+#: templates/exhibitors/add.html:29 templates/exhibitors/add.html:92
+#: templates/exhibitors/call_questions.html:62
+#: templates/exhibitors/settings.html:54
 msgid "Optional"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:80
-#: exhibition/templates/exhibitors/public_proposal_form.html:79
+#: templates/exhibitors/add.html:80
+#: templates/exhibitors/public_proposal_form.html:79
 msgid "Add social media link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:137
-#: exhibition/templates/exhibitors/public_proposal_form.html:120
+#: templates/exhibitors/add.html:137
+#: templates/exhibitors/public_proposal_form.html:120
 msgid "Add extra link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:157
-#: exhibition/templates/exhibitors/add.html:160
-#: exhibition/templates/exhibitors/public_proposal_form.html:140
-#: exhibition/templates/exhibitors/public_proposal_form.html:143
+#: templates/exhibitors/add.html:157 templates/exhibitors/add.html:161
+#: templates/exhibitors/public_proposal_form.html:140
+#: templates/exhibitors/public_proposal_form.html:144
 msgid "Logo preview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:162
-#: exhibition/templates/exhibitors/add.html:180
-#: exhibition/templates/exhibitors/public_proposal_form.html:145
-#: exhibition/templates/exhibitors/public_proposal_form.html:163
+#: templates/exhibitors/add.html:164 templates/exhibitors/add.html:184
+#: templates/exhibitors/public_proposal_form.html:147
+#: templates/exhibitors/public_proposal_form.html:167
 msgid "We could not load this image preview."
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:175
-#: exhibition/templates/exhibitors/add.html:178
-#: exhibition/templates/exhibitors/public_proposal_form.html:158
-#: exhibition/templates/exhibitors/public_proposal_form.html:161
+#: templates/exhibitors/add.html:177 templates/exhibitors/add.html:181
+#: templates/exhibitors/public_proposal_form.html:160
+#: templates/exhibitors/public_proposal_form.html:164
 msgid "Header image preview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:196
+#: templates/exhibitors/add.html:200
 msgid "Organizer only"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:237
+#: templates/exhibitors/add.html:241
 msgid "Internal notes"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:244
-#: exhibition/templates/exhibitors/email_edit.html:38
-#: exhibition/templates/exhibitors/public_proposal_form.html:182
-#: exhibition/templates/exhibitors/public_proposal_form.html:186
+#: templates/exhibitors/add.html:248 templates/exhibitors/email_edit.html:38
+#: templates/exhibitors/public_proposal_form.html:186
+#: templates/exhibitors/public_proposal_form.html:190
 msgid "Save changes"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:246
-#: exhibition/templates/exhibitors/call_default_field_form.html:21
-#: exhibition/templates/exhibitors/call_question_form.html:30
-#: exhibition/templates/exhibitors/call_questions.html:96
-#: exhibition/templates/exhibitors/email_custom_template_form.html:51
-#: exhibition/templates/exhibitors/email_templates.html:123
-#: exhibition/templates/exhibitors/proposal_detail.html:188
-#: exhibition/templates/exhibitors/settings.html:85
-#: exhibition/templates/exhibitors/settings.html:170
-#: exhibition/templates/exhibitors/settings.html:269
+#: templates/exhibitors/add.html:250
+#: templates/exhibitors/call_default_field_form.html:21
+#: templates/exhibitors/call_question_form.html:114
+#: templates/exhibitors/call_questions.html:96
+#: templates/exhibitors/email_custom_template_form.html:51
+#: templates/exhibitors/email_templates.html:123
+#: templates/exhibitors/proposal_detail.html:188
+#: templates/exhibitors/settings.html:89 templates/exhibitors/settings.html:217
+#: templates/exhibitors/settings.html:250
+#: templates/exhibitors/settings.html:359
 msgid "Save"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:255
-#: exhibition/templates/exhibitors/call_default_field_form.html:23
-#: exhibition/templates/exhibitors/call_default_field_reset.html:24
-#: exhibition/templates/exhibitors/call_question_delete.html:21
-#: exhibition/templates/exhibitors/call_question_form.html:32
-#: exhibition/templates/exhibitors/delete.html:24
-#: exhibition/templates/exhibitors/email_bulk_discard.html:27
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:21
-#: exhibition/templates/exhibitors/email_custom_template_form.html:53
-#: exhibition/templates/exhibitors/email_delete.html:28
-#: exhibition/templates/exhibitors/proposal_list.html:174
-#: exhibition/templates/exhibitors/public_proposal_form.html:176
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:16
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:21
-#: exhibition/templates/exhibitors/settings.html:194
-#: exhibition/templates/exhibitors/settings.html:270
+#: templates/exhibitors/add.html:259
+#: templates/exhibitors/call_default_field_form.html:23
+#: templates/exhibitors/call_default_field_reset.html:24
+#: templates/exhibitors/call_question_delete.html:21
+#: templates/exhibitors/call_question_form.html:116
+#: templates/exhibitors/delete.html:24
+#: templates/exhibitors/email_bulk_discard.html:27
+#: templates/exhibitors/email_custom_template_delete.html:21
+#: templates/exhibitors/email_custom_template_form.html:53
+#: templates/exhibitors/email_delete.html:28
+#: templates/exhibitors/proposal_list.html:175
+#: templates/exhibitors/public_proposal_form.html:180
+#: templates/exhibitors/public_proposal_reinstate.html:16
+#: templates/exhibitors/public_proposal_withdraw.html:21
+#: templates/exhibitors/settings.html:278
+#: templates/exhibitors/settings.html:360
+#: templates/exhibitors/voucher_bulk_send.html:96
 msgid "Cancel"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:262
-#: exhibition/templates/exhibitors/proposal_detail.html:208
+#: templates/exhibitors/add.html:266
+#: templates/exhibitors/proposal_detail.html:208
 msgid "History"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:11
+#: templates/exhibitors/base.html:17
 msgid "Overview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:18
-#: exhibition/templates/exhibitors/call_questions.html:33
+#: templates/exhibitors/base.html:24
+#: templates/exhibitors/call_questions.html:33
 msgid "Settings"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:26
-#: exhibition/templates/exhibitors/base.html:70
-#: exhibition/templates/exhibitors/dashboard.html:21
-#: exhibition/templates/exhibitors/exhibitor_info.html:4
-#: exhibition/templates/exhibitors/exhibitor_info.html:15
+#: templates/exhibitors/base.html:32 templates/exhibitors/base.html:81
+#: templates/exhibitors/dashboard.html:21
+#: templates/exhibitors/exhibitor_info.html:4
+#: templates/exhibitors/exhibitor_info.html:15
 msgid "Exhibitors"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:31
-#: exhibition/templates/exhibitors/base.html:76
-#: exhibition/templates/exhibitors/dashboard.html:29
-#: exhibition/templates/exhibitors/exhibitor_info.html:4
-#: exhibition/templates/exhibitors/exhibitor_info.html:15
+#: templates/exhibitors/base.html:37 templates/exhibitors/base.html:87
+#: templates/exhibitors/dashboard.html:29
+#: templates/exhibitors/exhibitor_info.html:4
+#: templates/exhibitors/exhibitor_info.html:15
 msgid "Sponsors"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:39
-#: exhibition/templates/exhibitors/dashboard.html:117
+#: templates/exhibitors/base.html:50 templates/exhibitors/dashboard.html:117
 msgid "Call for exhibitors"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:47
+#: templates/exhibitors/base.html:58
 msgid "Content"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:52
-#: exhibition/templates/exhibitors/call_questions.html:5
-#: exhibition/templates/exhibitors/call_questions.html:16
+#: templates/exhibitors/base.html:63 templates/exhibitors/call_questions.html:5
+#: templates/exhibitors/call_questions.html:16
 msgid "Exhibitor form"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:85
+#: templates/exhibitors/base.html:96
 msgid "Message center"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:94
+#: templates/exhibitors/base.html:105
 msgid "Compose"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:99
+#: templates/exhibitors/base.html:110
 msgid "Outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:111
+#: templates/exhibitors/base.html:122
 msgid "Templates"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:130
+#: templates/exhibitors/base.html:141
 msgid "Home"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:134
+#: templates/exhibitors/base.html:145
 msgid "Tickets"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:138
+#: templates/exhibitors/base.html:149
 msgid "Talks"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:143
+#: templates/exhibitors/base.html:154
 msgid "Access videos related to this event"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:144
+#: templates/exhibitors/base.html:155
 msgid "Videos"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_form.html:5
-#: exhibition/templates/exhibitors/call_default_field_form.html:8
-#: exhibition/templates/exhibitors/call_question_form.html:11
-#: exhibition/templates/exhibitors/call_question_form.html:14
+#: templates/exhibitors/call_default_field_form.html:5
+#: templates/exhibitors/call_default_field_form.html:8
+#: templates/exhibitors/call_question_form.html:14
+#: templates/exhibitors/call_question_form.html:17
 msgid "Form field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:4
-#: exhibition/templates/exhibitors/call_default_field_reset.html:7
+#: templates/exhibitors/call_default_field_reset.html:4
+#: templates/exhibitors/call_default_field_reset.html:7
 msgid "Reset form field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:14
+#: templates/exhibitors/call_default_field_reset.html:14
 #, python-format
 msgid ""
 "Are you sure you want to reset \"%(label)s\" back to the default "
 "\"%(default_label)s\"?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:19
+#: templates/exhibitors/call_default_field_reset.html:19
 msgid ""
 "This clears the custom label and help text. Default fields are part of the "
 "form and cannot be deleted; turn the field off with the Active toggle to "
 "hide it."
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:22
-#: exhibition/templates/exhibitors/public_list.html:32
+#: templates/exhibitors/call_default_field_reset.html:22
 msgid "Reset"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_question_delete.html:4
-#: exhibition/templates/exhibitors/call_question_delete.html:7
+#: templates/exhibitors/call_question_delete.html:4
+#: templates/exhibitors/call_question_delete.html:7
 msgid "Delete form field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_question_delete.html:14
+#: templates/exhibitors/call_question_delete.html:14
 #, python-format
 msgid "Are you sure you want to delete the question \"%(question)s\"?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_question_delete.html:19
-#: exhibition/templates/exhibitors/call_questions.html:74
-#: exhibition/templates/exhibitors/delete.html:19
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:19
-msgid "Delete"
+#: templates/exhibitors/call_question_form.html:31
+msgid "Answer options"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:23
+#: templates/exhibitors/call_question_form.html:34
+msgid "Only applicable if you choose a choice field type above."
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:48
+#, python-format
+msgid "Answer option %(id)s"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:56
+#: templates/exhibitors/call_question_form.html:58
+#: templates/exhibitors/call_question_form.html:87
+#: templates/exhibitors/call_question_form.html:89
+msgid "Move option up"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:60
+#: templates/exhibitors/call_question_form.html:62
+#: templates/exhibitors/call_question_form.html:91
+#: templates/exhibitors/call_question_form.html:93
+msgid "Move option down"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:64
+#: templates/exhibitors/call_question_form.html:66
+#: templates/exhibitors/call_question_form.html:95
+#: templates/exhibitors/call_question_form.html:97
+msgid "Delete option"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:81
+msgid "New answer option"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:106
+msgid "Add a new option"
+msgstr ""
+
+#: templates/exhibitors/call_questions.html:23
 msgid "Form fields"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:24
+#: templates/exhibitors/call_questions.html:24
 msgid ""
 "Choose which fields are shown on the exhibitor form and drag any row to "
 "reorder it."
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:29
-#: exhibition/templates/exhibitors/proposal_detail.html:38
+#: templates/exhibitors/call_questions.html:29
+#: templates/exhibitors/proposal_detail.html:38
 msgid "Field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:32
+#: templates/exhibitors/call_questions.html:32
 msgid "Answers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:42
+#: templates/exhibitors/call_questions.html:42
 msgid "Custom"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:48
+#: templates/exhibitors/call_questions.html:48
 #, python-format
 msgid "Toggle active state for %(field)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:61
+#: templates/exhibitors/call_questions.html:61
 #, python-format
 msgid "Required status for %(field)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:73
-#: exhibition/templates/exhibitors/call_questions.html:76
-#: exhibition/templates/exhibitors/dashboard.html:120
-#: exhibition/templates/exhibitors/email_compose.html:55
-#: exhibition/templates/exhibitors/email_custom_template_form.html:30
-#: exhibition/templates/exhibitors/email_templates.html:50
-#: exhibition/templates/exhibitors/email_templates.html:97
-#: exhibition/templates/exhibitors/public_proposal_list.html:32
-#: exhibition/templates/exhibitors/settings.html:55
-msgid "Edit"
-msgstr ""
-
-#: exhibition/templates/exhibitors/call_questions.html:77
+#: templates/exhibitors/call_questions.html:77
 msgid "Reset to default"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:79
+#: templates/exhibitors/call_questions.html:79
 msgid "Move field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:90
+#: templates/exhibitors/call_questions.html:90
 msgid "New custom field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:5
-#: exhibition/templates/exhibitors/dashboard.html:9
+#: templates/exhibitors/dashboard.html:5 templates/exhibitors/dashboard.html:9
 msgid "Exhibition overview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:39
+#: templates/exhibitors/dashboard.html:39
 msgid "Requests awaiting review"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:48
+#: templates/exhibitors/dashboard.html:48
 msgid "Emails in outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:61
+#: templates/exhibitors/dashboard.html:61
 msgid "Recent requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:64
+#: templates/exhibitors/dashboard.html:64
 msgid "View all"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:76
+#: templates/exhibitors/dashboard.html:76
 msgid "Submitted"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:91
-#: exhibition/templates/exhibitors/proposal_detail.html:97
-#: exhibition/templates/exhibitors/proposal_list.html:97
+#: templates/exhibitors/dashboard.html:91
+#: templates/exhibitors/proposal_detail.html:97
+#: templates/exhibitors/proposal_list.html:97
 msgid "Sponsor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:93
-#: exhibition/templates/exhibitors/proposal_detail.html:99
-#: exhibition/templates/exhibitors/proposal_list.html:99
+#: templates/exhibitors/dashboard.html:93
+#: templates/exhibitors/proposal_detail.html:99
+#: templates/exhibitors/proposal_list.html:99
 msgid "Exhibitor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:105
+#: templates/exhibitors/dashboard.html:105
 msgid "No requests have been submitted yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:128
+#: templates/exhibitors/dashboard.html:128
 msgid "The call is not published, so nobody can submit a request."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:131
+#: templates/exhibitors/dashboard.html:131
 msgid "Open"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:134
+#: templates/exhibitors/dashboard.html:134
 #, python-format
 msgid "Closes on %(deadline)s."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:139
+#: templates/exhibitors/dashboard.html:139
 msgid "No deadline set."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:142
+#: templates/exhibitors/dashboard.html:142
 msgid "Closed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:144
+#: templates/exhibitors/dashboard.html:144
 #, python-format
 msgid "The deadline passed on %(deadline)s."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:151
+#: templates/exhibitors/dashboard.html:151
 msgid "Private — reachable only with the secret link."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:157
-#: exhibition/templates/exhibitors/settings.html:90
-#: exhibition/templates/exhibitors/settings.html:94
+#: templates/exhibitors/dashboard.html:157
+#: templates/exhibitors/settings.html:94 templates/exhibitors/settings.html:98
 msgid "View call page"
 msgstr ""
 
-#: exhibition/templates/exhibitors/delete.html:11
+#: templates/exhibitors/delete.html:11
 #, python-format
 msgid ""
 "Are you sure you want to delete “%(name)s”? This action cannot be undone."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:8
+#: templates/exhibitors/devices.html:8
 #, python-format
 msgid "Lead-scanning devices for %(name)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:13
+#: templates/exhibitors/devices.html:13
 #, python-brace-format
 msgid ""
 "Provision check-in app devices for this partner. Each device gets its own "
@@ -1672,66 +1705,64 @@ msgid ""
 "through the {device_tokens} placeholder."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:21
+#: templates/exhibitors/devices.html:21
 msgid ""
 "Provisioning devices requires organizer-level permissions. Ask an organizer "
 "admin to create the devices for this partner."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:29
+#: templates/exhibitors/devices.html:29
 msgid "Provisioned devices"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:35
+#: templates/exhibitors/devices.html:35
 msgid "Device"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:36
+#: templates/exhibitors/devices.html:36
 msgid "Setup token"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:37
+#: templates/exhibitors/devices.html:37
 msgid "Status"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:47
+#: templates/exhibitors/devices.html:47
 msgid "Connected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:49
+#: templates/exhibitors/devices.html:49
 msgid "Awaiting setup"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:60
+#: templates/exhibitors/devices.html:60
 msgid ""
 "Generate new setup tokens? Any device that is already scanning will be "
 "disconnected and must be set up again."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:65
+#: templates/exhibitors/devices.html:65
 msgid "Generate new setup tokens"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:70
+#: templates/exhibitors/devices.html:70
 msgid "No devices have been provisioned for this partner yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:80
-#: exhibition/templates/exhibitors/devices.html:85
+#: templates/exhibitors/devices.html:80 templates/exhibitors/devices.html:85
 msgid "Add devices"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:87
-#: exhibition/templates/exhibitors/vouchers.html:88
+#: templates/exhibitors/devices.html:87 templates/exhibitors/vouchers.html:133
 msgid "Back"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_bulk_discard.html:4
-#: exhibition/templates/exhibitors/email_bulk_discard.html:7
+#: templates/exhibitors/email_bulk_discard.html:4
+#: templates/exhibitors/email_bulk_discard.html:7
 msgid "Discard emails"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_bulk_discard.html:19
+#: templates/exhibitors/email_bulk_discard.html:19
 #, python-format
 msgid ""
 "Are you sure you want to discard %(counter)s queued email? This cannot be "
@@ -1742,80 +1773,80 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/templates/exhibitors/email_bulk_discard.html:30
-#: exhibition/templates/exhibitors/email_delete.html:31
-msgid "Discard"
-msgstr ""
-
-#: exhibition/templates/exhibitors/email_compose.html:7
-#: exhibition/templates/exhibitors/email_compose.html:16
+#: templates/exhibitors/email_compose.html:7
+#: templates/exhibitors/email_compose.html:16
 msgid "Compose email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:21
+#: templates/exhibitors/email_compose.html:21
 msgid ""
 "Send an update to a group of applicants. One email is queued per recipient, "
 "with placeholders resolved individually."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:26
+#: templates/exhibitors/email_compose.html:26
 msgid "Load from template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:28
+#: templates/exhibitors/email_compose.html:28
 msgid "Select a saved template…"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:33
+#: templates/exhibitors/email_compose.html:33
 msgid "Load"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:41
-#: exhibition/templates/exhibitors/email_edit.html:23
+#: templates/exhibitors/email_compose.html:41
+#: templates/exhibitors/email_edit.html:23
 msgid "Recipients"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:47
+#: templates/exhibitors/email_compose.html:47
 msgid "Message"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:58
-#: exhibition/templates/exhibitors/email_custom_template_form.html:33
-#: exhibition/templates/exhibitors/email_templates.html:53
-#: exhibition/templates/exhibitors/email_templates.html:100
-#: exhibition/templates/exhibitors/settings.html:58
+#: templates/exhibitors/email_compose.html:51
+msgctxt "form"
+msgid "required"
+msgstr ""
+
+#: templates/exhibitors/email_compose.html:58
+#: templates/exhibitors/email_custom_template_form.html:33
+#: templates/exhibitors/email_templates.html:53
+#: templates/exhibitors/email_templates.html:100
+#: templates/exhibitors/settings.html:62
 msgid "Preview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:80
+#: templates/exhibitors/email_compose.html:80
 msgid "Save to outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:83
+#: templates/exhibitors/email_compose.html:83
 msgid "Send / Schedule"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:4
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:7
+#: templates/exhibitors/email_custom_template_delete.html:4
+#: templates/exhibitors/email_custom_template_delete.html:7
 msgid "Delete custom template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:14
+#: templates/exhibitors/email_custom_template_delete.html:14
 #, python-format
 msgid "Are you sure you want to delete the custom template \"%(name)s\"?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_custom_template_form.html:7
-#: exhibition/templates/exhibitors/email_custom_template_form.html:15
+#: templates/exhibitors/email_custom_template_form.html:7
+#: templates/exhibitors/email_custom_template_form.html:15
 msgid "Custom template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_delete.html:4
-#: exhibition/templates/exhibitors/email_delete.html:7
+#: templates/exhibitors/email_delete.html:4
+#: templates/exhibitors/email_delete.html:7
 msgid "Discard email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_delete.html:15
+#: templates/exhibitors/email_delete.html:15
 #, python-format
 msgid ""
 "Are you sure you want to discard the email “%(subject)s” to %(counter)s "
@@ -1826,908 +1857,1170 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/templates/exhibitors/email_delete.html:21
+#: templates/exhibitors/email_delete.html:21
 #, python-format
 msgid ""
 "Are you sure you want to discard the email “%(subject)s” to %(to)s? This "
 "cannot be undone."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:5
+#: templates/exhibitors/email_edit.html:5
 msgid "Edit email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:8
+#: templates/exhibitors/email_edit.html:8
 msgid "Preview / edit email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:14
+#: templates/exhibitors/email_edit.html:14
 msgid "Back to outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:41
+#: templates/exhibitors/email_edit.html:41
 msgid "Save & send"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_outbox.html:12
-#: exhibition/templates/exhibitors/email_outbox.html:15
+#: templates/exhibitors/email_outbox.html:12
+#: templates/exhibitors/email_outbox.html:15
 msgid "Email outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_outbox.html:20
+#: templates/exhibitors/email_outbox.html:20
 msgid ""
 "Emails waiting to be sent. Review, edit, or discard them before sending."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_sent.html:12
-#: exhibition/templates/exhibitors/email_sent.html:15
+#: templates/exhibitors/email_sent.html:12
+#: templates/exhibitors/email_sent.html:15
 msgid "Sent emails"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:7
-#: exhibition/templates/exhibitors/email_templates.html:16
+#: templates/exhibitors/email_templates.html:7
+#: templates/exhibitors/email_templates.html:16
 msgid "Email templates"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:22
+#: templates/exhibitors/email_templates.html:22
 msgid "New template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:27
+#: templates/exhibitors/email_templates.html:27
 msgid ""
 "These templates are used for the confirmation email sent when an applicant "
 "submits a request, and for the accept/reject emails you send from the outbox."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:81
+#: templates/exhibitors/email_templates.html:81
 msgid "Discard this template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:31
+#: templates/exhibitors/exhibitor_info.html:31
 msgid "No organizations match your filters."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:33
+#: templates/exhibitors/exhibitor_info.html:33
 msgid "You don't have any sponsors yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:35
+#: templates/exhibitors/exhibitor_info.html:35
 msgid "You don't have any exhibitors yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:37
+#: templates/exhibitors/exhibitor_info.html:37
 msgid "You don't have any exhibitors or sponsors yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:43
-#: exhibition/templates/exhibitors/exhibitor_info.html:52
-#: exhibition/views.py:1837
+#: templates/exhibitors/exhibitor_info.html:43
+#: templates/exhibitors/exhibitor_info.html:57 views.py:1979
 msgid "Add a Sponsor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:43
-#: exhibition/templates/exhibitors/exhibitor_info.html:52
-#: exhibition/views.py:1838
+#: templates/exhibitors/exhibitor_info.html:43
+#: templates/exhibitors/exhibitor_info.html:57 views.py:1980
 msgid "Add an Exhibitor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:43
-#: exhibition/templates/exhibitors/exhibitor_info.html:52
-#: exhibition/views.py:1839
+#: templates/exhibitors/exhibitor_info.html:43
+#: templates/exhibitors/exhibitor_info.html:57 views.py:1981
 msgid "Add an Exhibitor or Sponsor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:48
-#: exhibition/templates/exhibitors/proposal_list.html:169
+#: templates/exhibitors/exhibitor_info.html:48
+#: templates/exhibitors/proposal_list.html:170
 msgid "selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:54
+#: templates/exhibitors/exhibitor_info.html:59
 msgid "Download access keys as CSV"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:56
+#: templates/exhibitors/exhibitor_info.html:61
 msgid "Download sponsor keys"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:56
+#: templates/exhibitors/exhibitor_info.html:61
 msgid "Download exhibitor keys"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:56
+#: templates/exhibitors/exhibitor_info.html:61
 msgid "Download access keys"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:65
+#: templates/exhibitors/exhibitor_info.html:64
+msgid "Queue a voucher email for everyone in this list"
+msgstr ""
+
+#: templates/exhibitors/exhibitor_info.html:65
+msgid "Send vouchers to all"
+msgstr ""
+
+#: templates/exhibitors/exhibitor_info.html:75
 msgid ""
 "Drag-and-drop ordering is available only on the unfiltered, single-page list."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:70
+#: templates/exhibitors/exhibitor_info.html:80
 msgid "Booth"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:78
-#: exhibition/templates/exhibitors/exhibitor_info.html:106
+#: templates/exhibitors/exhibitor_info.html:88
+#: templates/exhibitors/exhibitor_info.html:117
 msgid "Select all partners"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:84
-#: exhibition/templates/exhibitors/exhibitor_info.html:112
+#: templates/exhibitors/exhibitor_info.html:94
+#: templates/exhibitors/exhibitor_info.html:123
 msgid "Group"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:12
-#: exhibition/templates/exhibitors/proposal_detail.html:15
+#: templates/exhibitors/proposal_detail.html:12
+#: templates/exhibitors/proposal_detail.html:15
 msgid "Review exhibition request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:21
+#: templates/exhibitors/proposal_detail.html:21
 msgid "Back to exhibition requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:29
+#: templates/exhibitors/proposal_detail.html:29
 #, python-format
 msgid "Changes made by the applicant after acceptance (%(when)s)"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:39
+#: templates/exhibitors/proposal_detail.html:39
 msgid "Before acceptance"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:40
+#: templates/exhibitors/proposal_detail.html:40
 msgid "After edit"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:55
+#: templates/exhibitors/proposal_detail.html:55
 msgid "The applicant edited the profile, but the tracked fields are unchanged."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:57
+#: templates/exhibitors/proposal_detail.html:57
 msgid ""
 "This profile was edited before change tracking was available, so the "
 "original values are not recorded."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:69
-#: exhibition/templates/exhibitors/proposal_list.html:20
+#: templates/exhibitors/proposal_detail.html:69
+#: templates/exhibitors/proposal_list.html:20
 msgid "Submitter"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:80
+#: templates/exhibitors/proposal_detail.html:80
 msgid "Hidden"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:121
+#: templates/exhibitors/proposal_detail.html:121
 msgid "Message to organizers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:129
+#: templates/exhibitors/proposal_detail.html:129
 msgid "Links"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:152
+#: templates/exhibitors/proposal_detail.html:152
 msgid "Download"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:154
+#: templates/exhibitors/proposal_detail.html:154
 msgid "Custom answers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:176
+#: templates/exhibitors/proposal_detail.html:176
 msgid "Review"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:192
-#: exhibition/templates/exhibitors/proposal_list.html:117
-#: exhibition/templates/exhibitors/proposal_list.html:164
+#: templates/exhibitors/proposal_detail.html:192
+#: templates/exhibitors/proposal_list.html:118
+#: templates/exhibitors/proposal_list.html:165
 msgid "Approve"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:195
-#: exhibition/templates/exhibitors/proposal_list.html:122
-#: exhibition/templates/exhibitors/proposal_list.html:165
+#: templates/exhibitors/proposal_detail.html:195
+#: templates/exhibitors/proposal_list.html:123
+#: templates/exhibitors/proposal_list.html:166
 msgid "Reject"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:200
+#: templates/exhibitors/proposal_detail.html:200
 msgid "Open profile"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:22
+#: templates/exhibitors/proposal_list.html:22
 msgid "Updated"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:33
+#: templates/exhibitors/proposal_list.html:33
 msgid "Select at least one request."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:34
+#: templates/exhibitors/proposal_list.html:34
 msgid "None of the selected requests can be approved."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:35
+#: templates/exhibitors/proposal_list.html:35
 msgid "None of the selected requests can be rejected."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:36
+#: templates/exhibitors/proposal_list.html:36
 #, python-brace-format
 msgid "{count} selected requests cannot be approved and will be skipped."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:37
+#: templates/exhibitors/proposal_list.html:37
 #, python-brace-format
 msgid "{count} selected requests cannot be rejected and will be skipped."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:41
+#: templates/exhibitors/proposal_list.html:41
 msgid "Approve selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:44
+#: templates/exhibitors/proposal_list.html:44
 msgid "Reject selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:55
+#: templates/exhibitors/proposal_list.html:55
 msgid "Select all matching requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:75
+#: templates/exhibitors/proposal_list.html:75
 msgid "Select request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:106
+#: templates/exhibitors/proposal_list.html:106
 msgid "Edited after acceptance, see detail view for changes."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:127
-#: exhibition/templates/exhibitors/proposal_list.html:166
-#: exhibition/templates/exhibitors/public_proposal_list.html:39
+#: templates/exhibitors/proposal_list.html:128
+#: templates/exhibitors/proposal_list.html:167
+#: templates/exhibitors/public_proposal_list.html:39
 msgid "Withdraw"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:132
-#: exhibition/templates/exhibitors/proposal_list.html:167
+#: templates/exhibitors/proposal_list.html:133
+#: templates/exhibitors/proposal_list.html:168
 msgid "Reopen for review"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:137
-#: exhibition/templates/exhibitors/public_proposal_list.html:34
+#: templates/exhibitors/proposal_list.html:138
+#: templates/exhibitors/public_proposal_list.html:34
 msgid "View"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:149
+#: templates/exhibitors/proposal_list.html:150
 msgid "No exhibition requests match your filters."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:151
+#: templates/exhibitors/proposal_list.html:152
 msgid "No exhibition requests have been submitted yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:159
+#: templates/exhibitors/proposal_list.html:160
 msgid "Approve the selected requests and create their partner profiles?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:160
+#: templates/exhibitors/proposal_list.html:161
 msgid "Reject the selected requests?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:161
+#: templates/exhibitors/proposal_list.html:162
 msgid "Reject this request?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:162
+#: templates/exhibitors/proposal_list.html:163
 msgid "Withdraw this request?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:163
+#: templates/exhibitors/proposal_list.html:164
 msgid "Reopen this request for review?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:168
+#: templates/exhibitors/proposal_list.html:169
 msgid "The action could not be completed. Please try again."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:170
+#: templates/exhibitors/proposal_list.html:171
 msgid ""
 "Approve every request matching the current filters, including those on other "
 "pages?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:171
+#: templates/exhibitors/proposal_list.html:172
 msgid ""
 "Reject every request matching the current filters, including those on other "
 "pages?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:172
+#: templates/exhibitors/proposal_list.html:173
 msgid "Please confirm"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:173
+#: templates/exhibitors/proposal_list.html:174
 msgid "Confirm"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:14
+#: templates/exhibitors/public_call.html:14
 msgid "Submit a request to become an exhibitor for this event."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:20
+#: templates/exhibitors/public_call.html:20
 #, python-format
 msgid "You can submit requests until %(deadline)s (%(timezone)s)."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:24
+#: templates/exhibitors/public_call.html:24
 #, python-format
 msgid "This call closed on %(deadline)s (%(timezone)s)."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:34
+#: templates/exhibitors/public_call.html:34
 msgid "View your requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:40
-#: exhibition/templates/exhibitors/public_proposal_form.html:18
-#: exhibition/templates/exhibitors/public_proposal_list.html:65
+#: templates/exhibitors/public_call.html:40
+#: templates/exhibitors/public_proposal_form.html:18
+#: templates/exhibitors/public_proposal_list.html:65
 msgid "Submit a request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:42
+#: templates/exhibitors/public_call.html:42
 msgid "Requests are closed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:21
-#: exhibition/templates/exhibitors/public_detail.html:94
+#: templates/exhibitors/public_detail.html:21
+#: templates/exhibitors/public_detail.html:93
 msgid "Previous"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:24
-#: exhibition/templates/exhibitors/public_detail.html:98
+#: templates/exhibitors/public_detail.html:24
+#: templates/exhibitors/public_detail.html:97
 msgid "Next"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:47
+#: templates/exhibitors/public_detail.html:47
 msgid "Get In Touch"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:87
-#: exhibition/templates/exhibitors/public_detail.html:103
+#: templates/exhibitors/public_detail.html:87
+#: templates/exhibitors/public_detail.html:102
 msgid "Open slides PDF"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:88
-#, python-brace-format
-msgid "Slide {current} of {total}"
-msgstr ""
-
-#: exhibition/templates/exhibitors/public_detail.html:112
+#: templates/exhibitors/public_detail.html:111
 msgid "Send email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:126
+#: templates/exhibitors/public_detail.html:125
 msgid "Visit website"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_list.html:54
+#: templates/exhibitors/public_list.html:32
+msgid "Clear"
+msgstr ""
+
+#: templates/exhibitors/public_list.html:54
 msgid "No exhibitors match your search."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_list.html:56
+#: templates/exhibitors/public_list.html:56
 msgid "No exhibitors are currently available."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:16
+#: templates/exhibitors/public_proposal_form.html:16
 msgid "Edit request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:23
-#: exhibition/views.py:883
+#: templates/exhibitors/public_proposal_form.html:23 views.py:958
 msgid "This request can no longer be edited."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:186
+#: templates/exhibitors/public_proposal_form.html:190
 msgid "Submit request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:189
+#: templates/exhibitors/public_proposal_form.html:193
 msgid "or save as draft for now"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:199
+#: templates/exhibitors/public_proposal_form.html:203
 msgid "Back to your requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:5
+#: templates/exhibitors/public_proposal_list.html:5
 msgid "Your exhibition requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:13
+#: templates/exhibitors/public_proposal_list.html:13
 msgid "Last modified"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:23
+#: templates/exhibitors/public_proposal_list.html:23
 msgid "Withdrawn"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:44
+#: templates/exhibitors/public_proposal_list.html:44
 msgid "Reinstate"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:56
+#: templates/exhibitors/public_proposal_list.html:56
 msgid "Create a new request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:61
+#: templates/exhibitors/public_proposal_list.html:61
 msgid "You have not submitted an exhibition request yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:5
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:21
+#: templates/exhibitors/public_proposal_reinstate.html:5
+#: templates/exhibitors/public_proposal_reinstate.html:21
 msgid "Reinstate request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:7
+#: templates/exhibitors/public_proposal_reinstate.html:7
 #, python-format
 msgid ""
 "Do you want to reinstate your withdrawn request “%(name)s”? It will be "
 "pending review again."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:5
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:26
+#: templates/exhibitors/public_proposal_withdraw.html:5
+#: templates/exhibitors/public_proposal_withdraw.html:26
 msgid "Withdraw request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:7
+#: templates/exhibitors/public_proposal_withdraw.html:7
 #, python-format
 msgid "Are you sure you want to withdraw your request “%(name)s”?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:13
+#: templates/exhibitors/public_proposal_withdraw.html:13
 msgid ""
 "This request has already been approved. Withdrawing it will hide the "
 "exhibitor or sponsor profile created from it from public listings."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:10
-#: exhibition/templates/exhibitors/settings.html:27
+#: templates/exhibitors/settings.html:10 templates/exhibitors/settings.html:29
 msgid "Sponsor Settings"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:12
-#: exhibition/templates/exhibitors/settings.html:29
+#: templates/exhibitors/settings.html:12 templates/exhibitors/settings.html:31
+msgid "Voucher Settings"
+msgstr ""
+
+#: templates/exhibitors/settings.html:14 templates/exhibitors/settings.html:33
 msgid "Exhibitor Settings"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:42
+#: templates/exhibitors/settings.html:46
 msgid "Publish your call"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:43
+#: templates/exhibitors/settings.html:47
 msgid "Publish a login-required application form for exhibitors."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:72
+#: templates/exhibitors/settings.html:76
 msgid ""
 "This panel renders unsaved draft text using the same styling as the live "
 "public call page."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:104
+#: templates/exhibitors/settings.html:108
 msgid "Secret call link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:107
+#: templates/exhibitors/settings.html:111
 msgid ""
 "This call is private: it is not linked anywhere public. Share the link below "
 "with the organizations you want to invite. Anyone who has it can open the "
 "call and apply."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:113
+#: templates/exhibitors/settings.html:117
 msgid "Copied"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:113
+#: templates/exhibitors/settings.html:117
 msgid "Copy to clipboard"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:114
+#: templates/exhibitors/settings.html:118
 msgid "Copy"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:119
+#: templates/exhibitors/settings.html:123
 msgid ""
 "Regenerate the secret link? The current link will stop working immediately."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:125
+#: templates/exhibitors/settings.html:129
 msgid "Regenerate link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:127
+#: templates/exhibitors/settings.html:131
 msgid "Regenerating immediately invalidates the current link."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:138
+#: templates/exhibitors/settings.html:143
+msgid "Voucher pools"
+msgstr ""
+
+#: templates/exhibitors/settings.html:147
+msgid ""
+"Create the voucher codes under Tickets → Vouchers and give them a tag, then "
+"pick that tag here. Exhibitors and sponsors are handed codes from the pool "
+"you choose. Reload this page to pick up a tag you just created."
+msgstr ""
+
+#: templates/exhibitors/settings.html:157
+msgid "Create vouchers pool"
+msgstr ""
+
+#: templates/exhibitors/settings.html:159
+msgid "(opens in a new tab)"
+msgstr ""
+
+#: templates/exhibitors/settings.html:168
+#: templates/exhibitors/settings.html:182
+#, python-format
+msgid "%(counter)s voucher in this pool is not assigned to anyone yet."
+msgid_plural ""
+"%(counter)s vouchers in this pool are not assigned to anyone yet."
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/exhibitors/settings.html:194
+msgid "How many each one gets"
+msgstr ""
+
+#: templates/exhibitors/settings.html:196
+msgid ""
+"Applies to any exhibitor or sponsor that does not belong to a sponsor group. "
+"Sponsor groups set their own number on the Sponsors page, and an individual "
+"exhibitor or sponsor can be given a different number on their own voucher "
+"page."
+msgstr ""
+
+#: templates/exhibitors/settings.html:206
+msgid "Voucher email"
+msgstr ""
+
+#: templates/exhibitors/settings.html:208
+msgid "Applies to the voucher email sent to exhibitors and sponsors alike."
+msgstr ""
+
+#: templates/exhibitors/settings.html:228
 msgid "Data access"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:139
+#: templates/exhibitors/settings.html:229
 msgid ""
 "In this section, you can control which attendee data is shared with "
 "exhibitors when an exhibitor voucher is used or when the exhibitor uses the "
 "lead scanning app."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:142
+#: templates/exhibitors/settings.html:232
 msgid "Exhibitor vouchers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:158
-msgid "Exhibitor login"
-msgstr ""
-
-#: exhibition/templates/exhibitors/settings.html:160
-msgid ""
-"The access-code email sent to exhibitors is now edited together with the "
-"plugin's other email templates."
-msgstr ""
-
-#: exhibition/templates/exhibitors/settings.html:162
-msgid "Edit email templates"
-msgstr ""
-
-#: exhibition/templates/exhibitors/settings.html:177
+#: templates/exhibitors/settings.html:257
 msgid "Group List"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:180
+#: templates/exhibitors/settings.html:260
 msgid "Add a Group"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:193
+#: templates/exhibitors/settings.html:272
+#: templates/exhibitors/settings.html:354
+msgid "Voucher defaults for this group"
+msgstr ""
+
+#: templates/exhibitors/settings.html:277
 msgid "Add"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:204
+#: templates/exhibitors/settings.html:288
 msgid "Group Name"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:206
+#: templates/exhibitors/settings.html:290
 msgid "Partners"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:207
+#: templates/exhibitors/settings.html:291
 msgid "Front Page"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:220
-#: exhibition/templates/exhibitors/settings.html:226
+#: templates/exhibitors/settings.html:304
+#: templates/exhibitors/settings.html:310
 msgid "Show this sponsor group in the Supported By section on the front page."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:251
+#: templates/exhibitors/settings.html:326
+msgid "Edit sponsor group"
+msgstr ""
+
+#: templates/exhibitors/settings.html:337
 msgid "Reorder sponsor group"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:281
+#: templates/exhibitors/settings.html:371
 msgid "You do not have any sponsor groups yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:8
+#: templates/exhibitors/voucher_bulk_send.html:4
+#: templates/exhibitors/voucher_bulk_send.html:7
+msgid "Send vouchers"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:18
+#, python-format
+msgid "A voucher email will be placed in the outbox for %(counter)s sponsor."
+msgid_plural ""
+"A voucher email will be placed in the outbox for %(counter)s sponsors."
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:24
+#, python-format
+msgid "A voucher email will be placed in the outbox for %(counter)s exhibitor."
+msgid_plural ""
+"A voucher email will be placed in the outbox for %(counter)s exhibitors."
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:37
+#, python-format
+msgid "&mdash; %(counter)s voucher will be created"
+msgid_plural "&mdash; %(counter)s vouchers will be created"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:45
+#, python-format
+msgid "&mdash; %(counter)s existing voucher"
+msgid_plural "&mdash; %(counter)s existing vouchers"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:58
+msgid "None of the sponsors in this list can be emailed yet."
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:60
+msgid "None of the exhibitors in this list can be emailed yet."
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:66
+msgid "Skipped: no email address"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:75
+msgid "Skipped: voucher count is set to 0"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:84
+msgid "Skipped: no vouchers available from their pool"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:86
+msgid ""
+"Check that a voucher pool is selected under Settings → Vouchers and that it "
+"still has unassigned codes."
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:99
+msgid "Queue emails"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:8
 #, python-format
 msgid "Vouchers for %(name)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:13
+#: templates/exhibitors/vouchers.html:13
 msgid ""
-"Issue ticket vouchers for this partner to hand out. Whoever redeems one on "
-"the ticket shop becomes a lead this partner can retrieve, as long as voucher "
+"Hand this exhibitor or sponsor codes from the voucher pool. Whoever redeems "
+"one on the ticket shop becomes a lead they can retrieve, as long as voucher "
 "data access is enabled for them."
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:20
-msgid "Issued vouchers"
+#: templates/exhibitors/vouchers.html:20
+msgid "Assigned vouchers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:24
+#: templates/exhibitors/vouchers.html:24
 msgid "Download codes (CSV)"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:31
+#: templates/exhibitors/vouchers.html:31
 msgid "Code"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:32 exhibition/views.py:1994
+#: templates/exhibitors/vouchers.html:32 utils.py:495
 msgid "Product"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:34 exhibition/views.py:1998
+#: templates/exhibitors/vouchers.html:33 utils.py:496
+msgid "Price effect"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:34 utils.py:499
 msgid "Redeemed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:56
+#: templates/exhibitors/vouchers.html:35 utils.py:498
+msgid "Valid until"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:56
 msgid "Already redeemed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:67
-msgid "No vouchers have been issued for this partner yet."
+#: templates/exhibitors/vouchers.html:62
+msgid "Return to pool"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:76
-msgid "Issue new vouchers"
+#: templates/exhibitors/vouchers.html:74
+msgid "No vouchers have been assigned to this partner yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:86
-msgid "Create vouchers"
+#: templates/exhibitors/vouchers.html:82
+msgid "Take more from the pool"
 msgstr ""
 
-#: exhibition/templates/sponsors/presale_supported_by.html:4
+#: templates/exhibitors/vouchers.html:84
+msgid ""
+"Codes come from the voucher pool chosen under Settings. The email always "
+"carries this partner's complete list of codes, so you can assign some now "
+"and send them together with more later. It is placed in the outbox for you "
+"to review before it goes out."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:92
+#, python-format
+msgid "%(counter)s voucher is left unassigned in the pool."
+msgid_plural "%(counter)s vouchers are left unassigned in the pool."
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/exhibitors/vouchers.html:100 views.py:2230
+msgid "No voucher pool is selected yet. Choose one under Settings → Vouchers."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:106
+msgid "A voucher email for this partner is waiting in the outbox."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:108
+msgid "Go to outbox"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:114
+#, python-format
+msgid "Vouchers were last emailed to this partner on %(sent)s."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:120
+msgid ""
+"This partner has no email address on file, so vouchers cannot be emailed."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:127
+msgid "Assign and prepare email"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:130
+msgid "Assign without emailing"
+msgstr ""
+
+#: templates/sponsors/presale_supported_by.html:4
 msgid "Supported By"
 msgstr ""
 
-#: exhibition/views.py:324
+#: utils.py:493
+msgid "Voucher code"
+msgstr ""
+
+#: utils.py:494
+msgid "Redeem link"
+msgstr ""
+
+#: utils.py:497
+msgid "Value"
+msgstr ""
+
+#: utils.py:500
+msgid "Maximum usages"
+msgstr ""
+
+#: views.py:342
 msgid "Company name"
 msgstr ""
 
-#: exhibition/views.py:325
+#: views.py:343
 msgid "Job title"
 msgstr ""
 
-#: exhibition/views.py:326
+#: views.py:344
 msgid "Address"
 msgstr ""
 
-#: exhibition/views.py:333
+#: views.py:351
 msgid "Attendee Name"
 msgstr ""
 
-#: exhibition/views.py:338
+#: views.py:356
 msgid "Attendee Email"
 msgstr ""
 
-#: exhibition/views.py:377
+#: views.py:395 views.py:412
 msgid "Settings have been saved."
 msgstr ""
 
-#: exhibition/views.py:393
+#: views.py:428
 msgid "Call settings have been saved."
 msgstr ""
 
-#: exhibition/views.py:401
+#: views.py:436
 msgid ""
 "A new secret call link has been generated. The old link no longer works."
 msgstr ""
 
-#: exhibition/views.py:416
+#: views.py:451
 msgid "Sponsor group added."
 msgstr ""
 
-#: exhibition/views.py:437
+#: views.py:454 views.py:477 views.py:853 views.py:1169 views.py:1796
+#: views.py:1918 views.py:2564 views.py:3025
+msgid "We could not save your changes. See below for details."
+msgstr ""
+
+#: views.py:474
 msgid "Sponsor group updated."
 msgstr ""
 
-#: exhibition/views.py:452
+#: views.py:491
 msgid "This sponsor group cannot be deleted while it is assigned to partners."
 msgstr ""
 
-#: exhibition/views.py:460
+#: views.py:499
 msgid "Unknown action."
 msgstr ""
 
-#: exhibition/views.py:505
+#: views.py:544
 msgid "Access key"
 msgstr ""
 
-#: exhibition/views.py:745 exhibition/views.py:1060
+#: views.py:819 views.py:1135
 msgid "Add at least one social media link."
 msgstr ""
 
-#: exhibition/views.py:754 exhibition/views.py:1069
+#: views.py:828 views.py:1144
 msgid "Add at least one extra link."
 msgstr ""
 
-#: exhibition/views.py:809
+#: views.py:884
 msgid "The call for exhibitors is closed."
 msgstr ""
 
-#: exhibition/views.py:837
+#: views.py:912
 msgid "Your request has been saved."
 msgstr ""
 
-#: exhibition/views.py:920 exhibition/views.py:1776
+#: views.py:995 views.py:1914
 msgid "Your changes have been saved."
 msgstr ""
 
-#: exhibition/views.py:953
+#: views.py:1028
 msgid "This proposal can no longer be withdrawn."
 msgstr ""
 
-#: exhibition/views.py:961
+#: views.py:1036
 msgid "Your request has been withdrawn."
 msgstr ""
 
-#: exhibition/views.py:963
+#: views.py:1038
 msgid "This request can no longer be withdrawn."
 msgstr ""
 
-#: exhibition/views.py:989 exhibition/views.py:999
+#: views.py:1064 views.py:1074
 msgid "This request can no longer be reinstated."
 msgstr ""
 
-#: exhibition/views.py:997
+#: views.py:1072
 msgid "Your request has been reinstated and is pending review again."
 msgstr ""
 
-#: exhibition/views.py:1121
+#: views.py:1197
 msgid "Invalid request body."
 msgstr ""
 
-#: exhibition/views.py:1124 exhibition/views.py:1129
+#: views.py:1200 views.py:1205
 msgid "Invalid sponsor group IDs."
 msgstr ""
 
-#: exhibition/views.py:1133
+#: views.py:1209
 msgid "Sponsor group IDs must be unique."
 msgstr ""
 
-#: exhibition/views.py:1141
+#: views.py:1217
 msgid "Reorder request must include each sponsor group exactly once."
 msgstr ""
 
-#: exhibition/views.py:1346
+#: views.py:1422
 msgid "This request can no longer be changed to that state."
 msgstr ""
 
-#: exhibition/views.py:1350
+#: views.py:1426
 msgid "Review details saved."
 msgstr ""
 
-#: exhibition/views.py:1359
+#: views.py:1435
 msgid ""
 "Request approved and partner profile created. An acceptance email was placed "
 "in the outbox."
 msgstr ""
 
-#: exhibition/views.py:1369
+#: views.py:1445
 msgid "Request rejected. A rejection email was placed in the outbox."
 msgstr ""
 
-#: exhibition/views.py:1372
+#: views.py:1448
 msgid "Request withdrawn."
 msgstr ""
 
-#: exhibition/views.py:1375
+#: views.py:1451
 msgid "Request reopened for review."
 msgstr ""
 
-#: exhibition/views.py:1407
+#: views.py:1483
 msgid "No valid action was selected."
 msgstr ""
 
-#: exhibition/views.py:1454
+#: views.py:1530
 #, python-format
 msgid "%(count)d request was approved."
 msgid_plural "%(count)d requests were approved."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1455
+#: views.py:1531
 #, python-format
 msgid "%(count)d request was rejected."
 msgid_plural "%(count)d requests were rejected."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1456
+#: views.py:1532
 #, python-format
 msgid "%(count)d request was withdrawn."
 msgid_plural "%(count)d requests were withdrawn."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1457
+#: views.py:1533
 #, python-format
 msgid "%(count)d request was reopened."
 msgid_plural "%(count)d requests were reopened."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1461
+#: views.py:1537
 msgid "No proposals were updated."
 msgstr ""
 
-#: exhibition/views.py:1464
+#: views.py:1540
 #, python-format
 msgid "%(skipped)d was skipped because it was already processed."
 msgid_plural "%(skipped)d were skipped because they were already processed."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1605
+#: views.py:1681
 msgid "Exhibitor form settings have been saved."
 msgstr ""
 
-#: exhibition/views.py:1730
+#: views.py:1868
 msgid "The requested form field does not exist."
 msgstr ""
 
-#: exhibition/views.py:1791
+#: views.py:1933
 msgid "The field has been reset to its default."
 msgstr ""
 
-#: exhibition/views.py:1829 exhibition/views.py:1900
+#: views.py:1971 views.py:2042
 msgid "An access-credentials email was placed in the outbox."
 msgstr ""
 
-#: exhibition/views.py:1907
+#: views.py:2049
 msgid "Edit Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1908
+#: views.py:2050
 msgid "Edit Exhibitor"
 msgstr ""
 
-#: exhibition/views.py:1909
+#: views.py:2051
 msgid "Edit Exhibitor & Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1910
+#: views.py:2052
 msgid "Edit Exhibitor or Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1940
+#: views.py:2082
 msgid "Delete Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1941
+#: views.py:2083
 msgid "Delete Exhibitor"
 msgstr ""
 
-#: exhibition/views.py:1942
+#: views.py:2084
 msgid "Delete Exhibitor & Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1943
+#: views.py:2085
 msgid "Delete Exhibitor or Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1992
-msgid "Voucher code"
+#: views.py:2164
+msgid "This voucher has already been redeemed and cannot be returned."
 msgstr ""
 
-#: exhibition/views.py:1993
-msgid "Redeem link"
+#: views.py:2170
+msgid ""
+"This code was already included in a voucher email to this partner, so it "
+"cannot be returned to the pool. Delete it under Tickets → Vouchers instead."
 msgstr ""
 
-#: exhibition/views.py:1999
-msgid "Maximum usages"
+#: views.py:2176
+msgid "Voucher returned to the pool."
 msgstr ""
 
-#: exhibition/views.py:2035
-msgid "This voucher has already been redeemed and cannot be removed."
+#: views.py:2207
+msgid "Enter how many vouchers to take from the pool."
 msgstr ""
 
-#: exhibition/views.py:2040
-msgid "Voucher removed."
-msgstr ""
-
-#: exhibition/views.py:2060
+#: views.py:2215
 #, python-format
-msgid "%(count)d voucher created."
-msgid_plural "%(count)d vouchers created."
+msgid "%(count)d voucher taken from the pool."
+msgid_plural "%(count)d vouchers taken from the pool."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2112
+#: views.py:2232
+#, python-format
+msgid ""
+"The pool only has %(remaining)d voucher(s) left, so %(count)d cannot be "
+"taken."
+msgstr ""
+
+#: views.py:2244
+msgid "No email address is on file, so vouchers cannot be emailed."
+msgstr ""
+
+#: views.py:2253
+msgid "This partner holds no vouchers yet, so there is nothing to email."
+msgstr ""
+
+#: views.py:2259
+#, python-format
+msgid "An email with %(count)d voucher code was placed in the outbox."
+msgid_plural "An email with %(count)d voucher codes was placed in the outbox."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2347
+msgid "There is nobody to send vouchers to in this list."
+msgstr ""
+
+#: views.py:2354
+#, python-format
+msgid "%(count)d voucher email was placed in the outbox."
+msgid_plural "%(count)d voucher emails were placed in the outbox."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2371
+#, python-format
+msgid ""
+"%(count)d was skipped because no unassigned codes were available from their "
+"pool."
+msgid_plural ""
+"%(count)d were skipped because no unassigned codes were available from their "
+"pool."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2386
+#, python-format
+msgid "%(count)d sponsor was skipped because it has no email address."
+msgid_plural ""
+"%(count)d sponsors were skipped because they have no email address."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2392
+#, python-format
+msgid "%(count)d exhibitor was skipped because it has no email address."
+msgid_plural ""
+"%(count)d exhibitors were skipped because they have no email address."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2401
+#, python-format
+msgid "%(count)d sponsor was skipped because their voucher count is set to 0."
+msgid_plural ""
+"%(count)d sponsors were skipped because their voucher count is set to 0."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2407
+#, python-format
+msgid ""
+"%(count)d exhibitor was skipped because their voucher count is set to 0."
+msgid_plural ""
+"%(count)d exhibitors were skipped because their voucher count is set to 0."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2461
 #, python-format
 msgid "%(count)d device added."
 msgid_plural "%(count)d devices added."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2123
+#: views.py:2472
 #, python-format
 msgid ""
 "New setup tokens generated. %(count)d device that was already scanning is "
@@ -2738,79 +3031,95 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2132
+#: views.py:2481
 msgid "New setup tokens generated."
 msgstr ""
 
-#: exhibition/views.py:2194
+#: views.py:2543
 msgid "No applicants matched the selected filters."
 msgstr ""
 
-#: exhibition/views.py:2202
+#: views.py:2551
 #, python-format
 msgid "%(count)d emails have been scheduled."
 msgstr ""
 
-#: exhibition/views.py:2206
+#: views.py:2555
 #, python-format
 msgid "%(count)d emails have been sent."
 msgstr ""
 
-#: exhibition/views.py:2210
+#: views.py:2559
 #, python-format
 msgid "%(count)d emails have been placed in the outbox."
 msgstr ""
 
-#: exhibition/views.py:2385
+#: views.py:2738
 msgid "The emails have been saved and sent."
 msgstr ""
 
-#: exhibition/views.py:2389
+#: views.py:2742
 msgid "The emails have been saved."
 msgstr ""
 
-#: exhibition/views.py:2395
+#: views.py:2748
 msgid "The email has been saved and sent."
 msgstr ""
 
-#: exhibition/views.py:2399
+#: views.py:2752
 msgid "The email has been saved."
 msgstr ""
 
-#: exhibition/views.py:2423 exhibition/views.py:2497
+#: views.py:2776 views.py:2850
 #, python-format
 msgid "%(count)d email has been sent."
 msgid_plural "%(count)d emails have been sent."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2459
+#: views.py:2812
 msgid "The email has been discarded."
 msgstr ""
 
-#: exhibition/views.py:2501 exhibition/views.py:2514 exhibition/views.py:2519
+#: views.py:2854 views.py:2867 views.py:2872
 msgid "No emails were selected."
 msgstr ""
 
-#: exhibition/views.py:2510
+#: views.py:2863
 #, python-format
 msgid "%(count)d email has been discarded."
 msgid_plural "%(count)d emails have been discarded."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2594
+#: views.py:2929
+msgid "Request received (confirmation)"
+msgstr ""
+
+#: views.py:2930
+msgid "Request accepted"
+msgstr ""
+
+#: views.py:2931
+msgid "Request rejected"
+msgstr ""
+
+#: views.py:2932
+msgid "Exhibitor lead scanning key"
+msgstr ""
+
+#: views.py:2948
 msgid "Email templates have been saved."
 msgstr ""
 
-#: exhibition/views.py:2617 exhibition/views.py:2621
+#: views.py:2971 views.py:2975
 msgid "Unknown template."
 msgstr ""
 
-#: exhibition/views.py:2667
+#: views.py:3021
 msgid "Custom template has been created."
 msgstr ""
 
-#: exhibition/views.py:2683
+#: views.py:3041
 msgid "Custom template has been deleted."
 msgstr ""

--- a/exhibition/locale/es/LC_MESSAGES/django.po
+++ b/exhibition/locale/es/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-29 10:33+0000\n"
+"POT-Creation-Date: 2026-09-11 11:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,595 +19,531 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? "
 "1 : 2;\n"
 
-#: exhibition/apps.py:14 exhibition/apps.py:17 exhibition/signals.py:157
-#: exhibition/templates/exhibitors/public_list.html:6
-#: exhibition/templates/exhibitors/public_list.html:14
-#: exhibition/templates/exhibitors/public_list.html:16
+#: apps.py:14 apps.py:17 signals.py:163 templates/exhibitors/public_list.html:6
+#: templates/exhibitors/public_list.html:14
+#: templates/exhibitors/public_list.html:16
 msgid "Exhibition"
 msgstr ""
 
-#: exhibition/apps.py:19
+#: apps.py:19
 msgid "This plugin enables to add and control exhibitors in eventyay"
 msgstr ""
 
-#: exhibition/filters.py:9
+#: filters.py:9
 msgid "Any"
 msgstr ""
 
-#: exhibition/filters.py:10
+#: filters.py:10
 msgid "Enabled"
 msgstr ""
 
-#: exhibition/filters.py:11 exhibition/templates/exhibitors/dashboard.html:127
+#: filters.py:11 templates/exhibitors/dashboard.html:127
 msgid "Disabled"
 msgstr ""
 
-#: exhibition/filters.py:15
+#: filters.py:15
 msgid "All types"
 msgstr ""
 
-#: exhibition/filters.py:16
+#: filters.py:16
 msgid "Exhibitor only"
 msgstr ""
 
-#: exhibition/filters.py:17
+#: filters.py:17
 msgid "Sponsor only"
 msgstr ""
 
-#: exhibition/filters.py:18 exhibition/templates/exhibitors/dashboard.html:89
-#: exhibition/templates/exhibitors/proposal_detail.html:95
-#: exhibition/templates/exhibitors/proposal_list.html:95
+#: filters.py:18 templates/exhibitors/dashboard.html:89
+#: templates/exhibitors/proposal_detail.html:95
+#: templates/exhibitors/proposal_list.html:95
 msgid "Exhibitor and sponsor"
 msgstr ""
 
-#: exhibition/filters.py:80 exhibition/filters.py:81
+#: filters.py:80 filters.py:81
 msgid "Search requests…"
 msgstr ""
 
-#: exhibition/filters.py:81
+#: filters.py:81
 msgid "Search requests"
 msgstr ""
 
-#: exhibition/filters.py:85 exhibition/templates/exhibitors/dashboard.html:75
-#: exhibition/templates/exhibitors/proposal_detail.html:85
-#: exhibition/templates/exhibitors/proposal_list.html:21
-#: exhibition/templates/exhibitors/public_proposal_list.html:12
+#: filters.py:85 templates/exhibitors/dashboard.html:75
+#: templates/exhibitors/proposal_detail.html:85
+#: templates/exhibitors/proposal_list.html:21
+#: templates/exhibitors/public_proposal_list.html:12
 msgid "State"
 msgstr ""
 
-#: exhibition/filters.py:86
+#: filters.py:86
 msgid "All states"
 msgstr ""
 
-#: exhibition/filters.py:90 exhibition/templates/exhibitors/dashboard.html:74
-#: exhibition/templates/exhibitors/proposal_detail.html:91
-#: exhibition/templates/exhibitors/proposal_list.html:62
+#: filters.py:90 templates/exhibitors/dashboard.html:74
+#: templates/exhibitors/proposal_detail.html:91
+#: templates/exhibitors/proposal_list.html:62
 msgid "Type"
 msgstr ""
 
-#: exhibition/filters.py:99 exhibition/filters.py:102
+#: filters.py:99 filters.py:102
 msgid "Search by name…"
 msgstr ""
 
-#: exhibition/filters.py:103
+#: filters.py:103
 msgid "Search requests by name"
 msgstr ""
 
-#: exhibition/filters.py:132 exhibition/filters.py:133
+#: filters.py:132 filters.py:133
 msgid "Search organizations…"
 msgstr ""
 
-#: exhibition/filters.py:133
+#: filters.py:133
 msgid "Search organizations"
 msgstr ""
 
-#: exhibition/filters.py:137
+#: filters.py:137
 msgid "Visibility"
 msgstr ""
 
-#: exhibition/filters.py:139
+#: filters.py:139
 msgid "All organizations"
 msgstr ""
 
-#: exhibition/filters.py:140 exhibition/forms.py:1512
-#: exhibition/templates/exhibitors/call_questions.html:30
+#: filters.py:140 forms.py:1553 templates/exhibitors/call_questions.html:30
 msgid "Active"
 msgstr ""
 
-#: exhibition/filters.py:141
+#: filters.py:141
 msgid "Inactive"
 msgstr ""
 
-#: exhibition/filters.py:146 exhibition/filters.py:207 exhibition/forms.py:207
-#: exhibition/forms.py:1410 exhibition/forms.py:1841
+#: filters.py:146 filters.py:207 forms.py:212 forms.py:1411 forms.py:1888
 msgid "Sponsor group"
 msgstr ""
 
-#: exhibition/filters.py:149 exhibition/filters.py:210
+#: filters.py:149 filters.py:210
 msgid "All groups"
 msgstr ""
 
-#: exhibition/filters.py:152 exhibition/templates/exhibitors/add.html:222
+#: filters.py:152 templates/exhibitors/add.html:226
 msgid "Lead scanning"
 msgstr ""
 
-#: exhibition/filters.py:157
+#: filters.py:157
 msgid "Lead access"
 msgstr ""
 
-#: exhibition/filters.py:162
+#: filters.py:162
 msgid "Voucher access"
 msgstr ""
 
-#: exhibition/filters.py:202 exhibition/filters.py:203
+#: filters.py:202 filters.py:203
 msgid "Search exhibitors…"
 msgstr ""
 
-#: exhibition/filters.py:203
+#: filters.py:203
 msgid "Search exhibitors"
 msgstr ""
 
-#: exhibition/filters.py:240 exhibition/filters.py:241
+#: filters.py:240 filters.py:241
 msgid "Search emails…"
 msgstr ""
 
-#: exhibition/filters.py:241
+#: filters.py:241
 msgid "Search emails"
 msgstr ""
 
-#: exhibition/forms.py:67
+#: forms.py:72
 #, python-format
 msgid "Times are in the event timezone: %(tz)s."
 msgstr ""
 
-#: exhibition/forms.py:128 exhibition/forms.py:139 exhibition/forms.py:933
-#: exhibition/forms.py:944
+#: forms.py:133 forms.py:144 forms.py:934 forms.py:945
 msgid "— No selection —"
 msgstr ""
 
-#: exhibition/forms.py:211
+#: forms.py:216
 msgid "Can view voucher redemptions"
 msgstr ""
 
-#: exhibition/forms.py:213 exhibition/forms.py:397
+#: forms.py:218 forms.py:402
 msgid ""
 "Lets this exhibitor or sponsor retrieve the attendees who redeemed vouchers "
 "issued to them. Separate from lead scanning, which covers attendees scanned "
 "at the booth."
 msgstr ""
 
-#: exhibition/forms.py:219
+#: forms.py:224
 msgid "Can view and export collected leads"
 msgstr ""
 
-#: exhibition/forms.py:221
+#: forms.py:226
 msgid ""
 "Lets this exhibitor retrieve the full list of leads they have already "
 "scanned. Turn this off to let them keep scanning without seeing the "
 "collected attendee data."
 msgstr ""
 
-#: exhibition/forms.py:226
+#: forms.py:231
 msgid "Lead scanning behavior"
 msgstr ""
 
-#: exhibition/forms.py:231
+#: forms.py:236
 msgid ""
 "Every attendee is one lead, even when scanned from multiple devices. Notes "
 "and ratings are shared between devices."
 msgstr ""
 
-#: exhibition/forms.py:238
+#: forms.py:243
 msgid ""
 "Every attendee is a new lead when scanned from a new device. Notes and "
 "ratings are specific to the device."
 msgstr ""
 
-#: exhibition/forms.py:251
+#: forms.py:256
 msgid "Comment"
 msgstr ""
 
-#: exhibition/forms.py:253
+#: forms.py:258
 msgid ""
 "The text entered in this field will not be visible to the user and is "
 "available for your convenience."
 msgstr ""
 
-#: exhibition/forms.py:258 exhibition/forms.py:1427 exhibition/views.py:505
+#: forms.py:263 forms.py:1428 views.py:544
 msgid "Booth ID"
 msgstr ""
 
-#: exhibition/forms.py:291 exhibition/forms.py:1027 exhibition/forms.py:1076
-#: exhibition/models.py:130
+#: forms.py:296 forms.py:1028 forms.py:1077 models.py:130
 msgid "Organization name"
 msgstr ""
 
-#: exhibition/forms.py:292 exhibition/forms.py:1030 exhibition/forms.py:1077
-#: exhibition/models.py:136
+#: forms.py:297 forms.py:1031 forms.py:1078 models.py:136
 msgid "Organization description"
 msgstr ""
 
-#: exhibition/forms.py:293 exhibition/forms.py:1078
+#: forms.py:298 forms.py:1079
 msgid "E-mail"
 msgstr ""
 
-#: exhibition/forms.py:294 exhibition/forms.py:1079 exhibition/models.py:139
+#: forms.py:299 forms.py:1080 models.py:139
 msgid "Contact page URL"
 msgstr ""
 
-#: exhibition/forms.py:295 exhibition/forms.py:1080 exhibition/models.py:140
+#: forms.py:300 forms.py:1081 models.py:140
 msgid "Promotional video URL"
 msgstr ""
 
-#: exhibition/forms.py:296 exhibition/forms.py:1081 exhibition/models.py:141
+#: forms.py:301 forms.py:1082 models.py:141
 msgid "Promotional slides"
 msgstr ""
 
-#: exhibition/forms.py:297 exhibition/forms.py:1082 exhibition/models.py:142
-#: exhibition/models.py:520
-#: exhibition/templates/exhibitors/proposal_detail.html:111
+#: forms.py:302 forms.py:1083 models.py:142 models.py:568
+#: templates/exhibitors/proposal_detail.html:111
 msgid "Logo"
 msgstr ""
 
-#: exhibition/forms.py:298 exhibition/forms.py:1083 exhibition/models.py:145
-#: exhibition/templates/exhibitors/proposal_detail.html:113
+#: forms.py:303 forms.py:1084 models.py:145
+#: templates/exhibitors/proposal_detail.html:113
 msgid "Header image"
 msgstr ""
 
-#: exhibition/forms.py:299 exhibition/forms.py:1084 exhibition/models.py:138
+#: forms.py:304 forms.py:1085 models.py:138
 msgid "Organization website"
 msgstr ""
 
-#: exhibition/forms.py:300
+#: forms.py:305
 msgid "Mark this partner as an exhibitor"
 msgstr ""
 
-#: exhibition/forms.py:301
+#: forms.py:306
 msgid "Mark this partner as an event sponsor"
 msgstr ""
 
-#: exhibition/forms.py:302 exhibition/forms.py:1036 exhibition/forms.py:1085
-#: exhibition/models.py:148 exhibition/models.py:522
+#: forms.py:307 forms.py:1037 forms.py:1086 models.py:148 models.py:570
 msgid "Preferred booth name"
 msgstr ""
 
-#: exhibition/forms.py:303
+#: forms.py:308
 msgid "Can scan attendee badges"
 msgstr ""
 
-#: exhibition/forms.py:307
+#: forms.py:312
 msgid ""
 "Lets this exhibitor sign in to the lead scanning app and scan attendees at "
 "their booth. Turn this off to block scanning entirely."
 msgstr ""
 
-#: exhibition/forms.py:348 exhibition/forms.py:1441
+#: forms.py:353 forms.py:1442
 msgid "No sponsor group"
 msgstr ""
 
-#: exhibition/forms.py:385
+#: forms.py:390
 msgid ""
 "Lets this exhibitor retrieve the attendees who redeemed vouchers issued to "
 "them. Separate from lead scanning, which covers attendees scanned at the "
 "booth."
 msgstr ""
 
-#: exhibition/forms.py:389
+#: forms.py:394
 msgid ""
 "Lets this sponsor retrieve the attendees who redeemed vouchers issued to "
 "them. Separate from lead scanning, which covers attendees scanned at the "
 "booth."
 msgstr ""
 
-#: exhibition/forms.py:393
+#: forms.py:398
 msgid ""
 "Lets this exhibitor and sponsor retrieve the attendees who redeemed vouchers "
 "issued to them. Separate from lead scanning, which covers attendees scanned "
 "at the booth."
 msgstr ""
 
-#: exhibition/forms.py:466 exhibition/forms.py:553 exhibition/forms.py:1361
-#: exhibition/forms.py:1375
+#: forms.py:471 forms.py:558 forms.py:1362 forms.py:1376 forms.py:1855
+#: forms.py:1924 forms.py:1930 forms.py:1932 forms.py:1934
 msgid "This field is required."
 msgstr ""
 
-#: exhibition/forms.py:511 exhibition/forms.py:516
+#: forms.py:516 forms.py:521
 msgid "Slides upload must be a PDF file."
 msgstr ""
 
-#: exhibition/forms.py:540
+#: forms.py:545
 msgid "A partner must be marked as an exhibitor, a sponsor, or both."
 msgstr ""
 
-#: exhibition/forms.py:615
+#: forms.py:620
 msgid "Devices to add"
 msgstr ""
 
-#: exhibition/forms.py:617
+#: forms.py:622
 msgid ""
 "How many new devices to provision now, in addition to any already listed "
 "above. Each device gets its own single-use setup token and QR code."
 msgstr ""
 
-#: exhibition/forms.py:627
-msgid "Select a product…"
+#: forms.py:635
+msgid "Vouchers to take from the pool"
 msgstr ""
 
-#: exhibition/forms.py:628
-msgid "Ticket product"
+#: forms.py:636
+msgid ""
+"Set to 0 to email the codes this partner already has without taking any more."
 msgstr ""
 
-#: exhibition/forms.py:629
-msgid "The product a redeemed voucher applies to."
-msgstr ""
-
-#: exhibition/forms.py:635
-msgid "Number of vouchers"
-msgstr ""
-
-#: exhibition/forms.py:640
-msgid "Maximum usages per voucher"
-msgstr ""
-
-#: exhibition/forms.py:645 exhibition/templates/exhibitors/vouchers.html:33
-#: exhibition/views.py:1995
-msgid "Price effect"
-msgstr ""
-
-#: exhibition/forms.py:651 exhibition/views.py:1996
-msgid "Value"
-msgstr ""
-
-#: exhibition/forms.py:652
-msgid "Amount or percentage, depending on the selected price effect."
-msgstr ""
-
-#: exhibition/forms.py:657 exhibition/templates/exhibitors/vouchers.html:35
-#: exhibition/views.py:1997
-msgid "Valid until"
-msgstr ""
-
-#: exhibition/forms.py:673
-msgid "Enter a value for the selected price effect."
-msgstr ""
-
-#: exhibition/forms.py:678 exhibition/models.py:295
-#: exhibition/templates/exhibitors/settings.html:205
+#: forms.py:647 models.py:326 templates/exhibitors/settings.html:289
 msgid "Level"
 msgstr ""
 
-#: exhibition/forms.py:685 exhibition/models.py:294
+#: forms.py:654 models.py:325
 msgid "Group name"
 msgstr ""
 
-#: exhibition/forms.py:718
+#: forms.py:677 models.py:225
+msgid "Exhibitor voucher pool"
+msgstr ""
+
+#: forms.py:678 models.py:232
+msgid "Sponsor voucher pool"
+msgstr ""
+
+#: forms.py:698
+msgid "— No pool selected —"
+msgstr ""
+
+#: forms.py:699
+msgid "— Use the exhibitor pool —"
+msgstr ""
+
+#: forms.py:719
 msgid "Enable call"
 msgstr ""
 
-#: exhibition/forms.py:719
+#: forms.py:720
 msgid "Hide call page after the deadline"
 msgstr ""
 
-#: exhibition/forms.py:720
+#: forms.py:721
 msgid "Make this call private (accessible only via a secret link)"
 msgstr ""
 
-#: exhibition/forms.py:724
+#: forms.py:725
 msgid ""
 "Turn the call on. Keep it enabled for private calls too, otherwise the "
 "secret link stops working."
 msgstr ""
 
-#: exhibition/forms.py:727
+#: forms.py:728
 msgid ""
 "The call page is not linked anywhere public and can only be opened with the "
 "secret link shown below."
 msgstr ""
 
-#: exhibition/forms.py:868
+#: forms.py:869
 msgid "Your answer"
 msgstr ""
 
-#: exhibition/forms.py:1024 exhibition/models.py:563
-#: exhibition/templates/exhibitors/proposal_detail.html:88
+#: forms.py:1025 models.py:611 templates/exhibitors/proposal_detail.html:88
 msgid "Language"
 msgstr ""
 
-#: exhibition/forms.py:1025
+#: forms.py:1026
 msgid "The language you are filling in this form with."
 msgstr ""
 
-#: exhibition/forms.py:1086 exhibition/models.py:151 exhibition/models.py:523
-#: exhibition/models.py:602
+#: forms.py:1087 models.py:151 models.py:571 models.py:650
 msgid "Message to the organizers"
 msgstr ""
 
-#: exhibition/forms.py:1149
+#: forms.py:1150
 msgid ""
 "The organization name is locked after acceptance. Contact the organizers to "
 "change it."
 msgstr ""
 
-#: exhibition/forms.py:1425
+#: forms.py:1426
 msgid "Approve as exhibitor"
 msgstr ""
 
-#: exhibition/forms.py:1426
+#: forms.py:1427
 msgid "Approve as sponsor"
 msgstr ""
 
-#: exhibition/forms.py:1428 exhibition/models.py:352 exhibition/models.py:596
-#: exhibition/models.py:966 exhibition/views.py:505
+#: forms.py:1429 models.py:383 models.py:644 models.py:1014 views.py:544
 msgid "Booth name"
 msgstr ""
 
-#: exhibition/forms.py:1429 exhibition/forms.py:1459 exhibition/models.py:607
+#: forms.py:1430 forms.py:1460 models.py:655
 msgid "Internal review notes"
 msgstr ""
 
-#: exhibition/forms.py:1470
+#: forms.py:1471
 msgid "Field label"
 msgstr ""
 
-#: exhibition/forms.py:1475 exhibition/forms.py:1510
+#: forms.py:1476 forms.py:1551
 msgid "Help text"
 msgstr ""
 
-#: exhibition/forms.py:1476
+#: forms.py:1477
 msgid "Shown below the field on the exhibitor form."
 msgstr ""
 
-#: exhibition/forms.py:1483
+#: forms.py:1484
 #, python-format
 msgid "Leave empty to use the default: %(label)s"
 msgstr ""
 
-#: exhibition/forms.py:1492
-msgid "Options"
-msgstr ""
-
-#: exhibition/forms.py:1493
-msgid "For choice fields, enter one option per line."
-msgstr ""
-
-#: exhibition/forms.py:1508
-msgid "Field type"
-msgstr ""
-
-#: exhibition/forms.py:1509 exhibition/models.py:878
-msgid "Custom question"
-msgstr ""
-
-#: exhibition/forms.py:1511
-#: exhibition/templates/exhibitors/call_questions.html:31
-#: exhibition/templates/exhibitors/call_questions.html:63
-msgid "Required"
-msgstr ""
-
-#: exhibition/forms.py:1535
+#: forms.py:1523
 msgid "Please provide at least one option for this question type."
 msgstr ""
 
-#: exhibition/forms.py:1576 exhibition/forms.py:1665
+#: forms.py:1549
+msgid "Field type"
+msgstr ""
+
+#: forms.py:1550 models.py:926
+msgid "Custom question"
+msgstr ""
+
+#: forms.py:1552 templates/exhibitors/call_questions.html:31
+#: templates/exhibitors/call_questions.html:63
+msgid "Required"
+msgstr ""
+
+#: forms.py:1583 forms.py:1672
 msgid "Choose social platform"
 msgstr ""
 
-#: exhibition/forms.py:1578 exhibition/forms.py:1667
+#: forms.py:1585 forms.py:1674
 msgid "Social platform"
 msgstr ""
 
-#: exhibition/forms.py:1582 exhibition/forms.py:1671
+#: forms.py:1589 forms.py:1678
 msgid "Profile or path"
 msgstr ""
 
-#: exhibition/forms.py:1596 exhibition/forms.py:1685
+#: forms.py:1603 forms.py:1692
 msgid "Profile, handle, or full URL"
 msgstr ""
 
-#: exhibition/forms.py:1616 exhibition/forms.py:1705
+#: forms.py:1623 forms.py:1712
 msgid "Please enter a profile, handle, or URL or remove this row."
 msgstr ""
 
-#: exhibition/forms.py:1622 exhibition/forms.py:1711
+#: forms.py:1629 forms.py:1718
 msgid "Please choose a social platform."
 msgstr ""
 
-#: exhibition/forms.py:1626 exhibition/forms.py:1715
+#: forms.py:1633 forms.py:1722
 msgid "Please enter a profile, handle, or URL."
 msgstr ""
 
-#: exhibition/forms.py:1648 exhibition/forms.py:1737
+#: forms.py:1655 forms.py:1744
 msgid "Link label"
 msgstr ""
 
-#: exhibition/forms.py:1654 exhibition/forms.py:1743
+#: forms.py:1661 forms.py:1750
 msgid "https://example.com"
 msgstr ""
 
-#: exhibition/forms.py:1807
+#: forms.py:1848
 msgid ""
 "Leave empty to keep this in the outbox until sent manually. Time is "
 "interpreted in the event timezone."
 msgstr ""
 
-#: exhibition/forms.py:1814 exhibition/forms.py:1877
+#: forms.py:1861 forms.py:1940
 msgid "The scheduled time must be in the future."
 msgstr ""
 
-#: exhibition/forms.py:1822
+#: forms.py:1869
 msgid "Exhibitors and sponsors"
 msgstr ""
 
-#: exhibition/forms.py:1823
+#: forms.py:1870
 msgid "Exhibitors only"
 msgstr ""
 
-#: exhibition/forms.py:1824
+#: forms.py:1871
 msgid "Sponsors only"
 msgstr ""
 
-#: exhibition/forms.py:1828
+#: forms.py:1875
 msgid "Application state"
 msgstr ""
 
-#: exhibition/forms.py:1836
+#: forms.py:1883
 msgid "Partner type"
 msgstr ""
 
-#: exhibition/forms.py:1844
+#: forms.py:1891
 msgid "Any sponsor group"
 msgstr ""
 
-#: exhibition/forms.py:1846 exhibition/models.py:1035 exhibition/models.py:1089
-#: exhibition/templates/exhibitors/_email_outbox_body.html:6
-#: exhibition/templates/exhibitors/_email_sent_body.html:6
+#: forms.py:1893 forms.py:1953 models.py:1084 models.py:1146
+#: templates/exhibitors/_email_outbox_body.html:6
+#: templates/exhibitors/_email_sent_body.html:6
 msgid "Subject"
 msgstr ""
 
-#: exhibition/forms.py:1848
+#: forms.py:1895
 msgid "Send at"
 msgstr ""
 
-#: exhibition/forms.py:1851
+#: forms.py:1898
 msgid "Leave empty to send immediately or save to the outbox."
 msgstr ""
 
-#: exhibition/forms.py:1859 exhibition/models.py:1036 exhibition/models.py:1090
+#: forms.py:1906 forms.py:1960 models.py:1085 models.py:1147
 msgid "Body"
 msgstr ""
 
-#: exhibition/forms.py:1885 exhibition/views.py:2576
-msgid "Request received (confirmation)"
-msgstr ""
-
-#: exhibition/forms.py:1886 exhibition/views.py:2577
-msgid "Request accepted"
-msgstr ""
-
-#: exhibition/forms.py:1887 exhibition/views.py:2578
-msgid "Request rejected"
-msgstr ""
-
-#: exhibition/forms.py:1888 exhibition/views.py:2579
-msgid "Exhibitor lead scanning key"
-msgstr ""
-
-#: exhibition/forms.py:1897
-#, python-format
-msgid "%(role)s — subject"
-msgstr ""
-
-#: exhibition/forms.py:1904
-#, python-format
-msgid "%(role)s — body"
-msgstr ""
-
-#: exhibition/mail.py:57
+#: mail.py:59
 #, python-brace-format
 msgid "We received your request for {event_name}"
 msgstr ""
 
-#: exhibition/mail.py:59
+#: mail.py:61
 #, python-brace-format
 msgid ""
 "Hello,\n"
@@ -622,12 +558,12 @@ msgid ""
 "The {event_name} team"
 msgstr ""
 
-#: exhibition/mail.py:69
+#: mail.py:71
 #, python-brace-format
 msgid "Your request for {event_name} has been accepted"
 msgstr ""
 
-#: exhibition/mail.py:71
+#: mail.py:73
 #, python-brace-format
 msgid ""
 "Hello,\n"
@@ -639,12 +575,12 @@ msgid ""
 "The {event_name} team"
 msgstr ""
 
-#: exhibition/mail.py:80
+#: mail.py:82
 #, python-brace-format
 msgid "Update on your request for {event_name}"
 msgstr ""
 
-#: exhibition/mail.py:82
+#: mail.py:84
 #, python-brace-format
 msgid ""
 "Hello,\n"
@@ -658,12 +594,12 @@ msgid ""
 "The {event_name} team"
 msgstr ""
 
-#: exhibition/mail.py:91
+#: mail.py:93
 #, python-brace-format
 msgid "Lead Scanning Access for {event_name}"
 msgstr ""
 
-#: exhibition/mail.py:93
+#: mail.py:95
 #, python-brace-format
 msgid ""
 "Hello {exhibitor_name},\n"
@@ -689,983 +625,1081 @@ msgid ""
 "The {event_name} Team"
 msgstr ""
 
-#: exhibition/mail.py:174
+#: mail.py:110
+#, python-brace-format
+msgid "Your vouchers for {event_name} — {exhibitor_name}"
+msgstr ""
+
+#: mail.py:112
+#, python-brace-format
+msgid ""
+"Dear {exhibitor_name},\n"
+"\n"
+"Thank you for participating in {event_name}. Please share the voucher codes "
+"below with your audience — anyone who uses one gets credited to you as a "
+"lead.\n"
+"\n"
+"{voucher_list}\n"
+"\n"
+"They can redeem a code on the event ticket shop at checkout.\n"
+"\n"
+"If you have any questions, please don't hesitate to reach out.\n"
+"\n"
+"Best regards,\n"
+"The {event_name} Team"
+msgstr ""
+
+#: mail.py:190
 msgid "This value will be replaced based on dynamic parameters."
 msgstr ""
 
-#: exhibition/models.py:137 exhibition/models.py:515
+#: mail.py:312
+#, python-format
+msgid "…and %(count)d more voucher code in the attached CSV file."
+msgid_plural "…and %(count)d more voucher codes in the attached CSV file."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: models.py:137 models.py:563
 msgid "Contact email"
 msgstr ""
 
-#: exhibition/models.py:156
-#: exhibition/templates/exhibitors/proposal_detail.html:132
+#: models.py:156 templates/exhibitors/proposal_detail.html:132
 msgid "Social media"
 msgstr ""
 
-#: exhibition/models.py:161
-#: exhibition/templates/exhibitors/proposal_detail.html:140
+#: models.py:161 templates/exhibitors/proposal_detail.html:140
 msgid "Extra links"
 msgstr ""
 
-#: exhibition/models.py:216
+#: models.py:212
+msgid "Vouchers per exhibitor"
+msgstr ""
+
+#: models.py:226
+msgid ""
+"The voucher tag created under Tickets → Vouchers that exhibitors draw their "
+"codes from."
+msgstr ""
+
+#: models.py:233
+msgid "Leave empty to draw sponsor codes from the exhibitor pool as well."
+msgstr ""
+
+#: models.py:239
+msgid "Attach voucher list as CSV"
+msgstr ""
+
+#: models.py:240
+msgid ""
+"Adds a spreadsheet of the recipient's own voucher codes to the voucher email."
+msgstr ""
+
+#: models.py:247
 msgid "Call headline"
 msgstr ""
 
-#: exhibition/models.py:220
+#: models.py:251
 msgid "Call text"
 msgstr ""
 
-#: exhibition/models.py:225
+#: models.py:256
 msgid "Submission deadline"
 msgstr ""
 
-#: exhibition/models.py:298
+#: models.py:329
 msgid "Show this sponsor group on the front page."
 msgstr ""
 
-#: exhibition/models.py:314 exhibition/models.py:558
-#: exhibition/templates/exhibitors/dashboard.html:73
-#: exhibition/templates/exhibitors/exhibitor_info.html:69
-#: exhibition/templates/exhibitors/proposal_list.html:19
-#: exhibition/templates/exhibitors/public_proposal_list.html:11
-#: exhibition/views.py:505
+#: models.py:345 models.py:606 templates/exhibitors/dashboard.html:73
+#: templates/exhibitors/exhibitor_info.html:79
+#: templates/exhibitors/proposal_list.html:19
+#: templates/exhibitors/public_proposal_list.html:11 views.py:544
 msgid "Name"
 msgstr ""
 
-#: exhibition/models.py:315 exhibition/models.py:559
-#: exhibition/templates/exhibitors/proposal_detail.html:117
+#: models.py:346 models.py:607 templates/exhibitors/proposal_detail.html:117
 msgid "Description"
 msgstr ""
 
-#: exhibition/models.py:316 exhibition/models.py:419 exhibition/models.py:435
-#: exhibition/models.py:565 exhibition/models.py:815 exhibition/models.py:831
-#: exhibition/models.py:844
-#: exhibition/templates/exhibitors/proposal_detail.html:103
+#: models.py:347 models.py:467 models.py:483 models.py:613 models.py:863
+#: models.py:879 models.py:892 templates/exhibitors/proposal_detail.html:103
 msgid "URL"
 msgstr ""
 
-#: exhibition/models.py:317 exhibition/models.py:566
-#: exhibition/templates/exhibitors/proposal_detail.html:77
-#: exhibition/views.py:505
+#: models.py:348 models.py:614 templates/exhibitors/proposal_detail.html:77
+#: views.py:544
 msgid "Email"
 msgstr ""
 
-#: exhibition/models.py:318 exhibition/models.py:567
-#: exhibition/templates/exhibitors/proposal_detail.html:105
+#: models.py:349 models.py:615 templates/exhibitors/proposal_detail.html:105
 msgid "Contact URL"
 msgstr ""
 
-#: exhibition/models.py:319 exhibition/models.py:568
-#: exhibition/templates/exhibitors/proposal_detail.html:107
+#: models.py:350 models.py:616 templates/exhibitors/proposal_detail.html:107
 msgid "Video URL"
 msgstr ""
 
-#: exhibition/models.py:322 exhibition/models.py:571
-#: exhibition/templates/exhibitors/proposal_detail.html:109
+#: models.py:353 models.py:619 templates/exhibitors/proposal_detail.html:109
 msgid "Slides"
 msgstr ""
 
-#: exhibition/models.py:326 exhibition/models.py:575
+#: models.py:357 models.py:623
 msgid "Slides URL"
 msgstr ""
 
-#: exhibition/models.py:328 exhibition/models.py:577
+#: models.py:359 models.py:625
 msgid "Logo URL"
 msgstr ""
 
-#: exhibition/models.py:330 exhibition/models.py:579
+#: models.py:361 models.py:627
 msgid "Header image URL"
 msgstr ""
 
-#: exhibition/models.py:434 exhibition/models.py:830
+#: models.py:482 models.py:878
 msgid "Label"
 msgstr ""
 
-#: exhibition/models.py:445
+#: models.py:493
 msgid "draft"
 msgstr ""
 
-#: exhibition/models.py:446
+#: models.py:494
 msgid "submitted"
 msgstr ""
 
-#: exhibition/models.py:447
+#: models.py:495
 msgid "accepted"
 msgstr ""
 
-#: exhibition/models.py:448
+#: models.py:496
 msgid "rejected"
 msgstr ""
 
-#: exhibition/models.py:449
+#: models.py:497
 msgid "withdrawn"
 msgstr ""
 
-#: exhibition/models.py:514
+#: models.py:562
 msgid "Organization Description"
 msgstr ""
 
-#: exhibition/models.py:516
+#: models.py:564
 msgid "Organization Website"
 msgstr ""
 
-#: exhibition/models.py:517
+#: models.py:565
 msgid "Contact Page URL"
 msgstr ""
 
-#: exhibition/models.py:518
+#: models.py:566
 msgid "Promotional Video URL"
 msgstr ""
 
-#: exhibition/models.py:519
+#: models.py:567
 msgid "Promotional Slides"
 msgstr ""
 
-#: exhibition/models.py:521
+#: models.py:569
 msgid "Header Image"
 msgstr ""
 
-#: exhibition/models.py:524 exhibition/templates/exhibitors/add.html:29
-#: exhibition/templates/exhibitors/public_proposal_form.html:38
+#: models.py:572 templates/exhibitors/add.html:29
+#: templates/exhibitors/public_proposal_form.html:38
 msgid "Social Media"
 msgstr ""
 
-#: exhibition/models.py:525 exhibition/templates/exhibitors/add.html:92
-#: exhibition/templates/exhibitors/public_proposal_form.html:91
+#: models.py:573 templates/exhibitors/add.html:92
+#: templates/exhibitors/public_proposal_form.html:91
 msgid "Extra Links"
 msgstr ""
 
-#: exhibition/models.py:841
+#: models.py:889
 msgid "Number"
 msgstr ""
 
-#: exhibition/models.py:842
+#: models.py:890
 msgid "Text (one line)"
 msgstr ""
 
-#: exhibition/models.py:843
+#: models.py:891
 msgid "Multiline text"
 msgstr ""
 
-#: exhibition/models.py:845
+#: models.py:893
 msgid "Email address"
 msgstr ""
 
-#: exhibition/models.py:846
+#: models.py:894
 msgid "Confirm Checkbox"
 msgstr ""
 
-#: exhibition/models.py:847
+#: models.py:895
 msgid "Radio button (Choose one option)"
 msgstr ""
 
-#: exhibition/models.py:848
+#: models.py:896
 msgid "Dropdown (Choose one option)"
 msgstr ""
 
-#: exhibition/models.py:849
+#: models.py:897
 msgid "Checkbox (Choose one or several options)"
 msgstr ""
 
-#: exhibition/models.py:850
+#: models.py:898
 msgid "File upload"
 msgstr ""
 
-#: exhibition/models.py:851
+#: models.py:899
 msgid "Date"
 msgstr ""
 
-#: exhibition/models.py:852
+#: models.py:900
 msgid "Time"
 msgstr ""
 
-#: exhibition/models.py:853
+#: models.py:901
 msgid "Date and time"
 msgstr ""
 
-#: exhibition/models.py:854
+#: models.py:902
 msgid "Country code (ISO 3166-1 alpha-2)"
 msgstr ""
 
-#: exhibition/models.py:855
+#: models.py:903
 msgid "Phone number"
 msgstr ""
 
-#: exhibition/models.py:883
+#: models.py:931
 msgid "help text"
 msgstr ""
 
-#: exhibition/models.py:885 exhibition/templates/exhibitors/add.html:29
-#: exhibition/templates/exhibitors/add.html:92
-#: exhibition/templates/exhibitors/public_proposal_form.html:38
-#: exhibition/templates/exhibitors/public_proposal_form.html:91
+#: models.py:933 templates/exhibitors/add.html:29
+#: templates/exhibitors/add.html:92
+#: templates/exhibitors/public_proposal_form.html:38
+#: templates/exhibitors/public_proposal_form.html:91
 msgid "required"
 msgstr ""
 
-#: exhibition/models.py:886
+#: models.py:934
 msgid "active"
 msgstr ""
 
-#: exhibition/models.py:906
+#: models.py:954
 msgid "Response"
 msgstr ""
 
-#: exhibition/models.py:938
+#: models.py:986
 msgid "Yes"
 msgstr ""
 
-#: exhibition/models.py:940
+#: models.py:988
 msgid "No"
 msgstr ""
 
-#: exhibition/models.py:1034
-#: exhibition/templates/exhibitors/_email_outbox_body.html:5
-#: exhibition/templates/exhibitors/_email_sent_body.html:5
+#: models.py:1083 templates/exhibitors/_email_outbox_body.html:5
+#: templates/exhibitors/_email_sent_body.html:5
 msgid "Recipient"
 msgstr ""
 
-#: exhibition/models.py:1045
+#: models.py:1101
 msgid "Queued email"
 msgstr ""
 
-#: exhibition/models.py:1046
+#: models.py:1102
 msgid "Queued emails"
 msgstr ""
 
-#: exhibition/models.py:1088
+#: models.py:1145
 msgid "Template name"
 msgstr ""
 
-#: exhibition/models.py:1095
+#: models.py:1152
 msgid "Custom email template"
 msgstr ""
 
-#: exhibition/models.py:1096
+#: models.py:1153
 msgid "Custom email templates"
 msgstr ""
 
-#: exhibition/signals.py:75
+#: signals.py:81
 msgid "Screen and evaluate exhibitor and sponsor requests for the event."
 msgstr ""
 
-#: exhibition/signals.py:76
+#: signals.py:82
 msgid "Request Review Dashboard"
 msgstr ""
 
-#: exhibition/signals.py:80
+#: signals.py:86
 msgid ""
 "Manage exhibitors and sponsors, maintain booth details, and create partner "
 "profiles for the event."
 msgstr ""
 
-#: exhibition/signals.py:82
+#: signals.py:88
 msgid "Exhibitors & Sponsors Dashboard"
 msgstr ""
 
-#: exhibition/signals.py:88 exhibition/templates/exhibitors/base.html:5
-#: exhibition/templates/exhibitors/base.html:125
-#: exhibition/templates/exhibitors/exhibitor_info.html:4
-#: exhibition/templates/exhibitors/exhibitor_info.html:15
+#: signals.py:94 templates/exhibitors/base.html:6
+#: templates/exhibitors/base.html:136
+#: templates/exhibitors/exhibitor_info.html:4
+#: templates/exhibitors/exhibitor_info.html:15
 msgid "Exhibitors & Sponsors"
 msgstr ""
 
-#: exhibition/signals.py:90
+#: signals.py:96
 msgid "Go to"
 msgstr ""
 
-#: exhibition/signals.py:166 exhibition/templates/exhibitors/call_base.html:4
-#: exhibition/templates/exhibitors/call_base.html:7
-#: exhibition/templates/exhibitors/public_call.html:7
-#: exhibition/templates/exhibitors/settings.html:8
-#: exhibition/templates/exhibitors/settings.html:25
+#: signals.py:172 templates/exhibitors/call_base.html:4
+#: templates/exhibitors/call_base.html:7
+#: templates/exhibitors/public_call.html:7 templates/exhibitors/settings.html:8
+#: templates/exhibitors/settings.html:27
 msgid "Call for Exhibitors"
 msgstr ""
 
-#: exhibition/signals.py:207 exhibition/signals.py:231
+#: signals.py:213 signals.py:237
 msgid "Acme Corp"
 msgstr ""
 
-#: exhibition/signals.py:225
+#: signals.py:231
 msgid "Jane Doe"
 msgstr ""
 
-#: exhibition/signals.py:293 exhibition/templates/exhibitors/base.html:62
-#: exhibition/templates/exhibitors/proposal_list.html:5
-#: exhibition/templates/exhibitors/proposal_list.html:15
+#: signals.py:305 templates/exhibitors/base.html:73
+#: templates/exhibitors/proposal_list.html:5
+#: templates/exhibitors/proposal_list.html:15
 msgid "Exhibition requests"
 msgstr ""
 
-#: exhibition/signals.py:298
+#: signals.py:310
 msgid "Exhibition request approved."
 msgstr ""
 
-#: exhibition/signals.py:299
+#: signals.py:311
 msgid "Exhibition request rejected."
 msgstr ""
 
-#: exhibition/signals.py:300
+#: signals.py:312
 msgid "Exhibition request withdrawn."
 msgstr ""
 
-#: exhibition/signals.py:301
+#: signals.py:313
 msgid "Exhibition request reopened for review."
 msgstr ""
 
-#: exhibition/signals.py:302
+#: signals.py:314
 msgid "Exhibition request changed."
 msgstr ""
 
-#: exhibition/signals.py:303
+#: signals.py:315
 msgid "Organization profile created from an approved request."
 msgstr ""
 
-#: exhibition/signals.py:304
+#: signals.py:316
 msgid "Organization profile reactivated after re-approval."
 msgstr ""
 
-#: exhibition/signals.py:305
+#: signals.py:317
 msgid "Organization profile updated from the submitter's changes."
 msgstr ""
 
-#: exhibition/signals.py:306
+#: signals.py:318
 msgid "Organization profile created."
 msgstr ""
 
-#: exhibition/signals.py:307
+#: signals.py:319
 msgid "Organization profile changed."
 msgstr ""
 
-#: exhibition/signals.py:308
+#: signals.py:320
 msgid "Organization profile deleted."
 msgstr ""
 
-#: exhibition/signals.py:309
+#: signals.py:321
 msgid "Exhibition settings changed."
 msgstr ""
 
-#: exhibition/signals.py:310
+#: signals.py:322
 msgid "Call for exhibitors settings changed."
 msgstr ""
 
-#: exhibition/signals.py:311
+#: signals.py:323
 msgid "Private call link regenerated."
 msgstr ""
 
-#: exhibition/signals.py:312
+#: signals.py:324
 msgid "Sponsor group created."
 msgstr ""
 
-#: exhibition/signals.py:313
+#: signals.py:325
 msgid "Sponsor group changed."
 msgstr ""
 
-#: exhibition/signals.py:314 exhibition/views.py:457
+#: signals.py:326 views.py:496
 msgid "Sponsor group deleted."
 msgstr ""
 
-#: exhibition/signals.py:315
+#: signals.py:327
 msgid "Exhibitor form question created."
 msgstr ""
 
-#: exhibition/signals.py:316
+#: signals.py:328
 msgid "Exhibitor form question changed."
 msgstr ""
 
-#: exhibition/signals.py:317
+#: signals.py:329
 msgid "Exhibitor form question deleted."
 msgstr ""
 
-#: exhibition/signals.py:318
+#: signals.py:330
 msgid "Email sent."
 msgstr ""
 
-#: exhibition/signals.py:337
+#: signals.py:349
 #, python-brace-format
 msgid "Updated: {fields}."
 msgstr ""
 
-#: exhibition/signals.py:360
+#: signals.py:372
 #, python-brace-format
 msgid "State changed from {old} to {new}."
 msgstr ""
 
-#: exhibition/signals.py:382
+#: signals.py:394
 #, python-brace-format
 msgid "Exhibition request {val}"
 msgstr ""
 
-#: exhibition/signals.py:391
+#: signals.py:403
 #, python-brace-format
 msgid "Organization profile {val}"
 msgstr ""
 
-#: exhibition/signals.py:400
+#: signals.py:412
 #, python-brace-format
 msgid "Exhibitor form question {val}"
 msgstr ""
 
-#: exhibition/signals.py:409
+#: signals.py:421
 #, python-brace-format
 msgid "Sponsor group {val}"
 msgstr ""
 
-#: exhibition/social_links.py:36
+#: social_links.py:36
 msgid "Facebook"
 msgstr ""
 
-#: exhibition/social_links.py:43
+#: social_links.py:43
 msgid "Flickr"
 msgstr ""
 
-#: exhibition/social_links.py:50
+#: social_links.py:50
 msgid "GitHub"
 msgstr ""
 
-#: exhibition/social_links.py:57
+#: social_links.py:57
 msgid "GitLab"
 msgstr ""
 
-#: exhibition/social_links.py:64
+#: social_links.py:64
 msgid "Gitter"
 msgstr ""
 
-#: exhibition/social_links.py:71
+#: social_links.py:71
 msgid "Google Groups"
 msgstr ""
 
-#: exhibition/social_links.py:78
+#: social_links.py:78
 msgid "Instagram"
 msgstr ""
 
-#: exhibition/social_links.py:85
+#: social_links.py:85
 msgid "LinkedIn"
 msgstr ""
 
-#: exhibition/social_links.py:92
+#: social_links.py:92
 msgid "Mastodon"
 msgstr ""
 
-#: exhibition/social_links.py:99
+#: social_links.py:99
 msgid "Patreon"
 msgstr ""
 
-#: exhibition/social_links.py:106
+#: social_links.py:106
 msgid "Telegram"
 msgstr ""
 
-#: exhibition/social_links.py:113
+#: social_links.py:113
 msgid "Vimeo"
 msgstr ""
 
-#: exhibition/social_links.py:120
+#: social_links.py:120
 msgid "VK"
 msgstr ""
 
-#: exhibition/social_links.py:127
+#: social_links.py:127
 msgid "Weibo"
 msgstr ""
 
-#: exhibition/social_links.py:134
+#: social_links.py:134
 msgid "X"
 msgstr ""
 
-#: exhibition/social_links.py:141
+#: social_links.py:141
 msgid "Xing"
 msgstr ""
 
-#: exhibition/social_links.py:148
+#: social_links.py:148
 msgid "YouTube"
 msgstr ""
 
-#: exhibition/social_links.py:155
+#: social_links.py:155
 msgid "YouTube Privacy"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:7
+#: templates/exhibitors/_email_outbox_body.html:7
 msgid "Created"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:14
+#: templates/exhibitors/_email_outbox_body.html:14
 msgid "Send selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:17
+#: templates/exhibitors/_email_outbox_body.html:17
 msgid "Discard selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:20
+#: templates/exhibitors/_email_outbox_body.html:20
 msgid "Send all"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:23
+#: templates/exhibitors/_email_outbox_body.html:23
 msgid "Discard all"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:35
+#: templates/exhibitors/_email_outbox_body.html:35
 msgid "Scheduled"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:36
-#: exhibition/templates/exhibitors/proposal_list.html:65
+#: templates/exhibitors/_email_outbox_body.html:36
+#: templates/exhibitors/proposal_list.html:65
 msgid "Actions"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:67
-msgid "Send this email"
+#: templates/exhibitors/_email_outbox_body.html:68
+msgid "Send"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:73
-msgid "Edit this email"
+#: templates/exhibitors/_email_outbox_body.html:75
+#: templates/exhibitors/_partner_row.html:54
+#: templates/exhibitors/call_questions.html:73
+#: templates/exhibitors/call_questions.html:76
+#: templates/exhibitors/dashboard.html:120
+#: templates/exhibitors/email_compose.html:55
+#: templates/exhibitors/email_custom_template_form.html:30
+#: templates/exhibitors/email_templates.html:50
+#: templates/exhibitors/email_templates.html:97
+#: templates/exhibitors/public_proposal_list.html:32
+#: templates/exhibitors/settings.html:59
+msgid "Edit"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:79
-msgid "Discard this email"
+#: templates/exhibitors/_email_outbox_body.html:82
+#: templates/exhibitors/email_bulk_discard.html:30
+#: templates/exhibitors/email_delete.html:31
+msgid "Discard"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:91
-#: exhibition/templates/exhibitors/_email_sent_body.html:34
+#: templates/exhibitors/_email_outbox_body.html:95
+#: templates/exhibitors/_email_sent_body.html:35
 msgid "No emails match your search."
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:93
+#: templates/exhibitors/_email_outbox_body.html:97
 msgid "The outbox is empty."
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_sent_body.html:7
-#: exhibition/templates/exhibitors/base.html:105
+#: templates/exhibitors/_email_sent_body.html:7
+#: templates/exhibitors/_partner_row.html:45 templates/exhibitors/base.html:116
 msgid "Sent"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_sent_body.html:36
+#: templates/exhibitors/_email_sent_body.html:37
 msgid "No emails have been sent yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:12
-#: exhibition/templates/exhibitors/public_list.html:29
+#: templates/exhibitors/_filter_form.html:12
+#: templates/exhibitors/public_list.html:29
 msgid "Search"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:18
-#: exhibition/templates/exhibitors/_filter_form.html:20
+#: templates/exhibitors/_filter_form.html:18
+#: templates/exhibitors/_filter_form.html:21
 msgid "Clear filters"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:29
+#: templates/exhibitors/_filter_form.html:30
 msgid "Filters"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:50
+#: templates/exhibitors/_filter_form.html:51
 msgid "Apply filters"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:5
+#: templates/exhibitors/_image_preview_dialog.html:11
+msgid "Close preview"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:5
 #, python-format
 msgid "Select %(name)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:33
+#: templates/exhibitors/_partner_row.html:33
 msgid "Untitled"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:40
+#: templates/exhibitors/_partner_row.html:40
+msgid "Waiting in the outbox"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:41
+msgid "In outbox"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:44
+#, python-format
+msgid "Last sent %(sent)s"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:48
+msgid "Not sent"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:55
 msgid "Copied!"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:40
+#: templates/exhibitors/_partner_row.html:55
 msgid "Copy failed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:40
+#: templates/exhibitors/_partner_row.html:55
 msgid "Key"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:41
-#: exhibition/templates/exhibitors/add.html:231
-#: exhibition/templates/exhibitors/vouchers.html:5
+#: templates/exhibitors/_partner_row.html:56 templates/exhibitors/add.html:235
+#: templates/exhibitors/base.html:42
+#: templates/exhibitors/exhibitor_info.html:95
+#: templates/exhibitors/exhibitor_info.html:125
+#: templates/exhibitors/vouchers.html:5 views.py:2933
 msgid "Vouchers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:42
-#: exhibition/templates/exhibitors/devices.html:5
+#: templates/exhibitors/_partner_row.html:57
+#: templates/exhibitors/devices.html:5
 msgid "Lead-scanning devices"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:45
+#: templates/exhibitors/_partner_row.html:58
+#: templates/exhibitors/call_question_delete.html:19
+#: templates/exhibitors/call_questions.html:74
+#: templates/exhibitors/delete.html:19
+#: templates/exhibitors/email_custom_template_delete.html:19
+#: templates/exhibitors/settings.html:335
+msgid "Delete"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:60
 msgid "Move"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_sort_header.html:7
+#: templates/exhibitors/_sort_header.html:7
 msgid "Sort ascending"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_sort_header.html:10
+#: templates/exhibitors/_sort_header.html:10
 msgid "Sort descending"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:24
+#: templates/exhibitors/add.html:24
 msgid "Profile"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:29
-#: exhibition/templates/exhibitors/add.html:92
-#: exhibition/templates/exhibitors/call_questions.html:62
-#: exhibition/templates/exhibitors/settings.html:50
+#: templates/exhibitors/add.html:29 templates/exhibitors/add.html:92
+#: templates/exhibitors/call_questions.html:62
+#: templates/exhibitors/settings.html:54
 msgid "Optional"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:80
-#: exhibition/templates/exhibitors/public_proposal_form.html:79
+#: templates/exhibitors/add.html:80
+#: templates/exhibitors/public_proposal_form.html:79
 msgid "Add social media link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:137
-#: exhibition/templates/exhibitors/public_proposal_form.html:120
+#: templates/exhibitors/add.html:137
+#: templates/exhibitors/public_proposal_form.html:120
 msgid "Add extra link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:157
-#: exhibition/templates/exhibitors/add.html:160
-#: exhibition/templates/exhibitors/public_proposal_form.html:140
-#: exhibition/templates/exhibitors/public_proposal_form.html:143
+#: templates/exhibitors/add.html:157 templates/exhibitors/add.html:161
+#: templates/exhibitors/public_proposal_form.html:140
+#: templates/exhibitors/public_proposal_form.html:144
 msgid "Logo preview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:162
-#: exhibition/templates/exhibitors/add.html:180
-#: exhibition/templates/exhibitors/public_proposal_form.html:145
-#: exhibition/templates/exhibitors/public_proposal_form.html:163
+#: templates/exhibitors/add.html:164 templates/exhibitors/add.html:184
+#: templates/exhibitors/public_proposal_form.html:147
+#: templates/exhibitors/public_proposal_form.html:167
 msgid "We could not load this image preview."
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:175
-#: exhibition/templates/exhibitors/add.html:178
-#: exhibition/templates/exhibitors/public_proposal_form.html:158
-#: exhibition/templates/exhibitors/public_proposal_form.html:161
+#: templates/exhibitors/add.html:177 templates/exhibitors/add.html:181
+#: templates/exhibitors/public_proposal_form.html:160
+#: templates/exhibitors/public_proposal_form.html:164
 msgid "Header image preview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:196
+#: templates/exhibitors/add.html:200
 msgid "Organizer only"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:237
+#: templates/exhibitors/add.html:241
 msgid "Internal notes"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:244
-#: exhibition/templates/exhibitors/email_edit.html:38
-#: exhibition/templates/exhibitors/public_proposal_form.html:182
-#: exhibition/templates/exhibitors/public_proposal_form.html:186
+#: templates/exhibitors/add.html:248 templates/exhibitors/email_edit.html:38
+#: templates/exhibitors/public_proposal_form.html:186
+#: templates/exhibitors/public_proposal_form.html:190
 msgid "Save changes"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:246
-#: exhibition/templates/exhibitors/call_default_field_form.html:21
-#: exhibition/templates/exhibitors/call_question_form.html:30
-#: exhibition/templates/exhibitors/call_questions.html:96
-#: exhibition/templates/exhibitors/email_custom_template_form.html:51
-#: exhibition/templates/exhibitors/email_templates.html:123
-#: exhibition/templates/exhibitors/proposal_detail.html:188
-#: exhibition/templates/exhibitors/settings.html:85
-#: exhibition/templates/exhibitors/settings.html:170
-#: exhibition/templates/exhibitors/settings.html:269
+#: templates/exhibitors/add.html:250
+#: templates/exhibitors/call_default_field_form.html:21
+#: templates/exhibitors/call_question_form.html:114
+#: templates/exhibitors/call_questions.html:96
+#: templates/exhibitors/email_custom_template_form.html:51
+#: templates/exhibitors/email_templates.html:123
+#: templates/exhibitors/proposal_detail.html:188
+#: templates/exhibitors/settings.html:89 templates/exhibitors/settings.html:217
+#: templates/exhibitors/settings.html:250
+#: templates/exhibitors/settings.html:359
 msgid "Save"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:255
-#: exhibition/templates/exhibitors/call_default_field_form.html:23
-#: exhibition/templates/exhibitors/call_default_field_reset.html:24
-#: exhibition/templates/exhibitors/call_question_delete.html:21
-#: exhibition/templates/exhibitors/call_question_form.html:32
-#: exhibition/templates/exhibitors/delete.html:24
-#: exhibition/templates/exhibitors/email_bulk_discard.html:27
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:21
-#: exhibition/templates/exhibitors/email_custom_template_form.html:53
-#: exhibition/templates/exhibitors/email_delete.html:28
-#: exhibition/templates/exhibitors/proposal_list.html:174
-#: exhibition/templates/exhibitors/public_proposal_form.html:176
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:16
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:21
-#: exhibition/templates/exhibitors/settings.html:194
-#: exhibition/templates/exhibitors/settings.html:270
+#: templates/exhibitors/add.html:259
+#: templates/exhibitors/call_default_field_form.html:23
+#: templates/exhibitors/call_default_field_reset.html:24
+#: templates/exhibitors/call_question_delete.html:21
+#: templates/exhibitors/call_question_form.html:116
+#: templates/exhibitors/delete.html:24
+#: templates/exhibitors/email_bulk_discard.html:27
+#: templates/exhibitors/email_custom_template_delete.html:21
+#: templates/exhibitors/email_custom_template_form.html:53
+#: templates/exhibitors/email_delete.html:28
+#: templates/exhibitors/proposal_list.html:175
+#: templates/exhibitors/public_proposal_form.html:180
+#: templates/exhibitors/public_proposal_reinstate.html:16
+#: templates/exhibitors/public_proposal_withdraw.html:21
+#: templates/exhibitors/settings.html:278
+#: templates/exhibitors/settings.html:360
+#: templates/exhibitors/voucher_bulk_send.html:96
 msgid "Cancel"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:262
-#: exhibition/templates/exhibitors/proposal_detail.html:208
+#: templates/exhibitors/add.html:266
+#: templates/exhibitors/proposal_detail.html:208
 msgid "History"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:11
+#: templates/exhibitors/base.html:17
 msgid "Overview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:18
-#: exhibition/templates/exhibitors/call_questions.html:33
+#: templates/exhibitors/base.html:24
+#: templates/exhibitors/call_questions.html:33
 msgid "Settings"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:26
-#: exhibition/templates/exhibitors/base.html:70
-#: exhibition/templates/exhibitors/dashboard.html:21
-#: exhibition/templates/exhibitors/exhibitor_info.html:4
-#: exhibition/templates/exhibitors/exhibitor_info.html:15
+#: templates/exhibitors/base.html:32 templates/exhibitors/base.html:81
+#: templates/exhibitors/dashboard.html:21
+#: templates/exhibitors/exhibitor_info.html:4
+#: templates/exhibitors/exhibitor_info.html:15
 msgid "Exhibitors"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:31
-#: exhibition/templates/exhibitors/base.html:76
-#: exhibition/templates/exhibitors/dashboard.html:29
-#: exhibition/templates/exhibitors/exhibitor_info.html:4
-#: exhibition/templates/exhibitors/exhibitor_info.html:15
+#: templates/exhibitors/base.html:37 templates/exhibitors/base.html:87
+#: templates/exhibitors/dashboard.html:29
+#: templates/exhibitors/exhibitor_info.html:4
+#: templates/exhibitors/exhibitor_info.html:15
 msgid "Sponsors"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:39
-#: exhibition/templates/exhibitors/dashboard.html:117
+#: templates/exhibitors/base.html:50 templates/exhibitors/dashboard.html:117
 msgid "Call for exhibitors"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:47
+#: templates/exhibitors/base.html:58
 msgid "Content"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:52
-#: exhibition/templates/exhibitors/call_questions.html:5
-#: exhibition/templates/exhibitors/call_questions.html:16
+#: templates/exhibitors/base.html:63 templates/exhibitors/call_questions.html:5
+#: templates/exhibitors/call_questions.html:16
 msgid "Exhibitor form"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:85
+#: templates/exhibitors/base.html:96
 msgid "Message center"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:94
+#: templates/exhibitors/base.html:105
 msgid "Compose"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:99
+#: templates/exhibitors/base.html:110
 msgid "Outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:111
+#: templates/exhibitors/base.html:122
 msgid "Templates"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:130
+#: templates/exhibitors/base.html:141
 msgid "Home"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:134
+#: templates/exhibitors/base.html:145
 msgid "Tickets"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:138
+#: templates/exhibitors/base.html:149
 msgid "Talks"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:143
+#: templates/exhibitors/base.html:154
 msgid "Access videos related to this event"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:144
+#: templates/exhibitors/base.html:155
 msgid "Videos"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_form.html:5
-#: exhibition/templates/exhibitors/call_default_field_form.html:8
-#: exhibition/templates/exhibitors/call_question_form.html:11
-#: exhibition/templates/exhibitors/call_question_form.html:14
+#: templates/exhibitors/call_default_field_form.html:5
+#: templates/exhibitors/call_default_field_form.html:8
+#: templates/exhibitors/call_question_form.html:14
+#: templates/exhibitors/call_question_form.html:17
 msgid "Form field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:4
-#: exhibition/templates/exhibitors/call_default_field_reset.html:7
+#: templates/exhibitors/call_default_field_reset.html:4
+#: templates/exhibitors/call_default_field_reset.html:7
 msgid "Reset form field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:14
+#: templates/exhibitors/call_default_field_reset.html:14
 #, python-format
 msgid ""
 "Are you sure you want to reset \"%(label)s\" back to the default "
 "\"%(default_label)s\"?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:19
+#: templates/exhibitors/call_default_field_reset.html:19
 msgid ""
 "This clears the custom label and help text. Default fields are part of the "
 "form and cannot be deleted; turn the field off with the Active toggle to "
 "hide it."
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:22
-#: exhibition/templates/exhibitors/public_list.html:32
+#: templates/exhibitors/call_default_field_reset.html:22
 msgid "Reset"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_question_delete.html:4
-#: exhibition/templates/exhibitors/call_question_delete.html:7
+#: templates/exhibitors/call_question_delete.html:4
+#: templates/exhibitors/call_question_delete.html:7
 msgid "Delete form field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_question_delete.html:14
+#: templates/exhibitors/call_question_delete.html:14
 #, python-format
 msgid "Are you sure you want to delete the question \"%(question)s\"?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_question_delete.html:19
-#: exhibition/templates/exhibitors/call_questions.html:74
-#: exhibition/templates/exhibitors/delete.html:19
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:19
-msgid "Delete"
+#: templates/exhibitors/call_question_form.html:31
+msgid "Answer options"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:23
+#: templates/exhibitors/call_question_form.html:34
+msgid "Only applicable if you choose a choice field type above."
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:48
+#, python-format
+msgid "Answer option %(id)s"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:56
+#: templates/exhibitors/call_question_form.html:58
+#: templates/exhibitors/call_question_form.html:87
+#: templates/exhibitors/call_question_form.html:89
+msgid "Move option up"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:60
+#: templates/exhibitors/call_question_form.html:62
+#: templates/exhibitors/call_question_form.html:91
+#: templates/exhibitors/call_question_form.html:93
+msgid "Move option down"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:64
+#: templates/exhibitors/call_question_form.html:66
+#: templates/exhibitors/call_question_form.html:95
+#: templates/exhibitors/call_question_form.html:97
+msgid "Delete option"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:81
+msgid "New answer option"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:106
+msgid "Add a new option"
+msgstr ""
+
+#: templates/exhibitors/call_questions.html:23
 msgid "Form fields"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:24
+#: templates/exhibitors/call_questions.html:24
 msgid ""
 "Choose which fields are shown on the exhibitor form and drag any row to "
 "reorder it."
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:29
-#: exhibition/templates/exhibitors/proposal_detail.html:38
+#: templates/exhibitors/call_questions.html:29
+#: templates/exhibitors/proposal_detail.html:38
 msgid "Field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:32
+#: templates/exhibitors/call_questions.html:32
 msgid "Answers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:42
+#: templates/exhibitors/call_questions.html:42
 msgid "Custom"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:48
+#: templates/exhibitors/call_questions.html:48
 #, python-format
 msgid "Toggle active state for %(field)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:61
+#: templates/exhibitors/call_questions.html:61
 #, python-format
 msgid "Required status for %(field)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:73
-#: exhibition/templates/exhibitors/call_questions.html:76
-#: exhibition/templates/exhibitors/dashboard.html:120
-#: exhibition/templates/exhibitors/email_compose.html:55
-#: exhibition/templates/exhibitors/email_custom_template_form.html:30
-#: exhibition/templates/exhibitors/email_templates.html:50
-#: exhibition/templates/exhibitors/email_templates.html:97
-#: exhibition/templates/exhibitors/public_proposal_list.html:32
-#: exhibition/templates/exhibitors/settings.html:55
-msgid "Edit"
-msgstr ""
-
-#: exhibition/templates/exhibitors/call_questions.html:77
+#: templates/exhibitors/call_questions.html:77
 msgid "Reset to default"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:79
+#: templates/exhibitors/call_questions.html:79
 msgid "Move field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:90
+#: templates/exhibitors/call_questions.html:90
 msgid "New custom field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:5
-#: exhibition/templates/exhibitors/dashboard.html:9
+#: templates/exhibitors/dashboard.html:5 templates/exhibitors/dashboard.html:9
 msgid "Exhibition overview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:39
+#: templates/exhibitors/dashboard.html:39
 msgid "Requests awaiting review"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:48
+#: templates/exhibitors/dashboard.html:48
 msgid "Emails in outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:61
+#: templates/exhibitors/dashboard.html:61
 msgid "Recent requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:64
+#: templates/exhibitors/dashboard.html:64
 msgid "View all"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:76
+#: templates/exhibitors/dashboard.html:76
 msgid "Submitted"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:91
-#: exhibition/templates/exhibitors/proposal_detail.html:97
-#: exhibition/templates/exhibitors/proposal_list.html:97
+#: templates/exhibitors/dashboard.html:91
+#: templates/exhibitors/proposal_detail.html:97
+#: templates/exhibitors/proposal_list.html:97
 msgid "Sponsor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:93
-#: exhibition/templates/exhibitors/proposal_detail.html:99
-#: exhibition/templates/exhibitors/proposal_list.html:99
+#: templates/exhibitors/dashboard.html:93
+#: templates/exhibitors/proposal_detail.html:99
+#: templates/exhibitors/proposal_list.html:99
 msgid "Exhibitor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:105
+#: templates/exhibitors/dashboard.html:105
 msgid "No requests have been submitted yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:128
+#: templates/exhibitors/dashboard.html:128
 msgid "The call is not published, so nobody can submit a request."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:131
+#: templates/exhibitors/dashboard.html:131
 msgid "Open"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:134
+#: templates/exhibitors/dashboard.html:134
 #, python-format
 msgid "Closes on %(deadline)s."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:139
+#: templates/exhibitors/dashboard.html:139
 msgid "No deadline set."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:142
+#: templates/exhibitors/dashboard.html:142
 msgid "Closed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:144
+#: templates/exhibitors/dashboard.html:144
 #, python-format
 msgid "The deadline passed on %(deadline)s."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:151
+#: templates/exhibitors/dashboard.html:151
 msgid "Private — reachable only with the secret link."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:157
-#: exhibition/templates/exhibitors/settings.html:90
-#: exhibition/templates/exhibitors/settings.html:94
+#: templates/exhibitors/dashboard.html:157
+#: templates/exhibitors/settings.html:94 templates/exhibitors/settings.html:98
 msgid "View call page"
 msgstr ""
 
-#: exhibition/templates/exhibitors/delete.html:11
+#: templates/exhibitors/delete.html:11
 #, python-format
 msgid ""
 "Are you sure you want to delete “%(name)s”? This action cannot be undone."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:8
+#: templates/exhibitors/devices.html:8
 #, python-format
 msgid "Lead-scanning devices for %(name)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:13
+#: templates/exhibitors/devices.html:13
 #, python-brace-format
 msgid ""
 "Provision check-in app devices for this partner. Each device gets its own "
@@ -1673,66 +1707,64 @@ msgid ""
 "through the {device_tokens} placeholder."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:21
+#: templates/exhibitors/devices.html:21
 msgid ""
 "Provisioning devices requires organizer-level permissions. Ask an organizer "
 "admin to create the devices for this partner."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:29
+#: templates/exhibitors/devices.html:29
 msgid "Provisioned devices"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:35
+#: templates/exhibitors/devices.html:35
 msgid "Device"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:36
+#: templates/exhibitors/devices.html:36
 msgid "Setup token"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:37
+#: templates/exhibitors/devices.html:37
 msgid "Status"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:47
+#: templates/exhibitors/devices.html:47
 msgid "Connected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:49
+#: templates/exhibitors/devices.html:49
 msgid "Awaiting setup"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:60
+#: templates/exhibitors/devices.html:60
 msgid ""
 "Generate new setup tokens? Any device that is already scanning will be "
 "disconnected and must be set up again."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:65
+#: templates/exhibitors/devices.html:65
 msgid "Generate new setup tokens"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:70
+#: templates/exhibitors/devices.html:70
 msgid "No devices have been provisioned for this partner yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:80
-#: exhibition/templates/exhibitors/devices.html:85
+#: templates/exhibitors/devices.html:80 templates/exhibitors/devices.html:85
 msgid "Add devices"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:87
-#: exhibition/templates/exhibitors/vouchers.html:88
+#: templates/exhibitors/devices.html:87 templates/exhibitors/vouchers.html:133
 msgid "Back"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_bulk_discard.html:4
-#: exhibition/templates/exhibitors/email_bulk_discard.html:7
+#: templates/exhibitors/email_bulk_discard.html:4
+#: templates/exhibitors/email_bulk_discard.html:7
 msgid "Discard emails"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_bulk_discard.html:19
+#: templates/exhibitors/email_bulk_discard.html:19
 #, python-format
 msgid ""
 "Are you sure you want to discard %(counter)s queued email? This cannot be "
@@ -1743,80 +1775,80 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/templates/exhibitors/email_bulk_discard.html:30
-#: exhibition/templates/exhibitors/email_delete.html:31
-msgid "Discard"
-msgstr ""
-
-#: exhibition/templates/exhibitors/email_compose.html:7
-#: exhibition/templates/exhibitors/email_compose.html:16
+#: templates/exhibitors/email_compose.html:7
+#: templates/exhibitors/email_compose.html:16
 msgid "Compose email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:21
+#: templates/exhibitors/email_compose.html:21
 msgid ""
 "Send an update to a group of applicants. One email is queued per recipient, "
 "with placeholders resolved individually."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:26
+#: templates/exhibitors/email_compose.html:26
 msgid "Load from template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:28
+#: templates/exhibitors/email_compose.html:28
 msgid "Select a saved template…"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:33
+#: templates/exhibitors/email_compose.html:33
 msgid "Load"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:41
-#: exhibition/templates/exhibitors/email_edit.html:23
+#: templates/exhibitors/email_compose.html:41
+#: templates/exhibitors/email_edit.html:23
 msgid "Recipients"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:47
+#: templates/exhibitors/email_compose.html:47
 msgid "Message"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:58
-#: exhibition/templates/exhibitors/email_custom_template_form.html:33
-#: exhibition/templates/exhibitors/email_templates.html:53
-#: exhibition/templates/exhibitors/email_templates.html:100
-#: exhibition/templates/exhibitors/settings.html:58
+#: templates/exhibitors/email_compose.html:51
+msgctxt "form"
+msgid "required"
+msgstr ""
+
+#: templates/exhibitors/email_compose.html:58
+#: templates/exhibitors/email_custom_template_form.html:33
+#: templates/exhibitors/email_templates.html:53
+#: templates/exhibitors/email_templates.html:100
+#: templates/exhibitors/settings.html:62
 msgid "Preview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:80
+#: templates/exhibitors/email_compose.html:80
 msgid "Save to outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:83
+#: templates/exhibitors/email_compose.html:83
 msgid "Send / Schedule"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:4
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:7
+#: templates/exhibitors/email_custom_template_delete.html:4
+#: templates/exhibitors/email_custom_template_delete.html:7
 msgid "Delete custom template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:14
+#: templates/exhibitors/email_custom_template_delete.html:14
 #, python-format
 msgid "Are you sure you want to delete the custom template \"%(name)s\"?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_custom_template_form.html:7
-#: exhibition/templates/exhibitors/email_custom_template_form.html:15
+#: templates/exhibitors/email_custom_template_form.html:7
+#: templates/exhibitors/email_custom_template_form.html:15
 msgid "Custom template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_delete.html:4
-#: exhibition/templates/exhibitors/email_delete.html:7
+#: templates/exhibitors/email_delete.html:4
+#: templates/exhibitors/email_delete.html:7
 msgid "Discard email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_delete.html:15
+#: templates/exhibitors/email_delete.html:15
 #, python-format
 msgid ""
 "Are you sure you want to discard the email “%(subject)s” to %(counter)s "
@@ -1827,908 +1859,1184 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/templates/exhibitors/email_delete.html:21
+#: templates/exhibitors/email_delete.html:21
 #, python-format
 msgid ""
 "Are you sure you want to discard the email “%(subject)s” to %(to)s? This "
 "cannot be undone."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:5
+#: templates/exhibitors/email_edit.html:5
 msgid "Edit email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:8
+#: templates/exhibitors/email_edit.html:8
 msgid "Preview / edit email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:14
+#: templates/exhibitors/email_edit.html:14
 msgid "Back to outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:41
+#: templates/exhibitors/email_edit.html:41
 msgid "Save & send"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_outbox.html:12
-#: exhibition/templates/exhibitors/email_outbox.html:15
+#: templates/exhibitors/email_outbox.html:12
+#: templates/exhibitors/email_outbox.html:15
 msgid "Email outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_outbox.html:20
+#: templates/exhibitors/email_outbox.html:20
 msgid ""
 "Emails waiting to be sent. Review, edit, or discard them before sending."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_sent.html:12
-#: exhibition/templates/exhibitors/email_sent.html:15
+#: templates/exhibitors/email_sent.html:12
+#: templates/exhibitors/email_sent.html:15
 msgid "Sent emails"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:7
-#: exhibition/templates/exhibitors/email_templates.html:16
+#: templates/exhibitors/email_templates.html:7
+#: templates/exhibitors/email_templates.html:16
 msgid "Email templates"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:22
+#: templates/exhibitors/email_templates.html:22
 msgid "New template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:27
+#: templates/exhibitors/email_templates.html:27
 msgid ""
 "These templates are used for the confirmation email sent when an applicant "
 "submits a request, and for the accept/reject emails you send from the outbox."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:81
+#: templates/exhibitors/email_templates.html:81
 msgid "Discard this template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:31
+#: templates/exhibitors/exhibitor_info.html:31
 msgid "No organizations match your filters."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:33
+#: templates/exhibitors/exhibitor_info.html:33
 msgid "You don't have any sponsors yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:35
+#: templates/exhibitors/exhibitor_info.html:35
 msgid "You don't have any exhibitors yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:37
+#: templates/exhibitors/exhibitor_info.html:37
 msgid "You don't have any exhibitors or sponsors yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:43
-#: exhibition/templates/exhibitors/exhibitor_info.html:52
-#: exhibition/views.py:1837
+#: templates/exhibitors/exhibitor_info.html:43
+#: templates/exhibitors/exhibitor_info.html:57 views.py:1979
 msgid "Add a Sponsor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:43
-#: exhibition/templates/exhibitors/exhibitor_info.html:52
-#: exhibition/views.py:1838
+#: templates/exhibitors/exhibitor_info.html:43
+#: templates/exhibitors/exhibitor_info.html:57 views.py:1980
 msgid "Add an Exhibitor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:43
-#: exhibition/templates/exhibitors/exhibitor_info.html:52
-#: exhibition/views.py:1839
+#: templates/exhibitors/exhibitor_info.html:43
+#: templates/exhibitors/exhibitor_info.html:57 views.py:1981
 msgid "Add an Exhibitor or Sponsor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:48
-#: exhibition/templates/exhibitors/proposal_list.html:169
+#: templates/exhibitors/exhibitor_info.html:48
+#: templates/exhibitors/proposal_list.html:170
 msgid "selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:54
+#: templates/exhibitors/exhibitor_info.html:59
 msgid "Download access keys as CSV"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:56
+#: templates/exhibitors/exhibitor_info.html:61
 msgid "Download sponsor keys"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:56
+#: templates/exhibitors/exhibitor_info.html:61
 msgid "Download exhibitor keys"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:56
+#: templates/exhibitors/exhibitor_info.html:61
 msgid "Download access keys"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:65
+#: templates/exhibitors/exhibitor_info.html:64
+msgid "Queue a voucher email for everyone in this list"
+msgstr ""
+
+#: templates/exhibitors/exhibitor_info.html:65
+msgid "Send vouchers to all"
+msgstr ""
+
+#: templates/exhibitors/exhibitor_info.html:75
 msgid ""
 "Drag-and-drop ordering is available only on the unfiltered, single-page list."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:70
+#: templates/exhibitors/exhibitor_info.html:80
 msgid "Booth"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:78
-#: exhibition/templates/exhibitors/exhibitor_info.html:106
+#: templates/exhibitors/exhibitor_info.html:88
+#: templates/exhibitors/exhibitor_info.html:117
 msgid "Select all partners"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:84
-#: exhibition/templates/exhibitors/exhibitor_info.html:112
+#: templates/exhibitors/exhibitor_info.html:94
+#: templates/exhibitors/exhibitor_info.html:123
 msgid "Group"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:12
-#: exhibition/templates/exhibitors/proposal_detail.html:15
+#: templates/exhibitors/proposal_detail.html:12
+#: templates/exhibitors/proposal_detail.html:15
 msgid "Review exhibition request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:21
+#: templates/exhibitors/proposal_detail.html:21
 msgid "Back to exhibition requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:29
+#: templates/exhibitors/proposal_detail.html:29
 #, python-format
 msgid "Changes made by the applicant after acceptance (%(when)s)"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:39
+#: templates/exhibitors/proposal_detail.html:39
 msgid "Before acceptance"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:40
+#: templates/exhibitors/proposal_detail.html:40
 msgid "After edit"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:55
+#: templates/exhibitors/proposal_detail.html:55
 msgid "The applicant edited the profile, but the tracked fields are unchanged."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:57
+#: templates/exhibitors/proposal_detail.html:57
 msgid ""
 "This profile was edited before change tracking was available, so the "
 "original values are not recorded."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:69
-#: exhibition/templates/exhibitors/proposal_list.html:20
+#: templates/exhibitors/proposal_detail.html:69
+#: templates/exhibitors/proposal_list.html:20
 msgid "Submitter"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:80
+#: templates/exhibitors/proposal_detail.html:80
 msgid "Hidden"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:121
+#: templates/exhibitors/proposal_detail.html:121
 msgid "Message to organizers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:129
+#: templates/exhibitors/proposal_detail.html:129
 msgid "Links"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:152
+#: templates/exhibitors/proposal_detail.html:152
 msgid "Download"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:154
+#: templates/exhibitors/proposal_detail.html:154
 msgid "Custom answers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:176
+#: templates/exhibitors/proposal_detail.html:176
 msgid "Review"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:192
-#: exhibition/templates/exhibitors/proposal_list.html:117
-#: exhibition/templates/exhibitors/proposal_list.html:164
+#: templates/exhibitors/proposal_detail.html:192
+#: templates/exhibitors/proposal_list.html:118
+#: templates/exhibitors/proposal_list.html:165
 msgid "Approve"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:195
-#: exhibition/templates/exhibitors/proposal_list.html:122
-#: exhibition/templates/exhibitors/proposal_list.html:165
+#: templates/exhibitors/proposal_detail.html:195
+#: templates/exhibitors/proposal_list.html:123
+#: templates/exhibitors/proposal_list.html:166
 msgid "Reject"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:200
+#: templates/exhibitors/proposal_detail.html:200
 msgid "Open profile"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:22
+#: templates/exhibitors/proposal_list.html:22
 msgid "Updated"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:33
+#: templates/exhibitors/proposal_list.html:33
 msgid "Select at least one request."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:34
+#: templates/exhibitors/proposal_list.html:34
 msgid "None of the selected requests can be approved."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:35
+#: templates/exhibitors/proposal_list.html:35
 msgid "None of the selected requests can be rejected."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:36
+#: templates/exhibitors/proposal_list.html:36
 #, python-brace-format
 msgid "{count} selected requests cannot be approved and will be skipped."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:37
+#: templates/exhibitors/proposal_list.html:37
 #, python-brace-format
 msgid "{count} selected requests cannot be rejected and will be skipped."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:41
+#: templates/exhibitors/proposal_list.html:41
 msgid "Approve selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:44
+#: templates/exhibitors/proposal_list.html:44
 msgid "Reject selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:55
+#: templates/exhibitors/proposal_list.html:55
 msgid "Select all matching requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:75
+#: templates/exhibitors/proposal_list.html:75
 msgid "Select request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:106
+#: templates/exhibitors/proposal_list.html:106
 msgid "Edited after acceptance, see detail view for changes."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:127
-#: exhibition/templates/exhibitors/proposal_list.html:166
-#: exhibition/templates/exhibitors/public_proposal_list.html:39
+#: templates/exhibitors/proposal_list.html:128
+#: templates/exhibitors/proposal_list.html:167
+#: templates/exhibitors/public_proposal_list.html:39
 msgid "Withdraw"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:132
-#: exhibition/templates/exhibitors/proposal_list.html:167
+#: templates/exhibitors/proposal_list.html:133
+#: templates/exhibitors/proposal_list.html:168
 msgid "Reopen for review"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:137
-#: exhibition/templates/exhibitors/public_proposal_list.html:34
+#: templates/exhibitors/proposal_list.html:138
+#: templates/exhibitors/public_proposal_list.html:34
 msgid "View"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:149
+#: templates/exhibitors/proposal_list.html:150
 msgid "No exhibition requests match your filters."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:151
+#: templates/exhibitors/proposal_list.html:152
 msgid "No exhibition requests have been submitted yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:159
+#: templates/exhibitors/proposal_list.html:160
 msgid "Approve the selected requests and create their partner profiles?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:160
+#: templates/exhibitors/proposal_list.html:161
 msgid "Reject the selected requests?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:161
+#: templates/exhibitors/proposal_list.html:162
 msgid "Reject this request?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:162
+#: templates/exhibitors/proposal_list.html:163
 msgid "Withdraw this request?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:163
+#: templates/exhibitors/proposal_list.html:164
 msgid "Reopen this request for review?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:168
+#: templates/exhibitors/proposal_list.html:169
 msgid "The action could not be completed. Please try again."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:170
+#: templates/exhibitors/proposal_list.html:171
 msgid ""
 "Approve every request matching the current filters, including those on other "
 "pages?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:171
+#: templates/exhibitors/proposal_list.html:172
 msgid ""
 "Reject every request matching the current filters, including those on other "
 "pages?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:172
+#: templates/exhibitors/proposal_list.html:173
 msgid "Please confirm"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:173
+#: templates/exhibitors/proposal_list.html:174
 msgid "Confirm"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:14
+#: templates/exhibitors/public_call.html:14
 msgid "Submit a request to become an exhibitor for this event."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:20
+#: templates/exhibitors/public_call.html:20
 #, python-format
 msgid "You can submit requests until %(deadline)s (%(timezone)s)."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:24
+#: templates/exhibitors/public_call.html:24
 #, python-format
 msgid "This call closed on %(deadline)s (%(timezone)s)."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:34
+#: templates/exhibitors/public_call.html:34
 msgid "View your requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:40
-#: exhibition/templates/exhibitors/public_proposal_form.html:18
-#: exhibition/templates/exhibitors/public_proposal_list.html:65
+#: templates/exhibitors/public_call.html:40
+#: templates/exhibitors/public_proposal_form.html:18
+#: templates/exhibitors/public_proposal_list.html:65
 msgid "Submit a request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:42
+#: templates/exhibitors/public_call.html:42
 msgid "Requests are closed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:21
-#: exhibition/templates/exhibitors/public_detail.html:94
+#: templates/exhibitors/public_detail.html:21
+#: templates/exhibitors/public_detail.html:93
 msgid "Previous"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:24
-#: exhibition/templates/exhibitors/public_detail.html:98
+#: templates/exhibitors/public_detail.html:24
+#: templates/exhibitors/public_detail.html:97
 msgid "Next"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:47
+#: templates/exhibitors/public_detail.html:47
 msgid "Get In Touch"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:87
-#: exhibition/templates/exhibitors/public_detail.html:103
+#: templates/exhibitors/public_detail.html:87
+#: templates/exhibitors/public_detail.html:102
 msgid "Open slides PDF"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:88
-#, python-brace-format
-msgid "Slide {current} of {total}"
-msgstr ""
-
-#: exhibition/templates/exhibitors/public_detail.html:112
+#: templates/exhibitors/public_detail.html:111
 msgid "Send email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:126
+#: templates/exhibitors/public_detail.html:125
 msgid "Visit website"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_list.html:54
+#: templates/exhibitors/public_list.html:32
+msgid "Clear"
+msgstr ""
+
+#: templates/exhibitors/public_list.html:54
 msgid "No exhibitors match your search."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_list.html:56
+#: templates/exhibitors/public_list.html:56
 msgid "No exhibitors are currently available."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:16
+#: templates/exhibitors/public_proposal_form.html:16
 msgid "Edit request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:23
-#: exhibition/views.py:883
+#: templates/exhibitors/public_proposal_form.html:23 views.py:958
 msgid "This request can no longer be edited."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:186
+#: templates/exhibitors/public_proposal_form.html:190
 msgid "Submit request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:189
+#: templates/exhibitors/public_proposal_form.html:193
 msgid "or save as draft for now"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:199
+#: templates/exhibitors/public_proposal_form.html:203
 msgid "Back to your requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:5
+#: templates/exhibitors/public_proposal_list.html:5
 msgid "Your exhibition requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:13
+#: templates/exhibitors/public_proposal_list.html:13
 msgid "Last modified"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:23
+#: templates/exhibitors/public_proposal_list.html:23
 msgid "Withdrawn"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:44
+#: templates/exhibitors/public_proposal_list.html:44
 msgid "Reinstate"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:56
+#: templates/exhibitors/public_proposal_list.html:56
 msgid "Create a new request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:61
+#: templates/exhibitors/public_proposal_list.html:61
 msgid "You have not submitted an exhibition request yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:5
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:21
+#: templates/exhibitors/public_proposal_reinstate.html:5
+#: templates/exhibitors/public_proposal_reinstate.html:21
 msgid "Reinstate request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:7
+#: templates/exhibitors/public_proposal_reinstate.html:7
 #, python-format
 msgid ""
 "Do you want to reinstate your withdrawn request “%(name)s”? It will be "
 "pending review again."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:5
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:26
+#: templates/exhibitors/public_proposal_withdraw.html:5
+#: templates/exhibitors/public_proposal_withdraw.html:26
 msgid "Withdraw request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:7
+#: templates/exhibitors/public_proposal_withdraw.html:7
 #, python-format
 msgid "Are you sure you want to withdraw your request “%(name)s”?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:13
+#: templates/exhibitors/public_proposal_withdraw.html:13
 msgid ""
 "This request has already been approved. Withdrawing it will hide the "
 "exhibitor or sponsor profile created from it from public listings."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:10
-#: exhibition/templates/exhibitors/settings.html:27
+#: templates/exhibitors/settings.html:10 templates/exhibitors/settings.html:29
 msgid "Sponsor Settings"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:12
-#: exhibition/templates/exhibitors/settings.html:29
+#: templates/exhibitors/settings.html:12 templates/exhibitors/settings.html:31
+msgid "Voucher Settings"
+msgstr ""
+
+#: templates/exhibitors/settings.html:14 templates/exhibitors/settings.html:33
 msgid "Exhibitor Settings"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:42
+#: templates/exhibitors/settings.html:46
 msgid "Publish your call"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:43
+#: templates/exhibitors/settings.html:47
 msgid "Publish a login-required application form for exhibitors."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:72
+#: templates/exhibitors/settings.html:76
 msgid ""
 "This panel renders unsaved draft text using the same styling as the live "
 "public call page."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:104
+#: templates/exhibitors/settings.html:108
 msgid "Secret call link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:107
+#: templates/exhibitors/settings.html:111
 msgid ""
 "This call is private: it is not linked anywhere public. Share the link below "
 "with the organizations you want to invite. Anyone who has it can open the "
 "call and apply."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:113
+#: templates/exhibitors/settings.html:117
 msgid "Copied"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:113
+#: templates/exhibitors/settings.html:117
 msgid "Copy to clipboard"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:114
+#: templates/exhibitors/settings.html:118
 msgid "Copy"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:119
+#: templates/exhibitors/settings.html:123
 msgid ""
 "Regenerate the secret link? The current link will stop working immediately."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:125
+#: templates/exhibitors/settings.html:129
 msgid "Regenerate link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:127
+#: templates/exhibitors/settings.html:131
 msgid "Regenerating immediately invalidates the current link."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:138
+#: templates/exhibitors/settings.html:143
+msgid "Voucher pools"
+msgstr ""
+
+#: templates/exhibitors/settings.html:147
+msgid ""
+"Create the voucher codes under Tickets → Vouchers and give them a tag, then "
+"pick that tag here. Exhibitors and sponsors are handed codes from the pool "
+"you choose. Reload this page to pick up a tag you just created."
+msgstr ""
+
+#: templates/exhibitors/settings.html:157
+msgid "Create vouchers pool"
+msgstr ""
+
+#: templates/exhibitors/settings.html:159
+msgid "(opens in a new tab)"
+msgstr ""
+
+#: templates/exhibitors/settings.html:168
+#: templates/exhibitors/settings.html:182
+#, python-format
+msgid "%(counter)s voucher in this pool is not assigned to anyone yet."
+msgid_plural ""
+"%(counter)s vouchers in this pool are not assigned to anyone yet."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: templates/exhibitors/settings.html:194
+msgid "How many each one gets"
+msgstr ""
+
+#: templates/exhibitors/settings.html:196
+msgid ""
+"Applies to any exhibitor or sponsor that does not belong to a sponsor group. "
+"Sponsor groups set their own number on the Sponsors page, and an individual "
+"exhibitor or sponsor can be given a different number on their own voucher "
+"page."
+msgstr ""
+
+#: templates/exhibitors/settings.html:206
+msgid "Voucher email"
+msgstr ""
+
+#: templates/exhibitors/settings.html:208
+msgid "Applies to the voucher email sent to exhibitors and sponsors alike."
+msgstr ""
+
+#: templates/exhibitors/settings.html:228
 msgid "Data access"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:139
+#: templates/exhibitors/settings.html:229
 msgid ""
 "In this section, you can control which attendee data is shared with "
 "exhibitors when an exhibitor voucher is used or when the exhibitor uses the "
 "lead scanning app."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:142
+#: templates/exhibitors/settings.html:232
 msgid "Exhibitor vouchers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:158
-msgid "Exhibitor login"
-msgstr ""
-
-#: exhibition/templates/exhibitors/settings.html:160
-msgid ""
-"The access-code email sent to exhibitors is now edited together with the "
-"plugin's other email templates."
-msgstr ""
-
-#: exhibition/templates/exhibitors/settings.html:162
-msgid "Edit email templates"
-msgstr ""
-
-#: exhibition/templates/exhibitors/settings.html:177
+#: templates/exhibitors/settings.html:257
 msgid "Group List"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:180
+#: templates/exhibitors/settings.html:260
 msgid "Add a Group"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:193
+#: templates/exhibitors/settings.html:272
+#: templates/exhibitors/settings.html:354
+msgid "Voucher defaults for this group"
+msgstr ""
+
+#: templates/exhibitors/settings.html:277
 msgid "Add"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:204
+#: templates/exhibitors/settings.html:288
 msgid "Group Name"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:206
+#: templates/exhibitors/settings.html:290
 msgid "Partners"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:207
+#: templates/exhibitors/settings.html:291
 msgid "Front Page"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:220
-#: exhibition/templates/exhibitors/settings.html:226
+#: templates/exhibitors/settings.html:304
+#: templates/exhibitors/settings.html:310
 msgid "Show this sponsor group in the Supported By section on the front page."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:251
+#: templates/exhibitors/settings.html:326
+msgid "Edit sponsor group"
+msgstr ""
+
+#: templates/exhibitors/settings.html:337
 msgid "Reorder sponsor group"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:281
+#: templates/exhibitors/settings.html:371
 msgid "You do not have any sponsor groups yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:8
+#: templates/exhibitors/voucher_bulk_send.html:4
+#: templates/exhibitors/voucher_bulk_send.html:7
+msgid "Send vouchers"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:18
+#, python-format
+msgid "A voucher email will be placed in the outbox for %(counter)s sponsor."
+msgid_plural ""
+"A voucher email will be placed in the outbox for %(counter)s sponsors."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:24
+#, python-format
+msgid "A voucher email will be placed in the outbox for %(counter)s exhibitor."
+msgid_plural ""
+"A voucher email will be placed in the outbox for %(counter)s exhibitors."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:37
+#, python-format
+msgid "&mdash; %(counter)s voucher will be created"
+msgid_plural "&mdash; %(counter)s vouchers will be created"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:45
+#, python-format
+msgid "&mdash; %(counter)s existing voucher"
+msgid_plural "&mdash; %(counter)s existing vouchers"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:58
+msgid "None of the sponsors in this list can be emailed yet."
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:60
+msgid "None of the exhibitors in this list can be emailed yet."
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:66
+msgid "Skipped: no email address"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:75
+msgid "Skipped: voucher count is set to 0"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:84
+msgid "Skipped: no vouchers available from their pool"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:86
+msgid ""
+"Check that a voucher pool is selected under Settings → Vouchers and that it "
+"still has unassigned codes."
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:99
+msgid "Queue emails"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:8
 #, python-format
 msgid "Vouchers for %(name)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:13
+#: templates/exhibitors/vouchers.html:13
 msgid ""
-"Issue ticket vouchers for this partner to hand out. Whoever redeems one on "
-"the ticket shop becomes a lead this partner can retrieve, as long as voucher "
+"Hand this exhibitor or sponsor codes from the voucher pool. Whoever redeems "
+"one on the ticket shop becomes a lead they can retrieve, as long as voucher "
 "data access is enabled for them."
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:20
-msgid "Issued vouchers"
+#: templates/exhibitors/vouchers.html:20
+msgid "Assigned vouchers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:24
+#: templates/exhibitors/vouchers.html:24
 msgid "Download codes (CSV)"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:31
+#: templates/exhibitors/vouchers.html:31
 msgid "Code"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:32 exhibition/views.py:1994
+#: templates/exhibitors/vouchers.html:32 utils.py:495
 msgid "Product"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:34 exhibition/views.py:1998
+#: templates/exhibitors/vouchers.html:33 utils.py:496
+msgid "Price effect"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:34 utils.py:499
 msgid "Redeemed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:56
+#: templates/exhibitors/vouchers.html:35 utils.py:498
+msgid "Valid until"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:56
 msgid "Already redeemed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:67
-msgid "No vouchers have been issued for this partner yet."
+#: templates/exhibitors/vouchers.html:62
+msgid "Return to pool"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:76
-msgid "Issue new vouchers"
+#: templates/exhibitors/vouchers.html:74
+msgid "No vouchers have been assigned to this partner yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:86
-msgid "Create vouchers"
+#: templates/exhibitors/vouchers.html:82
+msgid "Take more from the pool"
 msgstr ""
 
-#: exhibition/templates/sponsors/presale_supported_by.html:4
+#: templates/exhibitors/vouchers.html:84
+msgid ""
+"Codes come from the voucher pool chosen under Settings. The email always "
+"carries this partner's complete list of codes, so you can assign some now "
+"and send them together with more later. It is placed in the outbox for you "
+"to review before it goes out."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:92
+#, python-format
+msgid "%(counter)s voucher is left unassigned in the pool."
+msgid_plural "%(counter)s vouchers are left unassigned in the pool."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: templates/exhibitors/vouchers.html:100 views.py:2230
+msgid "No voucher pool is selected yet. Choose one under Settings → Vouchers."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:106
+msgid "A voucher email for this partner is waiting in the outbox."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:108
+msgid "Go to outbox"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:114
+#, python-format
+msgid "Vouchers were last emailed to this partner on %(sent)s."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:120
+msgid ""
+"This partner has no email address on file, so vouchers cannot be emailed."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:127
+msgid "Assign and prepare email"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:130
+msgid "Assign without emailing"
+msgstr ""
+
+#: templates/sponsors/presale_supported_by.html:4
 msgid "Supported By"
 msgstr ""
 
-#: exhibition/views.py:324
+#: utils.py:493
+msgid "Voucher code"
+msgstr ""
+
+#: utils.py:494
+msgid "Redeem link"
+msgstr ""
+
+#: utils.py:497
+msgid "Value"
+msgstr ""
+
+#: utils.py:500
+msgid "Maximum usages"
+msgstr ""
+
+#: views.py:342
 msgid "Company name"
 msgstr ""
 
-#: exhibition/views.py:325
+#: views.py:343
 msgid "Job title"
 msgstr ""
 
-#: exhibition/views.py:326
+#: views.py:344
 msgid "Address"
 msgstr ""
 
-#: exhibition/views.py:333
+#: views.py:351
 msgid "Attendee Name"
 msgstr ""
 
-#: exhibition/views.py:338
+#: views.py:356
 msgid "Attendee Email"
 msgstr ""
 
-#: exhibition/views.py:377
+#: views.py:395 views.py:412
 msgid "Settings have been saved."
 msgstr ""
 
-#: exhibition/views.py:393
+#: views.py:428
 msgid "Call settings have been saved."
 msgstr ""
 
-#: exhibition/views.py:401
+#: views.py:436
 msgid ""
 "A new secret call link has been generated. The old link no longer works."
 msgstr ""
 
-#: exhibition/views.py:416
+#: views.py:451
 msgid "Sponsor group added."
 msgstr ""
 
-#: exhibition/views.py:437
+#: views.py:454 views.py:477 views.py:853 views.py:1169 views.py:1796
+#: views.py:1918 views.py:2564 views.py:3025
+msgid "We could not save your changes. See below for details."
+msgstr ""
+
+#: views.py:474
 msgid "Sponsor group updated."
 msgstr ""
 
-#: exhibition/views.py:452
+#: views.py:491
 msgid "This sponsor group cannot be deleted while it is assigned to partners."
 msgstr ""
 
-#: exhibition/views.py:460
+#: views.py:499
 msgid "Unknown action."
 msgstr ""
 
-#: exhibition/views.py:505
+#: views.py:544
 msgid "Access key"
 msgstr ""
 
-#: exhibition/views.py:745 exhibition/views.py:1060
+#: views.py:819 views.py:1135
 msgid "Add at least one social media link."
 msgstr ""
 
-#: exhibition/views.py:754 exhibition/views.py:1069
+#: views.py:828 views.py:1144
 msgid "Add at least one extra link."
 msgstr ""
 
-#: exhibition/views.py:809
+#: views.py:884
 msgid "The call for exhibitors is closed."
 msgstr ""
 
-#: exhibition/views.py:837
+#: views.py:912
 msgid "Your request has been saved."
 msgstr ""
 
-#: exhibition/views.py:920 exhibition/views.py:1776
+#: views.py:995 views.py:1914
 msgid "Your changes have been saved."
 msgstr ""
 
-#: exhibition/views.py:953
+#: views.py:1028
 msgid "This proposal can no longer be withdrawn."
 msgstr ""
 
-#: exhibition/views.py:961
+#: views.py:1036
 msgid "Your request has been withdrawn."
 msgstr ""
 
-#: exhibition/views.py:963
+#: views.py:1038
 msgid "This request can no longer be withdrawn."
 msgstr ""
 
-#: exhibition/views.py:989 exhibition/views.py:999
+#: views.py:1064 views.py:1074
 msgid "This request can no longer be reinstated."
 msgstr ""
 
-#: exhibition/views.py:997
+#: views.py:1072
 msgid "Your request has been reinstated and is pending review again."
 msgstr ""
 
-#: exhibition/views.py:1121
+#: views.py:1197
 msgid "Invalid request body."
 msgstr ""
 
-#: exhibition/views.py:1124 exhibition/views.py:1129
+#: views.py:1200 views.py:1205
 msgid "Invalid sponsor group IDs."
 msgstr ""
 
-#: exhibition/views.py:1133
+#: views.py:1209
 msgid "Sponsor group IDs must be unique."
 msgstr ""
 
-#: exhibition/views.py:1141
+#: views.py:1217
 msgid "Reorder request must include each sponsor group exactly once."
 msgstr ""
 
-#: exhibition/views.py:1346
+#: views.py:1422
 msgid "This request can no longer be changed to that state."
 msgstr ""
 
-#: exhibition/views.py:1350
+#: views.py:1426
 msgid "Review details saved."
 msgstr ""
 
-#: exhibition/views.py:1359
+#: views.py:1435
 msgid ""
 "Request approved and partner profile created. An acceptance email was placed "
 "in the outbox."
 msgstr ""
 
-#: exhibition/views.py:1369
+#: views.py:1445
 msgid "Request rejected. A rejection email was placed in the outbox."
 msgstr ""
 
-#: exhibition/views.py:1372
+#: views.py:1448
 msgid "Request withdrawn."
 msgstr ""
 
-#: exhibition/views.py:1375
+#: views.py:1451
 msgid "Request reopened for review."
 msgstr ""
 
-#: exhibition/views.py:1407
+#: views.py:1483
 msgid "No valid action was selected."
 msgstr ""
 
-#: exhibition/views.py:1454
+#: views.py:1530
 #, python-format
 msgid "%(count)d request was approved."
 msgid_plural "%(count)d requests were approved."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1455
+#: views.py:1531
 #, python-format
 msgid "%(count)d request was rejected."
 msgid_plural "%(count)d requests were rejected."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1456
+#: views.py:1532
 #, python-format
 msgid "%(count)d request was withdrawn."
 msgid_plural "%(count)d requests were withdrawn."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1457
+#: views.py:1533
 #, python-format
 msgid "%(count)d request was reopened."
 msgid_plural "%(count)d requests were reopened."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1461
+#: views.py:1537
 msgid "No proposals were updated."
 msgstr ""
 
-#: exhibition/views.py:1464
+#: views.py:1540
 #, python-format
 msgid "%(skipped)d was skipped because it was already processed."
 msgid_plural "%(skipped)d were skipped because they were already processed."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1605
+#: views.py:1681
 msgid "Exhibitor form settings have been saved."
 msgstr ""
 
-#: exhibition/views.py:1730
+#: views.py:1868
 msgid "The requested form field does not exist."
 msgstr ""
 
-#: exhibition/views.py:1791
+#: views.py:1933
 msgid "The field has been reset to its default."
 msgstr ""
 
-#: exhibition/views.py:1829 exhibition/views.py:1900
+#: views.py:1971 views.py:2042
 msgid "An access-credentials email was placed in the outbox."
 msgstr ""
 
-#: exhibition/views.py:1907
+#: views.py:2049
 msgid "Edit Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1908
+#: views.py:2050
 msgid "Edit Exhibitor"
 msgstr ""
 
-#: exhibition/views.py:1909
+#: views.py:2051
 msgid "Edit Exhibitor & Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1910
+#: views.py:2052
 msgid "Edit Exhibitor or Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1940
+#: views.py:2082
 msgid "Delete Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1941
+#: views.py:2083
 msgid "Delete Exhibitor"
 msgstr ""
 
-#: exhibition/views.py:1942
+#: views.py:2084
 msgid "Delete Exhibitor & Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1943
+#: views.py:2085
 msgid "Delete Exhibitor or Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1992
-msgid "Voucher code"
+#: views.py:2164
+msgid "This voucher has already been redeemed and cannot be returned."
 msgstr ""
 
-#: exhibition/views.py:1993
-msgid "Redeem link"
+#: views.py:2170
+msgid ""
+"This code was already included in a voucher email to this partner, so it "
+"cannot be returned to the pool. Delete it under Tickets → Vouchers instead."
 msgstr ""
 
-#: exhibition/views.py:1999
-msgid "Maximum usages"
+#: views.py:2176
+msgid "Voucher returned to the pool."
 msgstr ""
 
-#: exhibition/views.py:2035
-msgid "This voucher has already been redeemed and cannot be removed."
+#: views.py:2207
+msgid "Enter how many vouchers to take from the pool."
 msgstr ""
 
-#: exhibition/views.py:2040
-msgid "Voucher removed."
-msgstr ""
-
-#: exhibition/views.py:2060
+#: views.py:2215
 #, python-format
-msgid "%(count)d voucher created."
-msgid_plural "%(count)d vouchers created."
+msgid "%(count)d voucher taken from the pool."
+msgid_plural "%(count)d vouchers taken from the pool."
 msgstr[0] ""
 msgstr[1] ""
+msgstr[2] ""
 
-#: exhibition/views.py:2112
+#: views.py:2232
+#, python-format
+msgid ""
+"The pool only has %(remaining)d voucher(s) left, so %(count)d cannot be "
+"taken."
+msgstr ""
+
+#: views.py:2244
+msgid "No email address is on file, so vouchers cannot be emailed."
+msgstr ""
+
+#: views.py:2253
+msgid "This partner holds no vouchers yet, so there is nothing to email."
+msgstr ""
+
+#: views.py:2259
+#, python-format
+msgid "An email with %(count)d voucher code was placed in the outbox."
+msgid_plural "An email with %(count)d voucher codes was placed in the outbox."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: views.py:2347
+msgid "There is nobody to send vouchers to in this list."
+msgstr ""
+
+#: views.py:2354
+#, python-format
+msgid "%(count)d voucher email was placed in the outbox."
+msgid_plural "%(count)d voucher emails were placed in the outbox."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: views.py:2371
+#, python-format
+msgid ""
+"%(count)d was skipped because no unassigned codes were available from their "
+"pool."
+msgid_plural ""
+"%(count)d were skipped because no unassigned codes were available from their "
+"pool."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: views.py:2386
+#, python-format
+msgid "%(count)d sponsor was skipped because it has no email address."
+msgid_plural ""
+"%(count)d sponsors were skipped because they have no email address."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: views.py:2392
+#, python-format
+msgid "%(count)d exhibitor was skipped because it has no email address."
+msgid_plural ""
+"%(count)d exhibitors were skipped because they have no email address."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: views.py:2401
+#, python-format
+msgid "%(count)d sponsor was skipped because their voucher count is set to 0."
+msgid_plural ""
+"%(count)d sponsors were skipped because their voucher count is set to 0."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: views.py:2407
+#, python-format
+msgid ""
+"%(count)d exhibitor was skipped because their voucher count is set to 0."
+msgid_plural ""
+"%(count)d exhibitors were skipped because their voucher count is set to 0."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: views.py:2461
 #, python-format
 msgid "%(count)d device added."
 msgid_plural "%(count)d devices added."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2123
+#: views.py:2472
 #, python-format
 msgid ""
 "New setup tokens generated. %(count)d device that was already scanning is "
@@ -2739,79 +3047,95 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2132
+#: views.py:2481
 msgid "New setup tokens generated."
 msgstr ""
 
-#: exhibition/views.py:2194
+#: views.py:2543
 msgid "No applicants matched the selected filters."
 msgstr ""
 
-#: exhibition/views.py:2202
+#: views.py:2551
 #, python-format
 msgid "%(count)d emails have been scheduled."
 msgstr ""
 
-#: exhibition/views.py:2206
+#: views.py:2555
 #, python-format
 msgid "%(count)d emails have been sent."
 msgstr ""
 
-#: exhibition/views.py:2210
+#: views.py:2559
 #, python-format
 msgid "%(count)d emails have been placed in the outbox."
 msgstr ""
 
-#: exhibition/views.py:2385
+#: views.py:2738
 msgid "The emails have been saved and sent."
 msgstr ""
 
-#: exhibition/views.py:2389
+#: views.py:2742
 msgid "The emails have been saved."
 msgstr ""
 
-#: exhibition/views.py:2395
+#: views.py:2748
 msgid "The email has been saved and sent."
 msgstr ""
 
-#: exhibition/views.py:2399
+#: views.py:2752
 msgid "The email has been saved."
 msgstr ""
 
-#: exhibition/views.py:2423 exhibition/views.py:2497
+#: views.py:2776 views.py:2850
 #, python-format
 msgid "%(count)d email has been sent."
 msgid_plural "%(count)d emails have been sent."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2459
+#: views.py:2812
 msgid "The email has been discarded."
 msgstr ""
 
-#: exhibition/views.py:2501 exhibition/views.py:2514 exhibition/views.py:2519
+#: views.py:2854 views.py:2867 views.py:2872
 msgid "No emails were selected."
 msgstr ""
 
-#: exhibition/views.py:2510
+#: views.py:2863
 #, python-format
 msgid "%(count)d email has been discarded."
 msgid_plural "%(count)d emails have been discarded."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2594
+#: views.py:2929
+msgid "Request received (confirmation)"
+msgstr ""
+
+#: views.py:2930
+msgid "Request accepted"
+msgstr ""
+
+#: views.py:2931
+msgid "Request rejected"
+msgstr ""
+
+#: views.py:2932
+msgid "Exhibitor lead scanning key"
+msgstr ""
+
+#: views.py:2948
 msgid "Email templates have been saved."
 msgstr ""
 
-#: exhibition/views.py:2617 exhibition/views.py:2621
+#: views.py:2971 views.py:2975
 msgid "Unknown template."
 msgstr ""
 
-#: exhibition/views.py:2667
+#: views.py:3021
 msgid "Custom template has been created."
 msgstr ""
 
-#: exhibition/views.py:2683
+#: views.py:3041
 msgid "Custom template has been deleted."
 msgstr ""

--- a/exhibition/locale/fr/LC_MESSAGES/django.po
+++ b/exhibition/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-29 10:33+0000\n"
+"POT-Creation-Date: 2026-09-11 11:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,595 +18,531 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: exhibition/apps.py:14 exhibition/apps.py:17 exhibition/signals.py:157
-#: exhibition/templates/exhibitors/public_list.html:6
-#: exhibition/templates/exhibitors/public_list.html:14
-#: exhibition/templates/exhibitors/public_list.html:16
+#: apps.py:14 apps.py:17 signals.py:163 templates/exhibitors/public_list.html:6
+#: templates/exhibitors/public_list.html:14
+#: templates/exhibitors/public_list.html:16
 msgid "Exhibition"
 msgstr ""
 
-#: exhibition/apps.py:19
+#: apps.py:19
 msgid "This plugin enables to add and control exhibitors in eventyay"
 msgstr ""
 
-#: exhibition/filters.py:9
+#: filters.py:9
 msgid "Any"
 msgstr ""
 
-#: exhibition/filters.py:10
+#: filters.py:10
 msgid "Enabled"
 msgstr ""
 
-#: exhibition/filters.py:11 exhibition/templates/exhibitors/dashboard.html:127
+#: filters.py:11 templates/exhibitors/dashboard.html:127
 msgid "Disabled"
 msgstr ""
 
-#: exhibition/filters.py:15
+#: filters.py:15
 msgid "All types"
 msgstr ""
 
-#: exhibition/filters.py:16
+#: filters.py:16
 msgid "Exhibitor only"
 msgstr ""
 
-#: exhibition/filters.py:17
+#: filters.py:17
 msgid "Sponsor only"
 msgstr ""
 
-#: exhibition/filters.py:18 exhibition/templates/exhibitors/dashboard.html:89
-#: exhibition/templates/exhibitors/proposal_detail.html:95
-#: exhibition/templates/exhibitors/proposal_list.html:95
+#: filters.py:18 templates/exhibitors/dashboard.html:89
+#: templates/exhibitors/proposal_detail.html:95
+#: templates/exhibitors/proposal_list.html:95
 msgid "Exhibitor and sponsor"
 msgstr ""
 
-#: exhibition/filters.py:80 exhibition/filters.py:81
+#: filters.py:80 filters.py:81
 msgid "Search requests…"
 msgstr ""
 
-#: exhibition/filters.py:81
+#: filters.py:81
 msgid "Search requests"
 msgstr ""
 
-#: exhibition/filters.py:85 exhibition/templates/exhibitors/dashboard.html:75
-#: exhibition/templates/exhibitors/proposal_detail.html:85
-#: exhibition/templates/exhibitors/proposal_list.html:21
-#: exhibition/templates/exhibitors/public_proposal_list.html:12
+#: filters.py:85 templates/exhibitors/dashboard.html:75
+#: templates/exhibitors/proposal_detail.html:85
+#: templates/exhibitors/proposal_list.html:21
+#: templates/exhibitors/public_proposal_list.html:12
 msgid "State"
 msgstr ""
 
-#: exhibition/filters.py:86
+#: filters.py:86
 msgid "All states"
 msgstr ""
 
-#: exhibition/filters.py:90 exhibition/templates/exhibitors/dashboard.html:74
-#: exhibition/templates/exhibitors/proposal_detail.html:91
-#: exhibition/templates/exhibitors/proposal_list.html:62
+#: filters.py:90 templates/exhibitors/dashboard.html:74
+#: templates/exhibitors/proposal_detail.html:91
+#: templates/exhibitors/proposal_list.html:62
 msgid "Type"
 msgstr ""
 
-#: exhibition/filters.py:99 exhibition/filters.py:102
+#: filters.py:99 filters.py:102
 msgid "Search by name…"
 msgstr ""
 
-#: exhibition/filters.py:103
+#: filters.py:103
 msgid "Search requests by name"
 msgstr ""
 
-#: exhibition/filters.py:132 exhibition/filters.py:133
+#: filters.py:132 filters.py:133
 msgid "Search organizations…"
 msgstr ""
 
-#: exhibition/filters.py:133
+#: filters.py:133
 msgid "Search organizations"
 msgstr ""
 
-#: exhibition/filters.py:137
+#: filters.py:137
 msgid "Visibility"
 msgstr ""
 
-#: exhibition/filters.py:139
+#: filters.py:139
 msgid "All organizations"
 msgstr ""
 
-#: exhibition/filters.py:140 exhibition/forms.py:1512
-#: exhibition/templates/exhibitors/call_questions.html:30
+#: filters.py:140 forms.py:1553 templates/exhibitors/call_questions.html:30
 msgid "Active"
 msgstr ""
 
-#: exhibition/filters.py:141
+#: filters.py:141
 msgid "Inactive"
 msgstr ""
 
-#: exhibition/filters.py:146 exhibition/filters.py:207 exhibition/forms.py:207
-#: exhibition/forms.py:1410 exhibition/forms.py:1841
+#: filters.py:146 filters.py:207 forms.py:212 forms.py:1411 forms.py:1888
 msgid "Sponsor group"
 msgstr ""
 
-#: exhibition/filters.py:149 exhibition/filters.py:210
+#: filters.py:149 filters.py:210
 msgid "All groups"
 msgstr ""
 
-#: exhibition/filters.py:152 exhibition/templates/exhibitors/add.html:222
+#: filters.py:152 templates/exhibitors/add.html:226
 msgid "Lead scanning"
 msgstr ""
 
-#: exhibition/filters.py:157
+#: filters.py:157
 msgid "Lead access"
 msgstr ""
 
-#: exhibition/filters.py:162
+#: filters.py:162
 msgid "Voucher access"
 msgstr ""
 
-#: exhibition/filters.py:202 exhibition/filters.py:203
+#: filters.py:202 filters.py:203
 msgid "Search exhibitors…"
 msgstr ""
 
-#: exhibition/filters.py:203
+#: filters.py:203
 msgid "Search exhibitors"
 msgstr ""
 
-#: exhibition/filters.py:240 exhibition/filters.py:241
+#: filters.py:240 filters.py:241
 msgid "Search emails…"
 msgstr ""
 
-#: exhibition/filters.py:241
+#: filters.py:241
 msgid "Search emails"
 msgstr ""
 
-#: exhibition/forms.py:67
+#: forms.py:72
 #, python-format
 msgid "Times are in the event timezone: %(tz)s."
 msgstr ""
 
-#: exhibition/forms.py:128 exhibition/forms.py:139 exhibition/forms.py:933
-#: exhibition/forms.py:944
+#: forms.py:133 forms.py:144 forms.py:934 forms.py:945
 msgid "— No selection —"
 msgstr ""
 
-#: exhibition/forms.py:211
+#: forms.py:216
 msgid "Can view voucher redemptions"
 msgstr ""
 
-#: exhibition/forms.py:213 exhibition/forms.py:397
+#: forms.py:218 forms.py:402
 msgid ""
 "Lets this exhibitor or sponsor retrieve the attendees who redeemed vouchers "
 "issued to them. Separate from lead scanning, which covers attendees scanned "
 "at the booth."
 msgstr ""
 
-#: exhibition/forms.py:219
+#: forms.py:224
 msgid "Can view and export collected leads"
 msgstr ""
 
-#: exhibition/forms.py:221
+#: forms.py:226
 msgid ""
 "Lets this exhibitor retrieve the full list of leads they have already "
 "scanned. Turn this off to let them keep scanning without seeing the "
 "collected attendee data."
 msgstr ""
 
-#: exhibition/forms.py:226
+#: forms.py:231
 msgid "Lead scanning behavior"
 msgstr ""
 
-#: exhibition/forms.py:231
+#: forms.py:236
 msgid ""
 "Every attendee is one lead, even when scanned from multiple devices. Notes "
 "and ratings are shared between devices."
 msgstr ""
 
-#: exhibition/forms.py:238
+#: forms.py:243
 msgid ""
 "Every attendee is a new lead when scanned from a new device. Notes and "
 "ratings are specific to the device."
 msgstr ""
 
-#: exhibition/forms.py:251
+#: forms.py:256
 msgid "Comment"
 msgstr ""
 
-#: exhibition/forms.py:253
+#: forms.py:258
 msgid ""
 "The text entered in this field will not be visible to the user and is "
 "available for your convenience."
 msgstr ""
 
-#: exhibition/forms.py:258 exhibition/forms.py:1427 exhibition/views.py:505
+#: forms.py:263 forms.py:1428 views.py:544
 msgid "Booth ID"
 msgstr ""
 
-#: exhibition/forms.py:291 exhibition/forms.py:1027 exhibition/forms.py:1076
-#: exhibition/models.py:130
+#: forms.py:296 forms.py:1028 forms.py:1077 models.py:130
 msgid "Organization name"
 msgstr ""
 
-#: exhibition/forms.py:292 exhibition/forms.py:1030 exhibition/forms.py:1077
-#: exhibition/models.py:136
+#: forms.py:297 forms.py:1031 forms.py:1078 models.py:136
 msgid "Organization description"
 msgstr ""
 
-#: exhibition/forms.py:293 exhibition/forms.py:1078
+#: forms.py:298 forms.py:1079
 msgid "E-mail"
 msgstr ""
 
-#: exhibition/forms.py:294 exhibition/forms.py:1079 exhibition/models.py:139
+#: forms.py:299 forms.py:1080 models.py:139
 msgid "Contact page URL"
 msgstr ""
 
-#: exhibition/forms.py:295 exhibition/forms.py:1080 exhibition/models.py:140
+#: forms.py:300 forms.py:1081 models.py:140
 msgid "Promotional video URL"
 msgstr ""
 
-#: exhibition/forms.py:296 exhibition/forms.py:1081 exhibition/models.py:141
+#: forms.py:301 forms.py:1082 models.py:141
 msgid "Promotional slides"
 msgstr ""
 
-#: exhibition/forms.py:297 exhibition/forms.py:1082 exhibition/models.py:142
-#: exhibition/models.py:520
-#: exhibition/templates/exhibitors/proposal_detail.html:111
+#: forms.py:302 forms.py:1083 models.py:142 models.py:568
+#: templates/exhibitors/proposal_detail.html:111
 msgid "Logo"
 msgstr ""
 
-#: exhibition/forms.py:298 exhibition/forms.py:1083 exhibition/models.py:145
-#: exhibition/templates/exhibitors/proposal_detail.html:113
+#: forms.py:303 forms.py:1084 models.py:145
+#: templates/exhibitors/proposal_detail.html:113
 msgid "Header image"
 msgstr ""
 
-#: exhibition/forms.py:299 exhibition/forms.py:1084 exhibition/models.py:138
+#: forms.py:304 forms.py:1085 models.py:138
 msgid "Organization website"
 msgstr ""
 
-#: exhibition/forms.py:300
+#: forms.py:305
 msgid "Mark this partner as an exhibitor"
 msgstr ""
 
-#: exhibition/forms.py:301
+#: forms.py:306
 msgid "Mark this partner as an event sponsor"
 msgstr ""
 
-#: exhibition/forms.py:302 exhibition/forms.py:1036 exhibition/forms.py:1085
-#: exhibition/models.py:148 exhibition/models.py:522
+#: forms.py:307 forms.py:1037 forms.py:1086 models.py:148 models.py:570
 msgid "Preferred booth name"
 msgstr ""
 
-#: exhibition/forms.py:303
+#: forms.py:308
 msgid "Can scan attendee badges"
 msgstr ""
 
-#: exhibition/forms.py:307
+#: forms.py:312
 msgid ""
 "Lets this exhibitor sign in to the lead scanning app and scan attendees at "
 "their booth. Turn this off to block scanning entirely."
 msgstr ""
 
-#: exhibition/forms.py:348 exhibition/forms.py:1441
+#: forms.py:353 forms.py:1442
 msgid "No sponsor group"
 msgstr ""
 
-#: exhibition/forms.py:385
+#: forms.py:390
 msgid ""
 "Lets this exhibitor retrieve the attendees who redeemed vouchers issued to "
 "them. Separate from lead scanning, which covers attendees scanned at the "
 "booth."
 msgstr ""
 
-#: exhibition/forms.py:389
+#: forms.py:394
 msgid ""
 "Lets this sponsor retrieve the attendees who redeemed vouchers issued to "
 "them. Separate from lead scanning, which covers attendees scanned at the "
 "booth."
 msgstr ""
 
-#: exhibition/forms.py:393
+#: forms.py:398
 msgid ""
 "Lets this exhibitor and sponsor retrieve the attendees who redeemed vouchers "
 "issued to them. Separate from lead scanning, which covers attendees scanned "
 "at the booth."
 msgstr ""
 
-#: exhibition/forms.py:466 exhibition/forms.py:553 exhibition/forms.py:1361
-#: exhibition/forms.py:1375
+#: forms.py:471 forms.py:558 forms.py:1362 forms.py:1376 forms.py:1855
+#: forms.py:1924 forms.py:1930 forms.py:1932 forms.py:1934
 msgid "This field is required."
 msgstr ""
 
-#: exhibition/forms.py:511 exhibition/forms.py:516
+#: forms.py:516 forms.py:521
 msgid "Slides upload must be a PDF file."
 msgstr ""
 
-#: exhibition/forms.py:540
+#: forms.py:545
 msgid "A partner must be marked as an exhibitor, a sponsor, or both."
 msgstr ""
 
-#: exhibition/forms.py:615
+#: forms.py:620
 msgid "Devices to add"
 msgstr ""
 
-#: exhibition/forms.py:617
+#: forms.py:622
 msgid ""
 "How many new devices to provision now, in addition to any already listed "
 "above. Each device gets its own single-use setup token and QR code."
 msgstr ""
 
-#: exhibition/forms.py:627
-msgid "Select a product…"
+#: forms.py:635
+msgid "Vouchers to take from the pool"
 msgstr ""
 
-#: exhibition/forms.py:628
-msgid "Ticket product"
+#: forms.py:636
+msgid ""
+"Set to 0 to email the codes this partner already has without taking any more."
 msgstr ""
 
-#: exhibition/forms.py:629
-msgid "The product a redeemed voucher applies to."
-msgstr ""
-
-#: exhibition/forms.py:635
-msgid "Number of vouchers"
-msgstr ""
-
-#: exhibition/forms.py:640
-msgid "Maximum usages per voucher"
-msgstr ""
-
-#: exhibition/forms.py:645 exhibition/templates/exhibitors/vouchers.html:33
-#: exhibition/views.py:1995
-msgid "Price effect"
-msgstr ""
-
-#: exhibition/forms.py:651 exhibition/views.py:1996
-msgid "Value"
-msgstr ""
-
-#: exhibition/forms.py:652
-msgid "Amount or percentage, depending on the selected price effect."
-msgstr ""
-
-#: exhibition/forms.py:657 exhibition/templates/exhibitors/vouchers.html:35
-#: exhibition/views.py:1997
-msgid "Valid until"
-msgstr ""
-
-#: exhibition/forms.py:673
-msgid "Enter a value for the selected price effect."
-msgstr ""
-
-#: exhibition/forms.py:678 exhibition/models.py:295
-#: exhibition/templates/exhibitors/settings.html:205
+#: forms.py:647 models.py:326 templates/exhibitors/settings.html:289
 msgid "Level"
 msgstr ""
 
-#: exhibition/forms.py:685 exhibition/models.py:294
+#: forms.py:654 models.py:325
 msgid "Group name"
 msgstr ""
 
-#: exhibition/forms.py:718
+#: forms.py:677 models.py:225
+msgid "Exhibitor voucher pool"
+msgstr ""
+
+#: forms.py:678 models.py:232
+msgid "Sponsor voucher pool"
+msgstr ""
+
+#: forms.py:698
+msgid "— No pool selected —"
+msgstr ""
+
+#: forms.py:699
+msgid "— Use the exhibitor pool —"
+msgstr ""
+
+#: forms.py:719
 msgid "Enable call"
 msgstr ""
 
-#: exhibition/forms.py:719
+#: forms.py:720
 msgid "Hide call page after the deadline"
 msgstr ""
 
-#: exhibition/forms.py:720
+#: forms.py:721
 msgid "Make this call private (accessible only via a secret link)"
 msgstr ""
 
-#: exhibition/forms.py:724
+#: forms.py:725
 msgid ""
 "Turn the call on. Keep it enabled for private calls too, otherwise the "
 "secret link stops working."
 msgstr ""
 
-#: exhibition/forms.py:727
+#: forms.py:728
 msgid ""
 "The call page is not linked anywhere public and can only be opened with the "
 "secret link shown below."
 msgstr ""
 
-#: exhibition/forms.py:868
+#: forms.py:869
 msgid "Your answer"
 msgstr ""
 
-#: exhibition/forms.py:1024 exhibition/models.py:563
-#: exhibition/templates/exhibitors/proposal_detail.html:88
+#: forms.py:1025 models.py:611 templates/exhibitors/proposal_detail.html:88
 msgid "Language"
 msgstr ""
 
-#: exhibition/forms.py:1025
+#: forms.py:1026
 msgid "The language you are filling in this form with."
 msgstr ""
 
-#: exhibition/forms.py:1086 exhibition/models.py:151 exhibition/models.py:523
-#: exhibition/models.py:602
+#: forms.py:1087 models.py:151 models.py:571 models.py:650
 msgid "Message to the organizers"
 msgstr ""
 
-#: exhibition/forms.py:1149
+#: forms.py:1150
 msgid ""
 "The organization name is locked after acceptance. Contact the organizers to "
 "change it."
 msgstr ""
 
-#: exhibition/forms.py:1425
+#: forms.py:1426
 msgid "Approve as exhibitor"
 msgstr ""
 
-#: exhibition/forms.py:1426
+#: forms.py:1427
 msgid "Approve as sponsor"
 msgstr ""
 
-#: exhibition/forms.py:1428 exhibition/models.py:352 exhibition/models.py:596
-#: exhibition/models.py:966 exhibition/views.py:505
+#: forms.py:1429 models.py:383 models.py:644 models.py:1014 views.py:544
 msgid "Booth name"
 msgstr ""
 
-#: exhibition/forms.py:1429 exhibition/forms.py:1459 exhibition/models.py:607
+#: forms.py:1430 forms.py:1460 models.py:655
 msgid "Internal review notes"
 msgstr ""
 
-#: exhibition/forms.py:1470
+#: forms.py:1471
 msgid "Field label"
 msgstr ""
 
-#: exhibition/forms.py:1475 exhibition/forms.py:1510
+#: forms.py:1476 forms.py:1551
 msgid "Help text"
 msgstr ""
 
-#: exhibition/forms.py:1476
+#: forms.py:1477
 msgid "Shown below the field on the exhibitor form."
 msgstr ""
 
-#: exhibition/forms.py:1483
+#: forms.py:1484
 #, python-format
 msgid "Leave empty to use the default: %(label)s"
 msgstr ""
 
-#: exhibition/forms.py:1492
-msgid "Options"
-msgstr ""
-
-#: exhibition/forms.py:1493
-msgid "For choice fields, enter one option per line."
-msgstr ""
-
-#: exhibition/forms.py:1508
-msgid "Field type"
-msgstr ""
-
-#: exhibition/forms.py:1509 exhibition/models.py:878
-msgid "Custom question"
-msgstr ""
-
-#: exhibition/forms.py:1511
-#: exhibition/templates/exhibitors/call_questions.html:31
-#: exhibition/templates/exhibitors/call_questions.html:63
-msgid "Required"
-msgstr ""
-
-#: exhibition/forms.py:1535
+#: forms.py:1523
 msgid "Please provide at least one option for this question type."
 msgstr ""
 
-#: exhibition/forms.py:1576 exhibition/forms.py:1665
+#: forms.py:1549
+msgid "Field type"
+msgstr ""
+
+#: forms.py:1550 models.py:926
+msgid "Custom question"
+msgstr ""
+
+#: forms.py:1552 templates/exhibitors/call_questions.html:31
+#: templates/exhibitors/call_questions.html:63
+msgid "Required"
+msgstr ""
+
+#: forms.py:1583 forms.py:1672
 msgid "Choose social platform"
 msgstr ""
 
-#: exhibition/forms.py:1578 exhibition/forms.py:1667
+#: forms.py:1585 forms.py:1674
 msgid "Social platform"
 msgstr ""
 
-#: exhibition/forms.py:1582 exhibition/forms.py:1671
+#: forms.py:1589 forms.py:1678
 msgid "Profile or path"
 msgstr ""
 
-#: exhibition/forms.py:1596 exhibition/forms.py:1685
+#: forms.py:1603 forms.py:1692
 msgid "Profile, handle, or full URL"
 msgstr ""
 
-#: exhibition/forms.py:1616 exhibition/forms.py:1705
+#: forms.py:1623 forms.py:1712
 msgid "Please enter a profile, handle, or URL or remove this row."
 msgstr ""
 
-#: exhibition/forms.py:1622 exhibition/forms.py:1711
+#: forms.py:1629 forms.py:1718
 msgid "Please choose a social platform."
 msgstr ""
 
-#: exhibition/forms.py:1626 exhibition/forms.py:1715
+#: forms.py:1633 forms.py:1722
 msgid "Please enter a profile, handle, or URL."
 msgstr ""
 
-#: exhibition/forms.py:1648 exhibition/forms.py:1737
+#: forms.py:1655 forms.py:1744
 msgid "Link label"
 msgstr ""
 
-#: exhibition/forms.py:1654 exhibition/forms.py:1743
+#: forms.py:1661 forms.py:1750
 msgid "https://example.com"
 msgstr ""
 
-#: exhibition/forms.py:1807
+#: forms.py:1848
 msgid ""
 "Leave empty to keep this in the outbox until sent manually. Time is "
 "interpreted in the event timezone."
 msgstr ""
 
-#: exhibition/forms.py:1814 exhibition/forms.py:1877
+#: forms.py:1861 forms.py:1940
 msgid "The scheduled time must be in the future."
 msgstr ""
 
-#: exhibition/forms.py:1822
+#: forms.py:1869
 msgid "Exhibitors and sponsors"
 msgstr ""
 
-#: exhibition/forms.py:1823
+#: forms.py:1870
 msgid "Exhibitors only"
 msgstr ""
 
-#: exhibition/forms.py:1824
+#: forms.py:1871
 msgid "Sponsors only"
 msgstr ""
 
-#: exhibition/forms.py:1828
+#: forms.py:1875
 msgid "Application state"
 msgstr ""
 
-#: exhibition/forms.py:1836
+#: forms.py:1883
 msgid "Partner type"
 msgstr ""
 
-#: exhibition/forms.py:1844
+#: forms.py:1891
 msgid "Any sponsor group"
 msgstr ""
 
-#: exhibition/forms.py:1846 exhibition/models.py:1035 exhibition/models.py:1089
-#: exhibition/templates/exhibitors/_email_outbox_body.html:6
-#: exhibition/templates/exhibitors/_email_sent_body.html:6
+#: forms.py:1893 forms.py:1953 models.py:1084 models.py:1146
+#: templates/exhibitors/_email_outbox_body.html:6
+#: templates/exhibitors/_email_sent_body.html:6
 msgid "Subject"
 msgstr ""
 
-#: exhibition/forms.py:1848
+#: forms.py:1895
 msgid "Send at"
 msgstr ""
 
-#: exhibition/forms.py:1851
+#: forms.py:1898
 msgid "Leave empty to send immediately or save to the outbox."
 msgstr ""
 
-#: exhibition/forms.py:1859 exhibition/models.py:1036 exhibition/models.py:1090
+#: forms.py:1906 forms.py:1960 models.py:1085 models.py:1147
 msgid "Body"
 msgstr ""
 
-#: exhibition/forms.py:1885 exhibition/views.py:2576
-msgid "Request received (confirmation)"
-msgstr ""
-
-#: exhibition/forms.py:1886 exhibition/views.py:2577
-msgid "Request accepted"
-msgstr ""
-
-#: exhibition/forms.py:1887 exhibition/views.py:2578
-msgid "Request rejected"
-msgstr ""
-
-#: exhibition/forms.py:1888 exhibition/views.py:2579
-msgid "Exhibitor lead scanning key"
-msgstr ""
-
-#: exhibition/forms.py:1897
-#, python-format
-msgid "%(role)s — subject"
-msgstr ""
-
-#: exhibition/forms.py:1904
-#, python-format
-msgid "%(role)s — body"
-msgstr ""
-
-#: exhibition/mail.py:57
+#: mail.py:59
 #, python-brace-format
 msgid "We received your request for {event_name}"
 msgstr ""
 
-#: exhibition/mail.py:59
+#: mail.py:61
 #, python-brace-format
 msgid ""
 "Hello,\n"
@@ -621,12 +557,12 @@ msgid ""
 "The {event_name} team"
 msgstr ""
 
-#: exhibition/mail.py:69
+#: mail.py:71
 #, python-brace-format
 msgid "Your request for {event_name} has been accepted"
 msgstr ""
 
-#: exhibition/mail.py:71
+#: mail.py:73
 #, python-brace-format
 msgid ""
 "Hello,\n"
@@ -638,12 +574,12 @@ msgid ""
 "The {event_name} team"
 msgstr ""
 
-#: exhibition/mail.py:80
+#: mail.py:82
 #, python-brace-format
 msgid "Update on your request for {event_name}"
 msgstr ""
 
-#: exhibition/mail.py:82
+#: mail.py:84
 #, python-brace-format
 msgid ""
 "Hello,\n"
@@ -657,12 +593,12 @@ msgid ""
 "The {event_name} team"
 msgstr ""
 
-#: exhibition/mail.py:91
+#: mail.py:93
 #, python-brace-format
 msgid "Lead Scanning Access for {event_name}"
 msgstr ""
 
-#: exhibition/mail.py:93
+#: mail.py:95
 #, python-brace-format
 msgid ""
 "Hello {exhibitor_name},\n"
@@ -688,983 +624,1080 @@ msgid ""
 "The {event_name} Team"
 msgstr ""
 
-#: exhibition/mail.py:174
+#: mail.py:110
+#, python-brace-format
+msgid "Your vouchers for {event_name} — {exhibitor_name}"
+msgstr ""
+
+#: mail.py:112
+#, python-brace-format
+msgid ""
+"Dear {exhibitor_name},\n"
+"\n"
+"Thank you for participating in {event_name}. Please share the voucher codes "
+"below with your audience — anyone who uses one gets credited to you as a "
+"lead.\n"
+"\n"
+"{voucher_list}\n"
+"\n"
+"They can redeem a code on the event ticket shop at checkout.\n"
+"\n"
+"If you have any questions, please don't hesitate to reach out.\n"
+"\n"
+"Best regards,\n"
+"The {event_name} Team"
+msgstr ""
+
+#: mail.py:190
 msgid "This value will be replaced based on dynamic parameters."
 msgstr ""
 
-#: exhibition/models.py:137 exhibition/models.py:515
+#: mail.py:312
+#, python-format
+msgid "…and %(count)d more voucher code in the attached CSV file."
+msgid_plural "…and %(count)d more voucher codes in the attached CSV file."
+msgstr[0] ""
+msgstr[1] ""
+
+#: models.py:137 models.py:563
 msgid "Contact email"
 msgstr ""
 
-#: exhibition/models.py:156
-#: exhibition/templates/exhibitors/proposal_detail.html:132
+#: models.py:156 templates/exhibitors/proposal_detail.html:132
 msgid "Social media"
 msgstr ""
 
-#: exhibition/models.py:161
-#: exhibition/templates/exhibitors/proposal_detail.html:140
+#: models.py:161 templates/exhibitors/proposal_detail.html:140
 msgid "Extra links"
 msgstr ""
 
-#: exhibition/models.py:216
+#: models.py:212
+msgid "Vouchers per exhibitor"
+msgstr ""
+
+#: models.py:226
+msgid ""
+"The voucher tag created under Tickets → Vouchers that exhibitors draw their "
+"codes from."
+msgstr ""
+
+#: models.py:233
+msgid "Leave empty to draw sponsor codes from the exhibitor pool as well."
+msgstr ""
+
+#: models.py:239
+msgid "Attach voucher list as CSV"
+msgstr ""
+
+#: models.py:240
+msgid ""
+"Adds a spreadsheet of the recipient's own voucher codes to the voucher email."
+msgstr ""
+
+#: models.py:247
 msgid "Call headline"
 msgstr ""
 
-#: exhibition/models.py:220
+#: models.py:251
 msgid "Call text"
 msgstr ""
 
-#: exhibition/models.py:225
+#: models.py:256
 msgid "Submission deadline"
 msgstr ""
 
-#: exhibition/models.py:298
+#: models.py:329
 msgid "Show this sponsor group on the front page."
 msgstr ""
 
-#: exhibition/models.py:314 exhibition/models.py:558
-#: exhibition/templates/exhibitors/dashboard.html:73
-#: exhibition/templates/exhibitors/exhibitor_info.html:69
-#: exhibition/templates/exhibitors/proposal_list.html:19
-#: exhibition/templates/exhibitors/public_proposal_list.html:11
-#: exhibition/views.py:505
+#: models.py:345 models.py:606 templates/exhibitors/dashboard.html:73
+#: templates/exhibitors/exhibitor_info.html:79
+#: templates/exhibitors/proposal_list.html:19
+#: templates/exhibitors/public_proposal_list.html:11 views.py:544
 msgid "Name"
 msgstr ""
 
-#: exhibition/models.py:315 exhibition/models.py:559
-#: exhibition/templates/exhibitors/proposal_detail.html:117
+#: models.py:346 models.py:607 templates/exhibitors/proposal_detail.html:117
 msgid "Description"
 msgstr ""
 
-#: exhibition/models.py:316 exhibition/models.py:419 exhibition/models.py:435
-#: exhibition/models.py:565 exhibition/models.py:815 exhibition/models.py:831
-#: exhibition/models.py:844
-#: exhibition/templates/exhibitors/proposal_detail.html:103
+#: models.py:347 models.py:467 models.py:483 models.py:613 models.py:863
+#: models.py:879 models.py:892 templates/exhibitors/proposal_detail.html:103
 msgid "URL"
 msgstr ""
 
-#: exhibition/models.py:317 exhibition/models.py:566
-#: exhibition/templates/exhibitors/proposal_detail.html:77
-#: exhibition/views.py:505
+#: models.py:348 models.py:614 templates/exhibitors/proposal_detail.html:77
+#: views.py:544
 msgid "Email"
 msgstr ""
 
-#: exhibition/models.py:318 exhibition/models.py:567
-#: exhibition/templates/exhibitors/proposal_detail.html:105
+#: models.py:349 models.py:615 templates/exhibitors/proposal_detail.html:105
 msgid "Contact URL"
 msgstr ""
 
-#: exhibition/models.py:319 exhibition/models.py:568
-#: exhibition/templates/exhibitors/proposal_detail.html:107
+#: models.py:350 models.py:616 templates/exhibitors/proposal_detail.html:107
 msgid "Video URL"
 msgstr ""
 
-#: exhibition/models.py:322 exhibition/models.py:571
-#: exhibition/templates/exhibitors/proposal_detail.html:109
+#: models.py:353 models.py:619 templates/exhibitors/proposal_detail.html:109
 msgid "Slides"
 msgstr ""
 
-#: exhibition/models.py:326 exhibition/models.py:575
+#: models.py:357 models.py:623
 msgid "Slides URL"
 msgstr ""
 
-#: exhibition/models.py:328 exhibition/models.py:577
+#: models.py:359 models.py:625
 msgid "Logo URL"
 msgstr ""
 
-#: exhibition/models.py:330 exhibition/models.py:579
+#: models.py:361 models.py:627
 msgid "Header image URL"
 msgstr ""
 
-#: exhibition/models.py:434 exhibition/models.py:830
+#: models.py:482 models.py:878
 msgid "Label"
 msgstr ""
 
-#: exhibition/models.py:445
+#: models.py:493
 msgid "draft"
 msgstr ""
 
-#: exhibition/models.py:446
+#: models.py:494
 msgid "submitted"
 msgstr ""
 
-#: exhibition/models.py:447
+#: models.py:495
 msgid "accepted"
 msgstr ""
 
-#: exhibition/models.py:448
+#: models.py:496
 msgid "rejected"
 msgstr ""
 
-#: exhibition/models.py:449
+#: models.py:497
 msgid "withdrawn"
 msgstr ""
 
-#: exhibition/models.py:514
+#: models.py:562
 msgid "Organization Description"
 msgstr ""
 
-#: exhibition/models.py:516
+#: models.py:564
 msgid "Organization Website"
 msgstr ""
 
-#: exhibition/models.py:517
+#: models.py:565
 msgid "Contact Page URL"
 msgstr ""
 
-#: exhibition/models.py:518
+#: models.py:566
 msgid "Promotional Video URL"
 msgstr ""
 
-#: exhibition/models.py:519
+#: models.py:567
 msgid "Promotional Slides"
 msgstr ""
 
-#: exhibition/models.py:521
+#: models.py:569
 msgid "Header Image"
 msgstr ""
 
-#: exhibition/models.py:524 exhibition/templates/exhibitors/add.html:29
-#: exhibition/templates/exhibitors/public_proposal_form.html:38
+#: models.py:572 templates/exhibitors/add.html:29
+#: templates/exhibitors/public_proposal_form.html:38
 msgid "Social Media"
 msgstr ""
 
-#: exhibition/models.py:525 exhibition/templates/exhibitors/add.html:92
-#: exhibition/templates/exhibitors/public_proposal_form.html:91
+#: models.py:573 templates/exhibitors/add.html:92
+#: templates/exhibitors/public_proposal_form.html:91
 msgid "Extra Links"
 msgstr ""
 
-#: exhibition/models.py:841
+#: models.py:889
 msgid "Number"
 msgstr ""
 
-#: exhibition/models.py:842
+#: models.py:890
 msgid "Text (one line)"
 msgstr ""
 
-#: exhibition/models.py:843
+#: models.py:891
 msgid "Multiline text"
 msgstr ""
 
-#: exhibition/models.py:845
+#: models.py:893
 msgid "Email address"
 msgstr ""
 
-#: exhibition/models.py:846
+#: models.py:894
 msgid "Confirm Checkbox"
 msgstr ""
 
-#: exhibition/models.py:847
+#: models.py:895
 msgid "Radio button (Choose one option)"
 msgstr ""
 
-#: exhibition/models.py:848
+#: models.py:896
 msgid "Dropdown (Choose one option)"
 msgstr ""
 
-#: exhibition/models.py:849
+#: models.py:897
 msgid "Checkbox (Choose one or several options)"
 msgstr ""
 
-#: exhibition/models.py:850
+#: models.py:898
 msgid "File upload"
 msgstr ""
 
-#: exhibition/models.py:851
+#: models.py:899
 msgid "Date"
 msgstr ""
 
-#: exhibition/models.py:852
+#: models.py:900
 msgid "Time"
 msgstr ""
 
-#: exhibition/models.py:853
+#: models.py:901
 msgid "Date and time"
 msgstr ""
 
-#: exhibition/models.py:854
+#: models.py:902
 msgid "Country code (ISO 3166-1 alpha-2)"
 msgstr ""
 
-#: exhibition/models.py:855
+#: models.py:903
 msgid "Phone number"
 msgstr ""
 
-#: exhibition/models.py:883
+#: models.py:931
 msgid "help text"
 msgstr ""
 
-#: exhibition/models.py:885 exhibition/templates/exhibitors/add.html:29
-#: exhibition/templates/exhibitors/add.html:92
-#: exhibition/templates/exhibitors/public_proposal_form.html:38
-#: exhibition/templates/exhibitors/public_proposal_form.html:91
+#: models.py:933 templates/exhibitors/add.html:29
+#: templates/exhibitors/add.html:92
+#: templates/exhibitors/public_proposal_form.html:38
+#: templates/exhibitors/public_proposal_form.html:91
 msgid "required"
 msgstr ""
 
-#: exhibition/models.py:886
+#: models.py:934
 msgid "active"
 msgstr ""
 
-#: exhibition/models.py:906
+#: models.py:954
 msgid "Response"
 msgstr ""
 
-#: exhibition/models.py:938
+#: models.py:986
 msgid "Yes"
 msgstr ""
 
-#: exhibition/models.py:940
+#: models.py:988
 msgid "No"
 msgstr ""
 
-#: exhibition/models.py:1034
-#: exhibition/templates/exhibitors/_email_outbox_body.html:5
-#: exhibition/templates/exhibitors/_email_sent_body.html:5
+#: models.py:1083 templates/exhibitors/_email_outbox_body.html:5
+#: templates/exhibitors/_email_sent_body.html:5
 msgid "Recipient"
 msgstr ""
 
-#: exhibition/models.py:1045
+#: models.py:1101
 msgid "Queued email"
 msgstr ""
 
-#: exhibition/models.py:1046
+#: models.py:1102
 msgid "Queued emails"
 msgstr ""
 
-#: exhibition/models.py:1088
+#: models.py:1145
 msgid "Template name"
 msgstr ""
 
-#: exhibition/models.py:1095
+#: models.py:1152
 msgid "Custom email template"
 msgstr ""
 
-#: exhibition/models.py:1096
+#: models.py:1153
 msgid "Custom email templates"
 msgstr ""
 
-#: exhibition/signals.py:75
+#: signals.py:81
 msgid "Screen and evaluate exhibitor and sponsor requests for the event."
 msgstr ""
 
-#: exhibition/signals.py:76
+#: signals.py:82
 msgid "Request Review Dashboard"
 msgstr ""
 
-#: exhibition/signals.py:80
+#: signals.py:86
 msgid ""
 "Manage exhibitors and sponsors, maintain booth details, and create partner "
 "profiles for the event."
 msgstr ""
 
-#: exhibition/signals.py:82
+#: signals.py:88
 msgid "Exhibitors & Sponsors Dashboard"
 msgstr ""
 
-#: exhibition/signals.py:88 exhibition/templates/exhibitors/base.html:5
-#: exhibition/templates/exhibitors/base.html:125
-#: exhibition/templates/exhibitors/exhibitor_info.html:4
-#: exhibition/templates/exhibitors/exhibitor_info.html:15
+#: signals.py:94 templates/exhibitors/base.html:6
+#: templates/exhibitors/base.html:136
+#: templates/exhibitors/exhibitor_info.html:4
+#: templates/exhibitors/exhibitor_info.html:15
 msgid "Exhibitors & Sponsors"
 msgstr ""
 
-#: exhibition/signals.py:90
+#: signals.py:96
 msgid "Go to"
 msgstr ""
 
-#: exhibition/signals.py:166 exhibition/templates/exhibitors/call_base.html:4
-#: exhibition/templates/exhibitors/call_base.html:7
-#: exhibition/templates/exhibitors/public_call.html:7
-#: exhibition/templates/exhibitors/settings.html:8
-#: exhibition/templates/exhibitors/settings.html:25
+#: signals.py:172 templates/exhibitors/call_base.html:4
+#: templates/exhibitors/call_base.html:7
+#: templates/exhibitors/public_call.html:7 templates/exhibitors/settings.html:8
+#: templates/exhibitors/settings.html:27
 msgid "Call for Exhibitors"
 msgstr ""
 
-#: exhibition/signals.py:207 exhibition/signals.py:231
+#: signals.py:213 signals.py:237
 msgid "Acme Corp"
 msgstr ""
 
-#: exhibition/signals.py:225
+#: signals.py:231
 msgid "Jane Doe"
 msgstr ""
 
-#: exhibition/signals.py:293 exhibition/templates/exhibitors/base.html:62
-#: exhibition/templates/exhibitors/proposal_list.html:5
-#: exhibition/templates/exhibitors/proposal_list.html:15
+#: signals.py:305 templates/exhibitors/base.html:73
+#: templates/exhibitors/proposal_list.html:5
+#: templates/exhibitors/proposal_list.html:15
 msgid "Exhibition requests"
 msgstr ""
 
-#: exhibition/signals.py:298
+#: signals.py:310
 msgid "Exhibition request approved."
 msgstr ""
 
-#: exhibition/signals.py:299
+#: signals.py:311
 msgid "Exhibition request rejected."
 msgstr ""
 
-#: exhibition/signals.py:300
+#: signals.py:312
 msgid "Exhibition request withdrawn."
 msgstr ""
 
-#: exhibition/signals.py:301
+#: signals.py:313
 msgid "Exhibition request reopened for review."
 msgstr ""
 
-#: exhibition/signals.py:302
+#: signals.py:314
 msgid "Exhibition request changed."
 msgstr ""
 
-#: exhibition/signals.py:303
+#: signals.py:315
 msgid "Organization profile created from an approved request."
 msgstr ""
 
-#: exhibition/signals.py:304
+#: signals.py:316
 msgid "Organization profile reactivated after re-approval."
 msgstr ""
 
-#: exhibition/signals.py:305
+#: signals.py:317
 msgid "Organization profile updated from the submitter's changes."
 msgstr ""
 
-#: exhibition/signals.py:306
+#: signals.py:318
 msgid "Organization profile created."
 msgstr ""
 
-#: exhibition/signals.py:307
+#: signals.py:319
 msgid "Organization profile changed."
 msgstr ""
 
-#: exhibition/signals.py:308
+#: signals.py:320
 msgid "Organization profile deleted."
 msgstr ""
 
-#: exhibition/signals.py:309
+#: signals.py:321
 msgid "Exhibition settings changed."
 msgstr ""
 
-#: exhibition/signals.py:310
+#: signals.py:322
 msgid "Call for exhibitors settings changed."
 msgstr ""
 
-#: exhibition/signals.py:311
+#: signals.py:323
 msgid "Private call link regenerated."
 msgstr ""
 
-#: exhibition/signals.py:312
+#: signals.py:324
 msgid "Sponsor group created."
 msgstr ""
 
-#: exhibition/signals.py:313
+#: signals.py:325
 msgid "Sponsor group changed."
 msgstr ""
 
-#: exhibition/signals.py:314 exhibition/views.py:457
+#: signals.py:326 views.py:496
 msgid "Sponsor group deleted."
 msgstr ""
 
-#: exhibition/signals.py:315
+#: signals.py:327
 msgid "Exhibitor form question created."
 msgstr ""
 
-#: exhibition/signals.py:316
+#: signals.py:328
 msgid "Exhibitor form question changed."
 msgstr ""
 
-#: exhibition/signals.py:317
+#: signals.py:329
 msgid "Exhibitor form question deleted."
 msgstr ""
 
-#: exhibition/signals.py:318
+#: signals.py:330
 msgid "Email sent."
 msgstr ""
 
-#: exhibition/signals.py:337
+#: signals.py:349
 #, python-brace-format
 msgid "Updated: {fields}."
 msgstr ""
 
-#: exhibition/signals.py:360
+#: signals.py:372
 #, python-brace-format
 msgid "State changed from {old} to {new}."
 msgstr ""
 
-#: exhibition/signals.py:382
+#: signals.py:394
 #, python-brace-format
 msgid "Exhibition request {val}"
 msgstr ""
 
-#: exhibition/signals.py:391
+#: signals.py:403
 #, python-brace-format
 msgid "Organization profile {val}"
 msgstr ""
 
-#: exhibition/signals.py:400
+#: signals.py:412
 #, python-brace-format
 msgid "Exhibitor form question {val}"
 msgstr ""
 
-#: exhibition/signals.py:409
+#: signals.py:421
 #, python-brace-format
 msgid "Sponsor group {val}"
 msgstr ""
 
-#: exhibition/social_links.py:36
+#: social_links.py:36
 msgid "Facebook"
 msgstr ""
 
-#: exhibition/social_links.py:43
+#: social_links.py:43
 msgid "Flickr"
 msgstr ""
 
-#: exhibition/social_links.py:50
+#: social_links.py:50
 msgid "GitHub"
 msgstr ""
 
-#: exhibition/social_links.py:57
+#: social_links.py:57
 msgid "GitLab"
 msgstr ""
 
-#: exhibition/social_links.py:64
+#: social_links.py:64
 msgid "Gitter"
 msgstr ""
 
-#: exhibition/social_links.py:71
+#: social_links.py:71
 msgid "Google Groups"
 msgstr ""
 
-#: exhibition/social_links.py:78
+#: social_links.py:78
 msgid "Instagram"
 msgstr ""
 
-#: exhibition/social_links.py:85
+#: social_links.py:85
 msgid "LinkedIn"
 msgstr ""
 
-#: exhibition/social_links.py:92
+#: social_links.py:92
 msgid "Mastodon"
 msgstr ""
 
-#: exhibition/social_links.py:99
+#: social_links.py:99
 msgid "Patreon"
 msgstr ""
 
-#: exhibition/social_links.py:106
+#: social_links.py:106
 msgid "Telegram"
 msgstr ""
 
-#: exhibition/social_links.py:113
+#: social_links.py:113
 msgid "Vimeo"
 msgstr ""
 
-#: exhibition/social_links.py:120
+#: social_links.py:120
 msgid "VK"
 msgstr ""
 
-#: exhibition/social_links.py:127
+#: social_links.py:127
 msgid "Weibo"
 msgstr ""
 
-#: exhibition/social_links.py:134
+#: social_links.py:134
 msgid "X"
 msgstr ""
 
-#: exhibition/social_links.py:141
+#: social_links.py:141
 msgid "Xing"
 msgstr ""
 
-#: exhibition/social_links.py:148
+#: social_links.py:148
 msgid "YouTube"
 msgstr ""
 
-#: exhibition/social_links.py:155
+#: social_links.py:155
 msgid "YouTube Privacy"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:7
+#: templates/exhibitors/_email_outbox_body.html:7
 msgid "Created"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:14
+#: templates/exhibitors/_email_outbox_body.html:14
 msgid "Send selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:17
+#: templates/exhibitors/_email_outbox_body.html:17
 msgid "Discard selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:20
+#: templates/exhibitors/_email_outbox_body.html:20
 msgid "Send all"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:23
+#: templates/exhibitors/_email_outbox_body.html:23
 msgid "Discard all"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:35
+#: templates/exhibitors/_email_outbox_body.html:35
 msgid "Scheduled"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:36
-#: exhibition/templates/exhibitors/proposal_list.html:65
+#: templates/exhibitors/_email_outbox_body.html:36
+#: templates/exhibitors/proposal_list.html:65
 msgid "Actions"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:67
-msgid "Send this email"
+#: templates/exhibitors/_email_outbox_body.html:68
+msgid "Send"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:73
-msgid "Edit this email"
+#: templates/exhibitors/_email_outbox_body.html:75
+#: templates/exhibitors/_partner_row.html:54
+#: templates/exhibitors/call_questions.html:73
+#: templates/exhibitors/call_questions.html:76
+#: templates/exhibitors/dashboard.html:120
+#: templates/exhibitors/email_compose.html:55
+#: templates/exhibitors/email_custom_template_form.html:30
+#: templates/exhibitors/email_templates.html:50
+#: templates/exhibitors/email_templates.html:97
+#: templates/exhibitors/public_proposal_list.html:32
+#: templates/exhibitors/settings.html:59
+msgid "Edit"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:79
-msgid "Discard this email"
+#: templates/exhibitors/_email_outbox_body.html:82
+#: templates/exhibitors/email_bulk_discard.html:30
+#: templates/exhibitors/email_delete.html:31
+msgid "Discard"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:91
-#: exhibition/templates/exhibitors/_email_sent_body.html:34
+#: templates/exhibitors/_email_outbox_body.html:95
+#: templates/exhibitors/_email_sent_body.html:35
 msgid "No emails match your search."
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:93
+#: templates/exhibitors/_email_outbox_body.html:97
 msgid "The outbox is empty."
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_sent_body.html:7
-#: exhibition/templates/exhibitors/base.html:105
+#: templates/exhibitors/_email_sent_body.html:7
+#: templates/exhibitors/_partner_row.html:45 templates/exhibitors/base.html:116
 msgid "Sent"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_sent_body.html:36
+#: templates/exhibitors/_email_sent_body.html:37
 msgid "No emails have been sent yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:12
-#: exhibition/templates/exhibitors/public_list.html:29
+#: templates/exhibitors/_filter_form.html:12
+#: templates/exhibitors/public_list.html:29
 msgid "Search"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:18
-#: exhibition/templates/exhibitors/_filter_form.html:20
+#: templates/exhibitors/_filter_form.html:18
+#: templates/exhibitors/_filter_form.html:21
 msgid "Clear filters"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:29
+#: templates/exhibitors/_filter_form.html:30
 msgid "Filters"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:50
+#: templates/exhibitors/_filter_form.html:51
 msgid "Apply filters"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:5
+#: templates/exhibitors/_image_preview_dialog.html:11
+msgid "Close preview"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:5
 #, python-format
 msgid "Select %(name)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:33
+#: templates/exhibitors/_partner_row.html:33
 msgid "Untitled"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:40
+#: templates/exhibitors/_partner_row.html:40
+msgid "Waiting in the outbox"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:41
+msgid "In outbox"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:44
+#, python-format
+msgid "Last sent %(sent)s"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:48
+msgid "Not sent"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:55
 msgid "Copied!"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:40
+#: templates/exhibitors/_partner_row.html:55
 msgid "Copy failed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:40
+#: templates/exhibitors/_partner_row.html:55
 msgid "Key"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:41
-#: exhibition/templates/exhibitors/add.html:231
-#: exhibition/templates/exhibitors/vouchers.html:5
+#: templates/exhibitors/_partner_row.html:56 templates/exhibitors/add.html:235
+#: templates/exhibitors/base.html:42
+#: templates/exhibitors/exhibitor_info.html:95
+#: templates/exhibitors/exhibitor_info.html:125
+#: templates/exhibitors/vouchers.html:5 views.py:2933
 msgid "Vouchers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:42
-#: exhibition/templates/exhibitors/devices.html:5
+#: templates/exhibitors/_partner_row.html:57
+#: templates/exhibitors/devices.html:5
 msgid "Lead-scanning devices"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:45
+#: templates/exhibitors/_partner_row.html:58
+#: templates/exhibitors/call_question_delete.html:19
+#: templates/exhibitors/call_questions.html:74
+#: templates/exhibitors/delete.html:19
+#: templates/exhibitors/email_custom_template_delete.html:19
+#: templates/exhibitors/settings.html:335
+msgid "Delete"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:60
 msgid "Move"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_sort_header.html:7
+#: templates/exhibitors/_sort_header.html:7
 msgid "Sort ascending"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_sort_header.html:10
+#: templates/exhibitors/_sort_header.html:10
 msgid "Sort descending"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:24
+#: templates/exhibitors/add.html:24
 msgid "Profile"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:29
-#: exhibition/templates/exhibitors/add.html:92
-#: exhibition/templates/exhibitors/call_questions.html:62
-#: exhibition/templates/exhibitors/settings.html:50
+#: templates/exhibitors/add.html:29 templates/exhibitors/add.html:92
+#: templates/exhibitors/call_questions.html:62
+#: templates/exhibitors/settings.html:54
 msgid "Optional"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:80
-#: exhibition/templates/exhibitors/public_proposal_form.html:79
+#: templates/exhibitors/add.html:80
+#: templates/exhibitors/public_proposal_form.html:79
 msgid "Add social media link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:137
-#: exhibition/templates/exhibitors/public_proposal_form.html:120
+#: templates/exhibitors/add.html:137
+#: templates/exhibitors/public_proposal_form.html:120
 msgid "Add extra link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:157
-#: exhibition/templates/exhibitors/add.html:160
-#: exhibition/templates/exhibitors/public_proposal_form.html:140
-#: exhibition/templates/exhibitors/public_proposal_form.html:143
+#: templates/exhibitors/add.html:157 templates/exhibitors/add.html:161
+#: templates/exhibitors/public_proposal_form.html:140
+#: templates/exhibitors/public_proposal_form.html:144
 msgid "Logo preview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:162
-#: exhibition/templates/exhibitors/add.html:180
-#: exhibition/templates/exhibitors/public_proposal_form.html:145
-#: exhibition/templates/exhibitors/public_proposal_form.html:163
+#: templates/exhibitors/add.html:164 templates/exhibitors/add.html:184
+#: templates/exhibitors/public_proposal_form.html:147
+#: templates/exhibitors/public_proposal_form.html:167
 msgid "We could not load this image preview."
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:175
-#: exhibition/templates/exhibitors/add.html:178
-#: exhibition/templates/exhibitors/public_proposal_form.html:158
-#: exhibition/templates/exhibitors/public_proposal_form.html:161
+#: templates/exhibitors/add.html:177 templates/exhibitors/add.html:181
+#: templates/exhibitors/public_proposal_form.html:160
+#: templates/exhibitors/public_proposal_form.html:164
 msgid "Header image preview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:196
+#: templates/exhibitors/add.html:200
 msgid "Organizer only"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:237
+#: templates/exhibitors/add.html:241
 msgid "Internal notes"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:244
-#: exhibition/templates/exhibitors/email_edit.html:38
-#: exhibition/templates/exhibitors/public_proposal_form.html:182
-#: exhibition/templates/exhibitors/public_proposal_form.html:186
+#: templates/exhibitors/add.html:248 templates/exhibitors/email_edit.html:38
+#: templates/exhibitors/public_proposal_form.html:186
+#: templates/exhibitors/public_proposal_form.html:190
 msgid "Save changes"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:246
-#: exhibition/templates/exhibitors/call_default_field_form.html:21
-#: exhibition/templates/exhibitors/call_question_form.html:30
-#: exhibition/templates/exhibitors/call_questions.html:96
-#: exhibition/templates/exhibitors/email_custom_template_form.html:51
-#: exhibition/templates/exhibitors/email_templates.html:123
-#: exhibition/templates/exhibitors/proposal_detail.html:188
-#: exhibition/templates/exhibitors/settings.html:85
-#: exhibition/templates/exhibitors/settings.html:170
-#: exhibition/templates/exhibitors/settings.html:269
+#: templates/exhibitors/add.html:250
+#: templates/exhibitors/call_default_field_form.html:21
+#: templates/exhibitors/call_question_form.html:114
+#: templates/exhibitors/call_questions.html:96
+#: templates/exhibitors/email_custom_template_form.html:51
+#: templates/exhibitors/email_templates.html:123
+#: templates/exhibitors/proposal_detail.html:188
+#: templates/exhibitors/settings.html:89 templates/exhibitors/settings.html:217
+#: templates/exhibitors/settings.html:250
+#: templates/exhibitors/settings.html:359
 msgid "Save"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:255
-#: exhibition/templates/exhibitors/call_default_field_form.html:23
-#: exhibition/templates/exhibitors/call_default_field_reset.html:24
-#: exhibition/templates/exhibitors/call_question_delete.html:21
-#: exhibition/templates/exhibitors/call_question_form.html:32
-#: exhibition/templates/exhibitors/delete.html:24
-#: exhibition/templates/exhibitors/email_bulk_discard.html:27
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:21
-#: exhibition/templates/exhibitors/email_custom_template_form.html:53
-#: exhibition/templates/exhibitors/email_delete.html:28
-#: exhibition/templates/exhibitors/proposal_list.html:174
-#: exhibition/templates/exhibitors/public_proposal_form.html:176
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:16
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:21
-#: exhibition/templates/exhibitors/settings.html:194
-#: exhibition/templates/exhibitors/settings.html:270
+#: templates/exhibitors/add.html:259
+#: templates/exhibitors/call_default_field_form.html:23
+#: templates/exhibitors/call_default_field_reset.html:24
+#: templates/exhibitors/call_question_delete.html:21
+#: templates/exhibitors/call_question_form.html:116
+#: templates/exhibitors/delete.html:24
+#: templates/exhibitors/email_bulk_discard.html:27
+#: templates/exhibitors/email_custom_template_delete.html:21
+#: templates/exhibitors/email_custom_template_form.html:53
+#: templates/exhibitors/email_delete.html:28
+#: templates/exhibitors/proposal_list.html:175
+#: templates/exhibitors/public_proposal_form.html:180
+#: templates/exhibitors/public_proposal_reinstate.html:16
+#: templates/exhibitors/public_proposal_withdraw.html:21
+#: templates/exhibitors/settings.html:278
+#: templates/exhibitors/settings.html:360
+#: templates/exhibitors/voucher_bulk_send.html:96
 msgid "Cancel"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:262
-#: exhibition/templates/exhibitors/proposal_detail.html:208
+#: templates/exhibitors/add.html:266
+#: templates/exhibitors/proposal_detail.html:208
 msgid "History"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:11
+#: templates/exhibitors/base.html:17
 msgid "Overview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:18
-#: exhibition/templates/exhibitors/call_questions.html:33
+#: templates/exhibitors/base.html:24
+#: templates/exhibitors/call_questions.html:33
 msgid "Settings"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:26
-#: exhibition/templates/exhibitors/base.html:70
-#: exhibition/templates/exhibitors/dashboard.html:21
-#: exhibition/templates/exhibitors/exhibitor_info.html:4
-#: exhibition/templates/exhibitors/exhibitor_info.html:15
+#: templates/exhibitors/base.html:32 templates/exhibitors/base.html:81
+#: templates/exhibitors/dashboard.html:21
+#: templates/exhibitors/exhibitor_info.html:4
+#: templates/exhibitors/exhibitor_info.html:15
 msgid "Exhibitors"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:31
-#: exhibition/templates/exhibitors/base.html:76
-#: exhibition/templates/exhibitors/dashboard.html:29
-#: exhibition/templates/exhibitors/exhibitor_info.html:4
-#: exhibition/templates/exhibitors/exhibitor_info.html:15
+#: templates/exhibitors/base.html:37 templates/exhibitors/base.html:87
+#: templates/exhibitors/dashboard.html:29
+#: templates/exhibitors/exhibitor_info.html:4
+#: templates/exhibitors/exhibitor_info.html:15
 msgid "Sponsors"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:39
-#: exhibition/templates/exhibitors/dashboard.html:117
+#: templates/exhibitors/base.html:50 templates/exhibitors/dashboard.html:117
 msgid "Call for exhibitors"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:47
+#: templates/exhibitors/base.html:58
 msgid "Content"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:52
-#: exhibition/templates/exhibitors/call_questions.html:5
-#: exhibition/templates/exhibitors/call_questions.html:16
+#: templates/exhibitors/base.html:63 templates/exhibitors/call_questions.html:5
+#: templates/exhibitors/call_questions.html:16
 msgid "Exhibitor form"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:85
+#: templates/exhibitors/base.html:96
 msgid "Message center"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:94
+#: templates/exhibitors/base.html:105
 msgid "Compose"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:99
+#: templates/exhibitors/base.html:110
 msgid "Outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:111
+#: templates/exhibitors/base.html:122
 msgid "Templates"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:130
+#: templates/exhibitors/base.html:141
 msgid "Home"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:134
+#: templates/exhibitors/base.html:145
 msgid "Tickets"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:138
+#: templates/exhibitors/base.html:149
 msgid "Talks"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:143
+#: templates/exhibitors/base.html:154
 msgid "Access videos related to this event"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:144
+#: templates/exhibitors/base.html:155
 msgid "Videos"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_form.html:5
-#: exhibition/templates/exhibitors/call_default_field_form.html:8
-#: exhibition/templates/exhibitors/call_question_form.html:11
-#: exhibition/templates/exhibitors/call_question_form.html:14
+#: templates/exhibitors/call_default_field_form.html:5
+#: templates/exhibitors/call_default_field_form.html:8
+#: templates/exhibitors/call_question_form.html:14
+#: templates/exhibitors/call_question_form.html:17
 msgid "Form field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:4
-#: exhibition/templates/exhibitors/call_default_field_reset.html:7
+#: templates/exhibitors/call_default_field_reset.html:4
+#: templates/exhibitors/call_default_field_reset.html:7
 msgid "Reset form field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:14
+#: templates/exhibitors/call_default_field_reset.html:14
 #, python-format
 msgid ""
 "Are you sure you want to reset \"%(label)s\" back to the default "
 "\"%(default_label)s\"?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:19
+#: templates/exhibitors/call_default_field_reset.html:19
 msgid ""
 "This clears the custom label and help text. Default fields are part of the "
 "form and cannot be deleted; turn the field off with the Active toggle to "
 "hide it."
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:22
-#: exhibition/templates/exhibitors/public_list.html:32
+#: templates/exhibitors/call_default_field_reset.html:22
 msgid "Reset"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_question_delete.html:4
-#: exhibition/templates/exhibitors/call_question_delete.html:7
+#: templates/exhibitors/call_question_delete.html:4
+#: templates/exhibitors/call_question_delete.html:7
 msgid "Delete form field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_question_delete.html:14
+#: templates/exhibitors/call_question_delete.html:14
 #, python-format
 msgid "Are you sure you want to delete the question \"%(question)s\"?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_question_delete.html:19
-#: exhibition/templates/exhibitors/call_questions.html:74
-#: exhibition/templates/exhibitors/delete.html:19
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:19
-msgid "Delete"
+#: templates/exhibitors/call_question_form.html:31
+msgid "Answer options"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:23
+#: templates/exhibitors/call_question_form.html:34
+msgid "Only applicable if you choose a choice field type above."
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:48
+#, python-format
+msgid "Answer option %(id)s"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:56
+#: templates/exhibitors/call_question_form.html:58
+#: templates/exhibitors/call_question_form.html:87
+#: templates/exhibitors/call_question_form.html:89
+msgid "Move option up"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:60
+#: templates/exhibitors/call_question_form.html:62
+#: templates/exhibitors/call_question_form.html:91
+#: templates/exhibitors/call_question_form.html:93
+msgid "Move option down"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:64
+#: templates/exhibitors/call_question_form.html:66
+#: templates/exhibitors/call_question_form.html:95
+#: templates/exhibitors/call_question_form.html:97
+msgid "Delete option"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:81
+msgid "New answer option"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:106
+msgid "Add a new option"
+msgstr ""
+
+#: templates/exhibitors/call_questions.html:23
 msgid "Form fields"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:24
+#: templates/exhibitors/call_questions.html:24
 msgid ""
 "Choose which fields are shown on the exhibitor form and drag any row to "
 "reorder it."
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:29
-#: exhibition/templates/exhibitors/proposal_detail.html:38
+#: templates/exhibitors/call_questions.html:29
+#: templates/exhibitors/proposal_detail.html:38
 msgid "Field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:32
+#: templates/exhibitors/call_questions.html:32
 msgid "Answers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:42
+#: templates/exhibitors/call_questions.html:42
 msgid "Custom"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:48
+#: templates/exhibitors/call_questions.html:48
 #, python-format
 msgid "Toggle active state for %(field)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:61
+#: templates/exhibitors/call_questions.html:61
 #, python-format
 msgid "Required status for %(field)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:73
-#: exhibition/templates/exhibitors/call_questions.html:76
-#: exhibition/templates/exhibitors/dashboard.html:120
-#: exhibition/templates/exhibitors/email_compose.html:55
-#: exhibition/templates/exhibitors/email_custom_template_form.html:30
-#: exhibition/templates/exhibitors/email_templates.html:50
-#: exhibition/templates/exhibitors/email_templates.html:97
-#: exhibition/templates/exhibitors/public_proposal_list.html:32
-#: exhibition/templates/exhibitors/settings.html:55
-msgid "Edit"
-msgstr ""
-
-#: exhibition/templates/exhibitors/call_questions.html:77
+#: templates/exhibitors/call_questions.html:77
 msgid "Reset to default"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:79
+#: templates/exhibitors/call_questions.html:79
 msgid "Move field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:90
+#: templates/exhibitors/call_questions.html:90
 msgid "New custom field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:5
-#: exhibition/templates/exhibitors/dashboard.html:9
+#: templates/exhibitors/dashboard.html:5 templates/exhibitors/dashboard.html:9
 msgid "Exhibition overview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:39
+#: templates/exhibitors/dashboard.html:39
 msgid "Requests awaiting review"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:48
+#: templates/exhibitors/dashboard.html:48
 msgid "Emails in outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:61
+#: templates/exhibitors/dashboard.html:61
 msgid "Recent requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:64
+#: templates/exhibitors/dashboard.html:64
 msgid "View all"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:76
+#: templates/exhibitors/dashboard.html:76
 msgid "Submitted"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:91
-#: exhibition/templates/exhibitors/proposal_detail.html:97
-#: exhibition/templates/exhibitors/proposal_list.html:97
+#: templates/exhibitors/dashboard.html:91
+#: templates/exhibitors/proposal_detail.html:97
+#: templates/exhibitors/proposal_list.html:97
 msgid "Sponsor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:93
-#: exhibition/templates/exhibitors/proposal_detail.html:99
-#: exhibition/templates/exhibitors/proposal_list.html:99
+#: templates/exhibitors/dashboard.html:93
+#: templates/exhibitors/proposal_detail.html:99
+#: templates/exhibitors/proposal_list.html:99
 msgid "Exhibitor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:105
+#: templates/exhibitors/dashboard.html:105
 msgid "No requests have been submitted yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:128
+#: templates/exhibitors/dashboard.html:128
 msgid "The call is not published, so nobody can submit a request."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:131
+#: templates/exhibitors/dashboard.html:131
 msgid "Open"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:134
+#: templates/exhibitors/dashboard.html:134
 #, python-format
 msgid "Closes on %(deadline)s."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:139
+#: templates/exhibitors/dashboard.html:139
 msgid "No deadline set."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:142
+#: templates/exhibitors/dashboard.html:142
 msgid "Closed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:144
+#: templates/exhibitors/dashboard.html:144
 #, python-format
 msgid "The deadline passed on %(deadline)s."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:151
+#: templates/exhibitors/dashboard.html:151
 msgid "Private — reachable only with the secret link."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:157
-#: exhibition/templates/exhibitors/settings.html:90
-#: exhibition/templates/exhibitors/settings.html:94
+#: templates/exhibitors/dashboard.html:157
+#: templates/exhibitors/settings.html:94 templates/exhibitors/settings.html:98
 msgid "View call page"
 msgstr ""
 
-#: exhibition/templates/exhibitors/delete.html:11
+#: templates/exhibitors/delete.html:11
 #, python-format
 msgid ""
 "Are you sure you want to delete “%(name)s”? This action cannot be undone."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:8
+#: templates/exhibitors/devices.html:8
 #, python-format
 msgid "Lead-scanning devices for %(name)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:13
+#: templates/exhibitors/devices.html:13
 #, python-brace-format
 msgid ""
 "Provision check-in app devices for this partner. Each device gets its own "
@@ -1672,66 +1705,64 @@ msgid ""
 "through the {device_tokens} placeholder."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:21
+#: templates/exhibitors/devices.html:21
 msgid ""
 "Provisioning devices requires organizer-level permissions. Ask an organizer "
 "admin to create the devices for this partner."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:29
+#: templates/exhibitors/devices.html:29
 msgid "Provisioned devices"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:35
+#: templates/exhibitors/devices.html:35
 msgid "Device"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:36
+#: templates/exhibitors/devices.html:36
 msgid "Setup token"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:37
+#: templates/exhibitors/devices.html:37
 msgid "Status"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:47
+#: templates/exhibitors/devices.html:47
 msgid "Connected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:49
+#: templates/exhibitors/devices.html:49
 msgid "Awaiting setup"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:60
+#: templates/exhibitors/devices.html:60
 msgid ""
 "Generate new setup tokens? Any device that is already scanning will be "
 "disconnected and must be set up again."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:65
+#: templates/exhibitors/devices.html:65
 msgid "Generate new setup tokens"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:70
+#: templates/exhibitors/devices.html:70
 msgid "No devices have been provisioned for this partner yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:80
-#: exhibition/templates/exhibitors/devices.html:85
+#: templates/exhibitors/devices.html:80 templates/exhibitors/devices.html:85
 msgid "Add devices"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:87
-#: exhibition/templates/exhibitors/vouchers.html:88
+#: templates/exhibitors/devices.html:87 templates/exhibitors/vouchers.html:133
 msgid "Back"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_bulk_discard.html:4
-#: exhibition/templates/exhibitors/email_bulk_discard.html:7
+#: templates/exhibitors/email_bulk_discard.html:4
+#: templates/exhibitors/email_bulk_discard.html:7
 msgid "Discard emails"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_bulk_discard.html:19
+#: templates/exhibitors/email_bulk_discard.html:19
 #, python-format
 msgid ""
 "Are you sure you want to discard %(counter)s queued email? This cannot be "
@@ -1742,80 +1773,80 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/templates/exhibitors/email_bulk_discard.html:30
-#: exhibition/templates/exhibitors/email_delete.html:31
-msgid "Discard"
-msgstr ""
-
-#: exhibition/templates/exhibitors/email_compose.html:7
-#: exhibition/templates/exhibitors/email_compose.html:16
+#: templates/exhibitors/email_compose.html:7
+#: templates/exhibitors/email_compose.html:16
 msgid "Compose email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:21
+#: templates/exhibitors/email_compose.html:21
 msgid ""
 "Send an update to a group of applicants. One email is queued per recipient, "
 "with placeholders resolved individually."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:26
+#: templates/exhibitors/email_compose.html:26
 msgid "Load from template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:28
+#: templates/exhibitors/email_compose.html:28
 msgid "Select a saved template…"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:33
+#: templates/exhibitors/email_compose.html:33
 msgid "Load"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:41
-#: exhibition/templates/exhibitors/email_edit.html:23
+#: templates/exhibitors/email_compose.html:41
+#: templates/exhibitors/email_edit.html:23
 msgid "Recipients"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:47
+#: templates/exhibitors/email_compose.html:47
 msgid "Message"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:58
-#: exhibition/templates/exhibitors/email_custom_template_form.html:33
-#: exhibition/templates/exhibitors/email_templates.html:53
-#: exhibition/templates/exhibitors/email_templates.html:100
-#: exhibition/templates/exhibitors/settings.html:58
+#: templates/exhibitors/email_compose.html:51
+msgctxt "form"
+msgid "required"
+msgstr ""
+
+#: templates/exhibitors/email_compose.html:58
+#: templates/exhibitors/email_custom_template_form.html:33
+#: templates/exhibitors/email_templates.html:53
+#: templates/exhibitors/email_templates.html:100
+#: templates/exhibitors/settings.html:62
 msgid "Preview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:80
+#: templates/exhibitors/email_compose.html:80
 msgid "Save to outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:83
+#: templates/exhibitors/email_compose.html:83
 msgid "Send / Schedule"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:4
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:7
+#: templates/exhibitors/email_custom_template_delete.html:4
+#: templates/exhibitors/email_custom_template_delete.html:7
 msgid "Delete custom template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:14
+#: templates/exhibitors/email_custom_template_delete.html:14
 #, python-format
 msgid "Are you sure you want to delete the custom template \"%(name)s\"?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_custom_template_form.html:7
-#: exhibition/templates/exhibitors/email_custom_template_form.html:15
+#: templates/exhibitors/email_custom_template_form.html:7
+#: templates/exhibitors/email_custom_template_form.html:15
 msgid "Custom template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_delete.html:4
-#: exhibition/templates/exhibitors/email_delete.html:7
+#: templates/exhibitors/email_delete.html:4
+#: templates/exhibitors/email_delete.html:7
 msgid "Discard email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_delete.html:15
+#: templates/exhibitors/email_delete.html:15
 #, python-format
 msgid ""
 "Are you sure you want to discard the email “%(subject)s” to %(counter)s "
@@ -1826,908 +1857,1170 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/templates/exhibitors/email_delete.html:21
+#: templates/exhibitors/email_delete.html:21
 #, python-format
 msgid ""
 "Are you sure you want to discard the email “%(subject)s” to %(to)s? This "
 "cannot be undone."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:5
+#: templates/exhibitors/email_edit.html:5
 msgid "Edit email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:8
+#: templates/exhibitors/email_edit.html:8
 msgid "Preview / edit email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:14
+#: templates/exhibitors/email_edit.html:14
 msgid "Back to outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:41
+#: templates/exhibitors/email_edit.html:41
 msgid "Save & send"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_outbox.html:12
-#: exhibition/templates/exhibitors/email_outbox.html:15
+#: templates/exhibitors/email_outbox.html:12
+#: templates/exhibitors/email_outbox.html:15
 msgid "Email outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_outbox.html:20
+#: templates/exhibitors/email_outbox.html:20
 msgid ""
 "Emails waiting to be sent. Review, edit, or discard them before sending."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_sent.html:12
-#: exhibition/templates/exhibitors/email_sent.html:15
+#: templates/exhibitors/email_sent.html:12
+#: templates/exhibitors/email_sent.html:15
 msgid "Sent emails"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:7
-#: exhibition/templates/exhibitors/email_templates.html:16
+#: templates/exhibitors/email_templates.html:7
+#: templates/exhibitors/email_templates.html:16
 msgid "Email templates"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:22
+#: templates/exhibitors/email_templates.html:22
 msgid "New template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:27
+#: templates/exhibitors/email_templates.html:27
 msgid ""
 "These templates are used for the confirmation email sent when an applicant "
 "submits a request, and for the accept/reject emails you send from the outbox."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:81
+#: templates/exhibitors/email_templates.html:81
 msgid "Discard this template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:31
+#: templates/exhibitors/exhibitor_info.html:31
 msgid "No organizations match your filters."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:33
+#: templates/exhibitors/exhibitor_info.html:33
 msgid "You don't have any sponsors yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:35
+#: templates/exhibitors/exhibitor_info.html:35
 msgid "You don't have any exhibitors yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:37
+#: templates/exhibitors/exhibitor_info.html:37
 msgid "You don't have any exhibitors or sponsors yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:43
-#: exhibition/templates/exhibitors/exhibitor_info.html:52
-#: exhibition/views.py:1837
+#: templates/exhibitors/exhibitor_info.html:43
+#: templates/exhibitors/exhibitor_info.html:57 views.py:1979
 msgid "Add a Sponsor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:43
-#: exhibition/templates/exhibitors/exhibitor_info.html:52
-#: exhibition/views.py:1838
+#: templates/exhibitors/exhibitor_info.html:43
+#: templates/exhibitors/exhibitor_info.html:57 views.py:1980
 msgid "Add an Exhibitor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:43
-#: exhibition/templates/exhibitors/exhibitor_info.html:52
-#: exhibition/views.py:1839
+#: templates/exhibitors/exhibitor_info.html:43
+#: templates/exhibitors/exhibitor_info.html:57 views.py:1981
 msgid "Add an Exhibitor or Sponsor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:48
-#: exhibition/templates/exhibitors/proposal_list.html:169
+#: templates/exhibitors/exhibitor_info.html:48
+#: templates/exhibitors/proposal_list.html:170
 msgid "selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:54
+#: templates/exhibitors/exhibitor_info.html:59
 msgid "Download access keys as CSV"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:56
+#: templates/exhibitors/exhibitor_info.html:61
 msgid "Download sponsor keys"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:56
+#: templates/exhibitors/exhibitor_info.html:61
 msgid "Download exhibitor keys"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:56
+#: templates/exhibitors/exhibitor_info.html:61
 msgid "Download access keys"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:65
+#: templates/exhibitors/exhibitor_info.html:64
+msgid "Queue a voucher email for everyone in this list"
+msgstr ""
+
+#: templates/exhibitors/exhibitor_info.html:65
+msgid "Send vouchers to all"
+msgstr ""
+
+#: templates/exhibitors/exhibitor_info.html:75
 msgid ""
 "Drag-and-drop ordering is available only on the unfiltered, single-page list."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:70
+#: templates/exhibitors/exhibitor_info.html:80
 msgid "Booth"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:78
-#: exhibition/templates/exhibitors/exhibitor_info.html:106
+#: templates/exhibitors/exhibitor_info.html:88
+#: templates/exhibitors/exhibitor_info.html:117
 msgid "Select all partners"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:84
-#: exhibition/templates/exhibitors/exhibitor_info.html:112
+#: templates/exhibitors/exhibitor_info.html:94
+#: templates/exhibitors/exhibitor_info.html:123
 msgid "Group"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:12
-#: exhibition/templates/exhibitors/proposal_detail.html:15
+#: templates/exhibitors/proposal_detail.html:12
+#: templates/exhibitors/proposal_detail.html:15
 msgid "Review exhibition request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:21
+#: templates/exhibitors/proposal_detail.html:21
 msgid "Back to exhibition requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:29
+#: templates/exhibitors/proposal_detail.html:29
 #, python-format
 msgid "Changes made by the applicant after acceptance (%(when)s)"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:39
+#: templates/exhibitors/proposal_detail.html:39
 msgid "Before acceptance"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:40
+#: templates/exhibitors/proposal_detail.html:40
 msgid "After edit"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:55
+#: templates/exhibitors/proposal_detail.html:55
 msgid "The applicant edited the profile, but the tracked fields are unchanged."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:57
+#: templates/exhibitors/proposal_detail.html:57
 msgid ""
 "This profile was edited before change tracking was available, so the "
 "original values are not recorded."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:69
-#: exhibition/templates/exhibitors/proposal_list.html:20
+#: templates/exhibitors/proposal_detail.html:69
+#: templates/exhibitors/proposal_list.html:20
 msgid "Submitter"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:80
+#: templates/exhibitors/proposal_detail.html:80
 msgid "Hidden"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:121
+#: templates/exhibitors/proposal_detail.html:121
 msgid "Message to organizers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:129
+#: templates/exhibitors/proposal_detail.html:129
 msgid "Links"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:152
+#: templates/exhibitors/proposal_detail.html:152
 msgid "Download"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:154
+#: templates/exhibitors/proposal_detail.html:154
 msgid "Custom answers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:176
+#: templates/exhibitors/proposal_detail.html:176
 msgid "Review"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:192
-#: exhibition/templates/exhibitors/proposal_list.html:117
-#: exhibition/templates/exhibitors/proposal_list.html:164
+#: templates/exhibitors/proposal_detail.html:192
+#: templates/exhibitors/proposal_list.html:118
+#: templates/exhibitors/proposal_list.html:165
 msgid "Approve"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:195
-#: exhibition/templates/exhibitors/proposal_list.html:122
-#: exhibition/templates/exhibitors/proposal_list.html:165
+#: templates/exhibitors/proposal_detail.html:195
+#: templates/exhibitors/proposal_list.html:123
+#: templates/exhibitors/proposal_list.html:166
 msgid "Reject"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:200
+#: templates/exhibitors/proposal_detail.html:200
 msgid "Open profile"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:22
+#: templates/exhibitors/proposal_list.html:22
 msgid "Updated"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:33
+#: templates/exhibitors/proposal_list.html:33
 msgid "Select at least one request."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:34
+#: templates/exhibitors/proposal_list.html:34
 msgid "None of the selected requests can be approved."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:35
+#: templates/exhibitors/proposal_list.html:35
 msgid "None of the selected requests can be rejected."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:36
+#: templates/exhibitors/proposal_list.html:36
 #, python-brace-format
 msgid "{count} selected requests cannot be approved and will be skipped."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:37
+#: templates/exhibitors/proposal_list.html:37
 #, python-brace-format
 msgid "{count} selected requests cannot be rejected and will be skipped."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:41
+#: templates/exhibitors/proposal_list.html:41
 msgid "Approve selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:44
+#: templates/exhibitors/proposal_list.html:44
 msgid "Reject selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:55
+#: templates/exhibitors/proposal_list.html:55
 msgid "Select all matching requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:75
+#: templates/exhibitors/proposal_list.html:75
 msgid "Select request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:106
+#: templates/exhibitors/proposal_list.html:106
 msgid "Edited after acceptance, see detail view for changes."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:127
-#: exhibition/templates/exhibitors/proposal_list.html:166
-#: exhibition/templates/exhibitors/public_proposal_list.html:39
+#: templates/exhibitors/proposal_list.html:128
+#: templates/exhibitors/proposal_list.html:167
+#: templates/exhibitors/public_proposal_list.html:39
 msgid "Withdraw"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:132
-#: exhibition/templates/exhibitors/proposal_list.html:167
+#: templates/exhibitors/proposal_list.html:133
+#: templates/exhibitors/proposal_list.html:168
 msgid "Reopen for review"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:137
-#: exhibition/templates/exhibitors/public_proposal_list.html:34
+#: templates/exhibitors/proposal_list.html:138
+#: templates/exhibitors/public_proposal_list.html:34
 msgid "View"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:149
+#: templates/exhibitors/proposal_list.html:150
 msgid "No exhibition requests match your filters."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:151
+#: templates/exhibitors/proposal_list.html:152
 msgid "No exhibition requests have been submitted yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:159
+#: templates/exhibitors/proposal_list.html:160
 msgid "Approve the selected requests and create their partner profiles?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:160
+#: templates/exhibitors/proposal_list.html:161
 msgid "Reject the selected requests?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:161
+#: templates/exhibitors/proposal_list.html:162
 msgid "Reject this request?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:162
+#: templates/exhibitors/proposal_list.html:163
 msgid "Withdraw this request?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:163
+#: templates/exhibitors/proposal_list.html:164
 msgid "Reopen this request for review?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:168
+#: templates/exhibitors/proposal_list.html:169
 msgid "The action could not be completed. Please try again."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:170
+#: templates/exhibitors/proposal_list.html:171
 msgid ""
 "Approve every request matching the current filters, including those on other "
 "pages?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:171
+#: templates/exhibitors/proposal_list.html:172
 msgid ""
 "Reject every request matching the current filters, including those on other "
 "pages?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:172
+#: templates/exhibitors/proposal_list.html:173
 msgid "Please confirm"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:173
+#: templates/exhibitors/proposal_list.html:174
 msgid "Confirm"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:14
+#: templates/exhibitors/public_call.html:14
 msgid "Submit a request to become an exhibitor for this event."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:20
+#: templates/exhibitors/public_call.html:20
 #, python-format
 msgid "You can submit requests until %(deadline)s (%(timezone)s)."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:24
+#: templates/exhibitors/public_call.html:24
 #, python-format
 msgid "This call closed on %(deadline)s (%(timezone)s)."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:34
+#: templates/exhibitors/public_call.html:34
 msgid "View your requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:40
-#: exhibition/templates/exhibitors/public_proposal_form.html:18
-#: exhibition/templates/exhibitors/public_proposal_list.html:65
+#: templates/exhibitors/public_call.html:40
+#: templates/exhibitors/public_proposal_form.html:18
+#: templates/exhibitors/public_proposal_list.html:65
 msgid "Submit a request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:42
+#: templates/exhibitors/public_call.html:42
 msgid "Requests are closed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:21
-#: exhibition/templates/exhibitors/public_detail.html:94
+#: templates/exhibitors/public_detail.html:21
+#: templates/exhibitors/public_detail.html:93
 msgid "Previous"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:24
-#: exhibition/templates/exhibitors/public_detail.html:98
+#: templates/exhibitors/public_detail.html:24
+#: templates/exhibitors/public_detail.html:97
 msgid "Next"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:47
+#: templates/exhibitors/public_detail.html:47
 msgid "Get In Touch"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:87
-#: exhibition/templates/exhibitors/public_detail.html:103
+#: templates/exhibitors/public_detail.html:87
+#: templates/exhibitors/public_detail.html:102
 msgid "Open slides PDF"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:88
-#, python-brace-format
-msgid "Slide {current} of {total}"
-msgstr ""
-
-#: exhibition/templates/exhibitors/public_detail.html:112
+#: templates/exhibitors/public_detail.html:111
 msgid "Send email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:126
+#: templates/exhibitors/public_detail.html:125
 msgid "Visit website"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_list.html:54
+#: templates/exhibitors/public_list.html:32
+msgid "Clear"
+msgstr ""
+
+#: templates/exhibitors/public_list.html:54
 msgid "No exhibitors match your search."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_list.html:56
+#: templates/exhibitors/public_list.html:56
 msgid "No exhibitors are currently available."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:16
+#: templates/exhibitors/public_proposal_form.html:16
 msgid "Edit request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:23
-#: exhibition/views.py:883
+#: templates/exhibitors/public_proposal_form.html:23 views.py:958
 msgid "This request can no longer be edited."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:186
+#: templates/exhibitors/public_proposal_form.html:190
 msgid "Submit request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:189
+#: templates/exhibitors/public_proposal_form.html:193
 msgid "or save as draft for now"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:199
+#: templates/exhibitors/public_proposal_form.html:203
 msgid "Back to your requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:5
+#: templates/exhibitors/public_proposal_list.html:5
 msgid "Your exhibition requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:13
+#: templates/exhibitors/public_proposal_list.html:13
 msgid "Last modified"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:23
+#: templates/exhibitors/public_proposal_list.html:23
 msgid "Withdrawn"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:44
+#: templates/exhibitors/public_proposal_list.html:44
 msgid "Reinstate"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:56
+#: templates/exhibitors/public_proposal_list.html:56
 msgid "Create a new request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:61
+#: templates/exhibitors/public_proposal_list.html:61
 msgid "You have not submitted an exhibition request yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:5
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:21
+#: templates/exhibitors/public_proposal_reinstate.html:5
+#: templates/exhibitors/public_proposal_reinstate.html:21
 msgid "Reinstate request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:7
+#: templates/exhibitors/public_proposal_reinstate.html:7
 #, python-format
 msgid ""
 "Do you want to reinstate your withdrawn request “%(name)s”? It will be "
 "pending review again."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:5
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:26
+#: templates/exhibitors/public_proposal_withdraw.html:5
+#: templates/exhibitors/public_proposal_withdraw.html:26
 msgid "Withdraw request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:7
+#: templates/exhibitors/public_proposal_withdraw.html:7
 #, python-format
 msgid "Are you sure you want to withdraw your request “%(name)s”?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:13
+#: templates/exhibitors/public_proposal_withdraw.html:13
 msgid ""
 "This request has already been approved. Withdrawing it will hide the "
 "exhibitor or sponsor profile created from it from public listings."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:10
-#: exhibition/templates/exhibitors/settings.html:27
+#: templates/exhibitors/settings.html:10 templates/exhibitors/settings.html:29
 msgid "Sponsor Settings"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:12
-#: exhibition/templates/exhibitors/settings.html:29
+#: templates/exhibitors/settings.html:12 templates/exhibitors/settings.html:31
+msgid "Voucher Settings"
+msgstr ""
+
+#: templates/exhibitors/settings.html:14 templates/exhibitors/settings.html:33
 msgid "Exhibitor Settings"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:42
+#: templates/exhibitors/settings.html:46
 msgid "Publish your call"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:43
+#: templates/exhibitors/settings.html:47
 msgid "Publish a login-required application form for exhibitors."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:72
+#: templates/exhibitors/settings.html:76
 msgid ""
 "This panel renders unsaved draft text using the same styling as the live "
 "public call page."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:104
+#: templates/exhibitors/settings.html:108
 msgid "Secret call link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:107
+#: templates/exhibitors/settings.html:111
 msgid ""
 "This call is private: it is not linked anywhere public. Share the link below "
 "with the organizations you want to invite. Anyone who has it can open the "
 "call and apply."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:113
+#: templates/exhibitors/settings.html:117
 msgid "Copied"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:113
+#: templates/exhibitors/settings.html:117
 msgid "Copy to clipboard"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:114
+#: templates/exhibitors/settings.html:118
 msgid "Copy"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:119
+#: templates/exhibitors/settings.html:123
 msgid ""
 "Regenerate the secret link? The current link will stop working immediately."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:125
+#: templates/exhibitors/settings.html:129
 msgid "Regenerate link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:127
+#: templates/exhibitors/settings.html:131
 msgid "Regenerating immediately invalidates the current link."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:138
+#: templates/exhibitors/settings.html:143
+msgid "Voucher pools"
+msgstr ""
+
+#: templates/exhibitors/settings.html:147
+msgid ""
+"Create the voucher codes under Tickets → Vouchers and give them a tag, then "
+"pick that tag here. Exhibitors and sponsors are handed codes from the pool "
+"you choose. Reload this page to pick up a tag you just created."
+msgstr ""
+
+#: templates/exhibitors/settings.html:157
+msgid "Create vouchers pool"
+msgstr ""
+
+#: templates/exhibitors/settings.html:159
+msgid "(opens in a new tab)"
+msgstr ""
+
+#: templates/exhibitors/settings.html:168
+#: templates/exhibitors/settings.html:182
+#, python-format
+msgid "%(counter)s voucher in this pool is not assigned to anyone yet."
+msgid_plural ""
+"%(counter)s vouchers in this pool are not assigned to anyone yet."
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/exhibitors/settings.html:194
+msgid "How many each one gets"
+msgstr ""
+
+#: templates/exhibitors/settings.html:196
+msgid ""
+"Applies to any exhibitor or sponsor that does not belong to a sponsor group. "
+"Sponsor groups set their own number on the Sponsors page, and an individual "
+"exhibitor or sponsor can be given a different number on their own voucher "
+"page."
+msgstr ""
+
+#: templates/exhibitors/settings.html:206
+msgid "Voucher email"
+msgstr ""
+
+#: templates/exhibitors/settings.html:208
+msgid "Applies to the voucher email sent to exhibitors and sponsors alike."
+msgstr ""
+
+#: templates/exhibitors/settings.html:228
 msgid "Data access"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:139
+#: templates/exhibitors/settings.html:229
 msgid ""
 "In this section, you can control which attendee data is shared with "
 "exhibitors when an exhibitor voucher is used or when the exhibitor uses the "
 "lead scanning app."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:142
+#: templates/exhibitors/settings.html:232
 msgid "Exhibitor vouchers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:158
-msgid "Exhibitor login"
-msgstr ""
-
-#: exhibition/templates/exhibitors/settings.html:160
-msgid ""
-"The access-code email sent to exhibitors is now edited together with the "
-"plugin's other email templates."
-msgstr ""
-
-#: exhibition/templates/exhibitors/settings.html:162
-msgid "Edit email templates"
-msgstr ""
-
-#: exhibition/templates/exhibitors/settings.html:177
+#: templates/exhibitors/settings.html:257
 msgid "Group List"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:180
+#: templates/exhibitors/settings.html:260
 msgid "Add a Group"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:193
+#: templates/exhibitors/settings.html:272
+#: templates/exhibitors/settings.html:354
+msgid "Voucher defaults for this group"
+msgstr ""
+
+#: templates/exhibitors/settings.html:277
 msgid "Add"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:204
+#: templates/exhibitors/settings.html:288
 msgid "Group Name"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:206
+#: templates/exhibitors/settings.html:290
 msgid "Partners"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:207
+#: templates/exhibitors/settings.html:291
 msgid "Front Page"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:220
-#: exhibition/templates/exhibitors/settings.html:226
+#: templates/exhibitors/settings.html:304
+#: templates/exhibitors/settings.html:310
 msgid "Show this sponsor group in the Supported By section on the front page."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:251
+#: templates/exhibitors/settings.html:326
+msgid "Edit sponsor group"
+msgstr ""
+
+#: templates/exhibitors/settings.html:337
 msgid "Reorder sponsor group"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:281
+#: templates/exhibitors/settings.html:371
 msgid "You do not have any sponsor groups yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:8
+#: templates/exhibitors/voucher_bulk_send.html:4
+#: templates/exhibitors/voucher_bulk_send.html:7
+msgid "Send vouchers"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:18
+#, python-format
+msgid "A voucher email will be placed in the outbox for %(counter)s sponsor."
+msgid_plural ""
+"A voucher email will be placed in the outbox for %(counter)s sponsors."
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:24
+#, python-format
+msgid "A voucher email will be placed in the outbox for %(counter)s exhibitor."
+msgid_plural ""
+"A voucher email will be placed in the outbox for %(counter)s exhibitors."
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:37
+#, python-format
+msgid "&mdash; %(counter)s voucher will be created"
+msgid_plural "&mdash; %(counter)s vouchers will be created"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:45
+#, python-format
+msgid "&mdash; %(counter)s existing voucher"
+msgid_plural "&mdash; %(counter)s existing vouchers"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:58
+msgid "None of the sponsors in this list can be emailed yet."
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:60
+msgid "None of the exhibitors in this list can be emailed yet."
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:66
+msgid "Skipped: no email address"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:75
+msgid "Skipped: voucher count is set to 0"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:84
+msgid "Skipped: no vouchers available from their pool"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:86
+msgid ""
+"Check that a voucher pool is selected under Settings → Vouchers and that it "
+"still has unassigned codes."
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:99
+msgid "Queue emails"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:8
 #, python-format
 msgid "Vouchers for %(name)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:13
+#: templates/exhibitors/vouchers.html:13
 msgid ""
-"Issue ticket vouchers for this partner to hand out. Whoever redeems one on "
-"the ticket shop becomes a lead this partner can retrieve, as long as voucher "
+"Hand this exhibitor or sponsor codes from the voucher pool. Whoever redeems "
+"one on the ticket shop becomes a lead they can retrieve, as long as voucher "
 "data access is enabled for them."
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:20
-msgid "Issued vouchers"
+#: templates/exhibitors/vouchers.html:20
+msgid "Assigned vouchers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:24
+#: templates/exhibitors/vouchers.html:24
 msgid "Download codes (CSV)"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:31
+#: templates/exhibitors/vouchers.html:31
 msgid "Code"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:32 exhibition/views.py:1994
+#: templates/exhibitors/vouchers.html:32 utils.py:495
 msgid "Product"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:34 exhibition/views.py:1998
+#: templates/exhibitors/vouchers.html:33 utils.py:496
+msgid "Price effect"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:34 utils.py:499
 msgid "Redeemed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:56
+#: templates/exhibitors/vouchers.html:35 utils.py:498
+msgid "Valid until"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:56
 msgid "Already redeemed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:67
-msgid "No vouchers have been issued for this partner yet."
+#: templates/exhibitors/vouchers.html:62
+msgid "Return to pool"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:76
-msgid "Issue new vouchers"
+#: templates/exhibitors/vouchers.html:74
+msgid "No vouchers have been assigned to this partner yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:86
-msgid "Create vouchers"
+#: templates/exhibitors/vouchers.html:82
+msgid "Take more from the pool"
 msgstr ""
 
-#: exhibition/templates/sponsors/presale_supported_by.html:4
+#: templates/exhibitors/vouchers.html:84
+msgid ""
+"Codes come from the voucher pool chosen under Settings. The email always "
+"carries this partner's complete list of codes, so you can assign some now "
+"and send them together with more later. It is placed in the outbox for you "
+"to review before it goes out."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:92
+#, python-format
+msgid "%(counter)s voucher is left unassigned in the pool."
+msgid_plural "%(counter)s vouchers are left unassigned in the pool."
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/exhibitors/vouchers.html:100 views.py:2230
+msgid "No voucher pool is selected yet. Choose one under Settings → Vouchers."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:106
+msgid "A voucher email for this partner is waiting in the outbox."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:108
+msgid "Go to outbox"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:114
+#, python-format
+msgid "Vouchers were last emailed to this partner on %(sent)s."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:120
+msgid ""
+"This partner has no email address on file, so vouchers cannot be emailed."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:127
+msgid "Assign and prepare email"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:130
+msgid "Assign without emailing"
+msgstr ""
+
+#: templates/sponsors/presale_supported_by.html:4
 msgid "Supported By"
 msgstr ""
 
-#: exhibition/views.py:324
+#: utils.py:493
+msgid "Voucher code"
+msgstr ""
+
+#: utils.py:494
+msgid "Redeem link"
+msgstr ""
+
+#: utils.py:497
+msgid "Value"
+msgstr ""
+
+#: utils.py:500
+msgid "Maximum usages"
+msgstr ""
+
+#: views.py:342
 msgid "Company name"
 msgstr ""
 
-#: exhibition/views.py:325
+#: views.py:343
 msgid "Job title"
 msgstr ""
 
-#: exhibition/views.py:326
+#: views.py:344
 msgid "Address"
 msgstr ""
 
-#: exhibition/views.py:333
+#: views.py:351
 msgid "Attendee Name"
 msgstr ""
 
-#: exhibition/views.py:338
+#: views.py:356
 msgid "Attendee Email"
 msgstr ""
 
-#: exhibition/views.py:377
+#: views.py:395 views.py:412
 msgid "Settings have been saved."
 msgstr ""
 
-#: exhibition/views.py:393
+#: views.py:428
 msgid "Call settings have been saved."
 msgstr ""
 
-#: exhibition/views.py:401
+#: views.py:436
 msgid ""
 "A new secret call link has been generated. The old link no longer works."
 msgstr ""
 
-#: exhibition/views.py:416
+#: views.py:451
 msgid "Sponsor group added."
 msgstr ""
 
-#: exhibition/views.py:437
+#: views.py:454 views.py:477 views.py:853 views.py:1169 views.py:1796
+#: views.py:1918 views.py:2564 views.py:3025
+msgid "We could not save your changes. See below for details."
+msgstr ""
+
+#: views.py:474
 msgid "Sponsor group updated."
 msgstr ""
 
-#: exhibition/views.py:452
+#: views.py:491
 msgid "This sponsor group cannot be deleted while it is assigned to partners."
 msgstr ""
 
-#: exhibition/views.py:460
+#: views.py:499
 msgid "Unknown action."
 msgstr ""
 
-#: exhibition/views.py:505
+#: views.py:544
 msgid "Access key"
 msgstr ""
 
-#: exhibition/views.py:745 exhibition/views.py:1060
+#: views.py:819 views.py:1135
 msgid "Add at least one social media link."
 msgstr ""
 
-#: exhibition/views.py:754 exhibition/views.py:1069
+#: views.py:828 views.py:1144
 msgid "Add at least one extra link."
 msgstr ""
 
-#: exhibition/views.py:809
+#: views.py:884
 msgid "The call for exhibitors is closed."
 msgstr ""
 
-#: exhibition/views.py:837
+#: views.py:912
 msgid "Your request has been saved."
 msgstr ""
 
-#: exhibition/views.py:920 exhibition/views.py:1776
+#: views.py:995 views.py:1914
 msgid "Your changes have been saved."
 msgstr ""
 
-#: exhibition/views.py:953
+#: views.py:1028
 msgid "This proposal can no longer be withdrawn."
 msgstr ""
 
-#: exhibition/views.py:961
+#: views.py:1036
 msgid "Your request has been withdrawn."
 msgstr ""
 
-#: exhibition/views.py:963
+#: views.py:1038
 msgid "This request can no longer be withdrawn."
 msgstr ""
 
-#: exhibition/views.py:989 exhibition/views.py:999
+#: views.py:1064 views.py:1074
 msgid "This request can no longer be reinstated."
 msgstr ""
 
-#: exhibition/views.py:997
+#: views.py:1072
 msgid "Your request has been reinstated and is pending review again."
 msgstr ""
 
-#: exhibition/views.py:1121
+#: views.py:1197
 msgid "Invalid request body."
 msgstr ""
 
-#: exhibition/views.py:1124 exhibition/views.py:1129
+#: views.py:1200 views.py:1205
 msgid "Invalid sponsor group IDs."
 msgstr ""
 
-#: exhibition/views.py:1133
+#: views.py:1209
 msgid "Sponsor group IDs must be unique."
 msgstr ""
 
-#: exhibition/views.py:1141
+#: views.py:1217
 msgid "Reorder request must include each sponsor group exactly once."
 msgstr ""
 
-#: exhibition/views.py:1346
+#: views.py:1422
 msgid "This request can no longer be changed to that state."
 msgstr ""
 
-#: exhibition/views.py:1350
+#: views.py:1426
 msgid "Review details saved."
 msgstr ""
 
-#: exhibition/views.py:1359
+#: views.py:1435
 msgid ""
 "Request approved and partner profile created. An acceptance email was placed "
 "in the outbox."
 msgstr ""
 
-#: exhibition/views.py:1369
+#: views.py:1445
 msgid "Request rejected. A rejection email was placed in the outbox."
 msgstr ""
 
-#: exhibition/views.py:1372
+#: views.py:1448
 msgid "Request withdrawn."
 msgstr ""
 
-#: exhibition/views.py:1375
+#: views.py:1451
 msgid "Request reopened for review."
 msgstr ""
 
-#: exhibition/views.py:1407
+#: views.py:1483
 msgid "No valid action was selected."
 msgstr ""
 
-#: exhibition/views.py:1454
+#: views.py:1530
 #, python-format
 msgid "%(count)d request was approved."
 msgid_plural "%(count)d requests were approved."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1455
+#: views.py:1531
 #, python-format
 msgid "%(count)d request was rejected."
 msgid_plural "%(count)d requests were rejected."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1456
+#: views.py:1532
 #, python-format
 msgid "%(count)d request was withdrawn."
 msgid_plural "%(count)d requests were withdrawn."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1457
+#: views.py:1533
 #, python-format
 msgid "%(count)d request was reopened."
 msgid_plural "%(count)d requests were reopened."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1461
+#: views.py:1537
 msgid "No proposals were updated."
 msgstr ""
 
-#: exhibition/views.py:1464
+#: views.py:1540
 #, python-format
 msgid "%(skipped)d was skipped because it was already processed."
 msgid_plural "%(skipped)d were skipped because they were already processed."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1605
+#: views.py:1681
 msgid "Exhibitor form settings have been saved."
 msgstr ""
 
-#: exhibition/views.py:1730
+#: views.py:1868
 msgid "The requested form field does not exist."
 msgstr ""
 
-#: exhibition/views.py:1791
+#: views.py:1933
 msgid "The field has been reset to its default."
 msgstr ""
 
-#: exhibition/views.py:1829 exhibition/views.py:1900
+#: views.py:1971 views.py:2042
 msgid "An access-credentials email was placed in the outbox."
 msgstr ""
 
-#: exhibition/views.py:1907
+#: views.py:2049
 msgid "Edit Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1908
+#: views.py:2050
 msgid "Edit Exhibitor"
 msgstr ""
 
-#: exhibition/views.py:1909
+#: views.py:2051
 msgid "Edit Exhibitor & Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1910
+#: views.py:2052
 msgid "Edit Exhibitor or Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1940
+#: views.py:2082
 msgid "Delete Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1941
+#: views.py:2083
 msgid "Delete Exhibitor"
 msgstr ""
 
-#: exhibition/views.py:1942
+#: views.py:2084
 msgid "Delete Exhibitor & Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1943
+#: views.py:2085
 msgid "Delete Exhibitor or Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1992
-msgid "Voucher code"
+#: views.py:2164
+msgid "This voucher has already been redeemed and cannot be returned."
 msgstr ""
 
-#: exhibition/views.py:1993
-msgid "Redeem link"
+#: views.py:2170
+msgid ""
+"This code was already included in a voucher email to this partner, so it "
+"cannot be returned to the pool. Delete it under Tickets → Vouchers instead."
 msgstr ""
 
-#: exhibition/views.py:1999
-msgid "Maximum usages"
+#: views.py:2176
+msgid "Voucher returned to the pool."
 msgstr ""
 
-#: exhibition/views.py:2035
-msgid "This voucher has already been redeemed and cannot be removed."
+#: views.py:2207
+msgid "Enter how many vouchers to take from the pool."
 msgstr ""
 
-#: exhibition/views.py:2040
-msgid "Voucher removed."
-msgstr ""
-
-#: exhibition/views.py:2060
+#: views.py:2215
 #, python-format
-msgid "%(count)d voucher created."
-msgid_plural "%(count)d vouchers created."
+msgid "%(count)d voucher taken from the pool."
+msgid_plural "%(count)d vouchers taken from the pool."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2112
+#: views.py:2232
+#, python-format
+msgid ""
+"The pool only has %(remaining)d voucher(s) left, so %(count)d cannot be "
+"taken."
+msgstr ""
+
+#: views.py:2244
+msgid "No email address is on file, so vouchers cannot be emailed."
+msgstr ""
+
+#: views.py:2253
+msgid "This partner holds no vouchers yet, so there is nothing to email."
+msgstr ""
+
+#: views.py:2259
+#, python-format
+msgid "An email with %(count)d voucher code was placed in the outbox."
+msgid_plural "An email with %(count)d voucher codes was placed in the outbox."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2347
+msgid "There is nobody to send vouchers to in this list."
+msgstr ""
+
+#: views.py:2354
+#, python-format
+msgid "%(count)d voucher email was placed in the outbox."
+msgid_plural "%(count)d voucher emails were placed in the outbox."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2371
+#, python-format
+msgid ""
+"%(count)d was skipped because no unassigned codes were available from their "
+"pool."
+msgid_plural ""
+"%(count)d were skipped because no unassigned codes were available from their "
+"pool."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2386
+#, python-format
+msgid "%(count)d sponsor was skipped because it has no email address."
+msgid_plural ""
+"%(count)d sponsors were skipped because they have no email address."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2392
+#, python-format
+msgid "%(count)d exhibitor was skipped because it has no email address."
+msgid_plural ""
+"%(count)d exhibitors were skipped because they have no email address."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2401
+#, python-format
+msgid "%(count)d sponsor was skipped because their voucher count is set to 0."
+msgid_plural ""
+"%(count)d sponsors were skipped because their voucher count is set to 0."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2407
+#, python-format
+msgid ""
+"%(count)d exhibitor was skipped because their voucher count is set to 0."
+msgid_plural ""
+"%(count)d exhibitors were skipped because their voucher count is set to 0."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2461
 #, python-format
 msgid "%(count)d device added."
 msgid_plural "%(count)d devices added."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2123
+#: views.py:2472
 #, python-format
 msgid ""
 "New setup tokens generated. %(count)d device that was already scanning is "
@@ -2738,79 +3031,95 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2132
+#: views.py:2481
 msgid "New setup tokens generated."
 msgstr ""
 
-#: exhibition/views.py:2194
+#: views.py:2543
 msgid "No applicants matched the selected filters."
 msgstr ""
 
-#: exhibition/views.py:2202
+#: views.py:2551
 #, python-format
 msgid "%(count)d emails have been scheduled."
 msgstr ""
 
-#: exhibition/views.py:2206
+#: views.py:2555
 #, python-format
 msgid "%(count)d emails have been sent."
 msgstr ""
 
-#: exhibition/views.py:2210
+#: views.py:2559
 #, python-format
 msgid "%(count)d emails have been placed in the outbox."
 msgstr ""
 
-#: exhibition/views.py:2385
+#: views.py:2738
 msgid "The emails have been saved and sent."
 msgstr ""
 
-#: exhibition/views.py:2389
+#: views.py:2742
 msgid "The emails have been saved."
 msgstr ""
 
-#: exhibition/views.py:2395
+#: views.py:2748
 msgid "The email has been saved and sent."
 msgstr ""
 
-#: exhibition/views.py:2399
+#: views.py:2752
 msgid "The email has been saved."
 msgstr ""
 
-#: exhibition/views.py:2423 exhibition/views.py:2497
+#: views.py:2776 views.py:2850
 #, python-format
 msgid "%(count)d email has been sent."
 msgid_plural "%(count)d emails have been sent."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2459
+#: views.py:2812
 msgid "The email has been discarded."
 msgstr ""
 
-#: exhibition/views.py:2501 exhibition/views.py:2514 exhibition/views.py:2519
+#: views.py:2854 views.py:2867 views.py:2872
 msgid "No emails were selected."
 msgstr ""
 
-#: exhibition/views.py:2510
+#: views.py:2863
 #, python-format
 msgid "%(count)d email has been discarded."
 msgid_plural "%(count)d emails have been discarded."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2594
+#: views.py:2929
+msgid "Request received (confirmation)"
+msgstr ""
+
+#: views.py:2930
+msgid "Request accepted"
+msgstr ""
+
+#: views.py:2931
+msgid "Request rejected"
+msgstr ""
+
+#: views.py:2932
+msgid "Exhibitor lead scanning key"
+msgstr ""
+
+#: views.py:2948
 msgid "Email templates have been saved."
 msgstr ""
 
-#: exhibition/views.py:2617 exhibition/views.py:2621
+#: views.py:2971 views.py:2975
 msgid "Unknown template."
 msgstr ""
 
-#: exhibition/views.py:2667
+#: views.py:3021
 msgid "Custom template has been created."
 msgstr ""
 
-#: exhibition/views.py:2683
+#: views.py:3041
 msgid "Custom template has been deleted."
 msgstr ""

--- a/exhibition/locale/hi/LC_MESSAGES/django.po
+++ b/exhibition/locale/hi/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 10:11+0000\n"
+"POT-Creation-Date: 2026-09-11 11:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,595 +18,531 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: exhibition/apps.py:14 exhibition/apps.py:17 exhibition/signals.py:157
-#: exhibition/templates/exhibitors/public_list.html:6
-#: exhibition/templates/exhibitors/public_list.html:14
-#: exhibition/templates/exhibitors/public_list.html:16
+#: apps.py:14 apps.py:17 signals.py:163 templates/exhibitors/public_list.html:6
+#: templates/exhibitors/public_list.html:14
+#: templates/exhibitors/public_list.html:16
 msgid "Exhibition"
 msgstr ""
 
-#: exhibition/apps.py:19
+#: apps.py:19
 msgid "This plugin enables to add and control exhibitors in eventyay"
 msgstr ""
 
-#: exhibition/filters.py:9
+#: filters.py:9
 msgid "Any"
 msgstr ""
 
-#: exhibition/filters.py:10
+#: filters.py:10
 msgid "Enabled"
 msgstr ""
 
-#: exhibition/filters.py:11 exhibition/templates/exhibitors/dashboard.html:127
+#: filters.py:11 templates/exhibitors/dashboard.html:127
 msgid "Disabled"
 msgstr ""
 
-#: exhibition/filters.py:15
+#: filters.py:15
 msgid "All types"
 msgstr ""
 
-#: exhibition/filters.py:16
+#: filters.py:16
 msgid "Exhibitor only"
 msgstr ""
 
-#: exhibition/filters.py:17
+#: filters.py:17
 msgid "Sponsor only"
 msgstr ""
 
-#: exhibition/filters.py:18 exhibition/templates/exhibitors/dashboard.html:89
-#: exhibition/templates/exhibitors/proposal_detail.html:95
-#: exhibition/templates/exhibitors/proposal_list.html:95
+#: filters.py:18 templates/exhibitors/dashboard.html:89
+#: templates/exhibitors/proposal_detail.html:95
+#: templates/exhibitors/proposal_list.html:95
 msgid "Exhibitor and sponsor"
 msgstr ""
 
-#: exhibition/filters.py:80 exhibition/filters.py:81
+#: filters.py:80 filters.py:81
 msgid "Search requests…"
 msgstr ""
 
-#: exhibition/filters.py:81
+#: filters.py:81
 msgid "Search requests"
 msgstr ""
 
-#: exhibition/filters.py:85 exhibition/templates/exhibitors/dashboard.html:75
-#: exhibition/templates/exhibitors/proposal_detail.html:85
-#: exhibition/templates/exhibitors/proposal_list.html:21
-#: exhibition/templates/exhibitors/public_proposal_list.html:12
+#: filters.py:85 templates/exhibitors/dashboard.html:75
+#: templates/exhibitors/proposal_detail.html:85
+#: templates/exhibitors/proposal_list.html:21
+#: templates/exhibitors/public_proposal_list.html:12
 msgid "State"
 msgstr ""
 
-#: exhibition/filters.py:86
+#: filters.py:86
 msgid "All states"
 msgstr ""
 
-#: exhibition/filters.py:90 exhibition/templates/exhibitors/dashboard.html:74
-#: exhibition/templates/exhibitors/proposal_detail.html:91
-#: exhibition/templates/exhibitors/proposal_list.html:62
+#: filters.py:90 templates/exhibitors/dashboard.html:74
+#: templates/exhibitors/proposal_detail.html:91
+#: templates/exhibitors/proposal_list.html:62
 msgid "Type"
 msgstr ""
 
-#: exhibition/filters.py:99 exhibition/filters.py:102
+#: filters.py:99 filters.py:102
 msgid "Search by name…"
 msgstr ""
 
-#: exhibition/filters.py:103
+#: filters.py:103
 msgid "Search requests by name"
 msgstr ""
 
-#: exhibition/filters.py:132 exhibition/filters.py:133
+#: filters.py:132 filters.py:133
 msgid "Search organizations…"
 msgstr ""
 
-#: exhibition/filters.py:133
+#: filters.py:133
 msgid "Search organizations"
 msgstr ""
 
-#: exhibition/filters.py:137
+#: filters.py:137
 msgid "Visibility"
 msgstr ""
 
-#: exhibition/filters.py:139
+#: filters.py:139
 msgid "All organizations"
 msgstr ""
 
-#: exhibition/filters.py:140 exhibition/forms.py:1512
-#: exhibition/templates/exhibitors/call_questions.html:30
+#: filters.py:140 forms.py:1553 templates/exhibitors/call_questions.html:30
 msgid "Active"
 msgstr ""
 
-#: exhibition/filters.py:141
+#: filters.py:141
 msgid "Inactive"
 msgstr ""
 
-#: exhibition/filters.py:146 exhibition/filters.py:207 exhibition/forms.py:207
-#: exhibition/forms.py:1410 exhibition/forms.py:1841
+#: filters.py:146 filters.py:207 forms.py:212 forms.py:1411 forms.py:1888
 msgid "Sponsor group"
 msgstr ""
 
-#: exhibition/filters.py:149 exhibition/filters.py:210
+#: filters.py:149 filters.py:210
 msgid "All groups"
 msgstr ""
 
-#: exhibition/filters.py:152 exhibition/templates/exhibitors/add.html:222
+#: filters.py:152 templates/exhibitors/add.html:226
 msgid "Lead scanning"
 msgstr ""
 
-#: exhibition/filters.py:157
+#: filters.py:157
 msgid "Lead access"
 msgstr ""
 
-#: exhibition/filters.py:162
+#: filters.py:162
 msgid "Voucher access"
 msgstr ""
 
-#: exhibition/filters.py:202 exhibition/filters.py:203
+#: filters.py:202 filters.py:203
 msgid "Search exhibitors…"
 msgstr ""
 
-#: exhibition/filters.py:203
+#: filters.py:203
 msgid "Search exhibitors"
 msgstr ""
 
-#: exhibition/filters.py:240 exhibition/filters.py:241
+#: filters.py:240 filters.py:241
 msgid "Search emails…"
 msgstr ""
 
-#: exhibition/filters.py:241
+#: filters.py:241
 msgid "Search emails"
 msgstr ""
 
-#: exhibition/forms.py:67
+#: forms.py:72
 #, python-format
 msgid "Times are in the event timezone: %(tz)s."
 msgstr ""
 
-#: exhibition/forms.py:128 exhibition/forms.py:139 exhibition/forms.py:933
-#: exhibition/forms.py:944
+#: forms.py:133 forms.py:144 forms.py:934 forms.py:945
 msgid "— No selection —"
 msgstr ""
 
-#: exhibition/forms.py:211
+#: forms.py:216
 msgid "Can view voucher redemptions"
 msgstr ""
 
-#: exhibition/forms.py:213 exhibition/forms.py:397
+#: forms.py:218 forms.py:402
 msgid ""
 "Lets this exhibitor or sponsor retrieve the attendees who redeemed vouchers "
 "issued to them. Separate from lead scanning, which covers attendees scanned "
 "at the booth."
 msgstr ""
 
-#: exhibition/forms.py:219
+#: forms.py:224
 msgid "Can view and export collected leads"
 msgstr ""
 
-#: exhibition/forms.py:221
+#: forms.py:226
 msgid ""
 "Lets this exhibitor retrieve the full list of leads they have already "
 "scanned. Turn this off to let them keep scanning without seeing the "
 "collected attendee data."
 msgstr ""
 
-#: exhibition/forms.py:226
+#: forms.py:231
 msgid "Lead scanning behavior"
 msgstr ""
 
-#: exhibition/forms.py:231
+#: forms.py:236
 msgid ""
 "Every attendee is one lead, even when scanned from multiple devices. Notes "
 "and ratings are shared between devices."
 msgstr ""
 
-#: exhibition/forms.py:238
+#: forms.py:243
 msgid ""
 "Every attendee is a new lead when scanned from a new device. Notes and "
 "ratings are specific to the device."
 msgstr ""
 
-#: exhibition/forms.py:251
+#: forms.py:256
 msgid "Comment"
 msgstr ""
 
-#: exhibition/forms.py:253
+#: forms.py:258
 msgid ""
 "The text entered in this field will not be visible to the user and is "
 "available for your convenience."
 msgstr ""
 
-#: exhibition/forms.py:258 exhibition/forms.py:1427 exhibition/views.py:505
+#: forms.py:263 forms.py:1428 views.py:544
 msgid "Booth ID"
 msgstr ""
 
-#: exhibition/forms.py:291 exhibition/forms.py:1027 exhibition/forms.py:1076
-#: exhibition/models.py:130
+#: forms.py:296 forms.py:1028 forms.py:1077 models.py:130
 msgid "Organization name"
 msgstr ""
 
-#: exhibition/forms.py:292 exhibition/forms.py:1030 exhibition/forms.py:1077
-#: exhibition/models.py:136
+#: forms.py:297 forms.py:1031 forms.py:1078 models.py:136
 msgid "Organization description"
 msgstr ""
 
-#: exhibition/forms.py:293 exhibition/forms.py:1078
+#: forms.py:298 forms.py:1079
 msgid "E-mail"
 msgstr ""
 
-#: exhibition/forms.py:294 exhibition/forms.py:1079 exhibition/models.py:139
+#: forms.py:299 forms.py:1080 models.py:139
 msgid "Contact page URL"
 msgstr ""
 
-#: exhibition/forms.py:295 exhibition/forms.py:1080 exhibition/models.py:140
+#: forms.py:300 forms.py:1081 models.py:140
 msgid "Promotional video URL"
 msgstr ""
 
-#: exhibition/forms.py:296 exhibition/forms.py:1081 exhibition/models.py:141
+#: forms.py:301 forms.py:1082 models.py:141
 msgid "Promotional slides"
 msgstr ""
 
-#: exhibition/forms.py:297 exhibition/forms.py:1082 exhibition/models.py:142
-#: exhibition/models.py:520
-#: exhibition/templates/exhibitors/proposal_detail.html:111
+#: forms.py:302 forms.py:1083 models.py:142 models.py:568
+#: templates/exhibitors/proposal_detail.html:111
 msgid "Logo"
 msgstr ""
 
-#: exhibition/forms.py:298 exhibition/forms.py:1083 exhibition/models.py:145
-#: exhibition/templates/exhibitors/proposal_detail.html:113
+#: forms.py:303 forms.py:1084 models.py:145
+#: templates/exhibitors/proposal_detail.html:113
 msgid "Header image"
 msgstr ""
 
-#: exhibition/forms.py:299 exhibition/forms.py:1084 exhibition/models.py:138
+#: forms.py:304 forms.py:1085 models.py:138
 msgid "Organization website"
 msgstr ""
 
-#: exhibition/forms.py:300
+#: forms.py:305
 msgid "Mark this partner as an exhibitor"
 msgstr ""
 
-#: exhibition/forms.py:301
+#: forms.py:306
 msgid "Mark this partner as an event sponsor"
 msgstr ""
 
-#: exhibition/forms.py:302 exhibition/forms.py:1036 exhibition/forms.py:1085
-#: exhibition/models.py:148 exhibition/models.py:522
+#: forms.py:307 forms.py:1037 forms.py:1086 models.py:148 models.py:570
 msgid "Preferred booth name"
 msgstr ""
 
-#: exhibition/forms.py:303
+#: forms.py:308
 msgid "Can scan attendee badges"
 msgstr ""
 
-#: exhibition/forms.py:307
+#: forms.py:312
 msgid ""
 "Lets this exhibitor sign in to the lead scanning app and scan attendees at "
 "their booth. Turn this off to block scanning entirely."
 msgstr ""
 
-#: exhibition/forms.py:348 exhibition/forms.py:1441
+#: forms.py:353 forms.py:1442
 msgid "No sponsor group"
 msgstr ""
 
-#: exhibition/forms.py:385
+#: forms.py:390
 msgid ""
 "Lets this exhibitor retrieve the attendees who redeemed vouchers issued to "
 "them. Separate from lead scanning, which covers attendees scanned at the "
 "booth."
 msgstr ""
 
-#: exhibition/forms.py:389
+#: forms.py:394
 msgid ""
 "Lets this sponsor retrieve the attendees who redeemed vouchers issued to "
 "them. Separate from lead scanning, which covers attendees scanned at the "
 "booth."
 msgstr ""
 
-#: exhibition/forms.py:393
+#: forms.py:398
 msgid ""
 "Lets this exhibitor and sponsor retrieve the attendees who redeemed vouchers "
 "issued to them. Separate from lead scanning, which covers attendees scanned "
 "at the booth."
 msgstr ""
 
-#: exhibition/forms.py:466 exhibition/forms.py:553 exhibition/forms.py:1361
-#: exhibition/forms.py:1375
+#: forms.py:471 forms.py:558 forms.py:1362 forms.py:1376 forms.py:1855
+#: forms.py:1924 forms.py:1930 forms.py:1932 forms.py:1934
 msgid "This field is required."
 msgstr ""
 
-#: exhibition/forms.py:511 exhibition/forms.py:516
+#: forms.py:516 forms.py:521
 msgid "Slides upload must be a PDF file."
 msgstr ""
 
-#: exhibition/forms.py:540
+#: forms.py:545
 msgid "A partner must be marked as an exhibitor, a sponsor, or both."
 msgstr ""
 
-#: exhibition/forms.py:615
+#: forms.py:620
 msgid "Devices to add"
 msgstr ""
 
-#: exhibition/forms.py:617
+#: forms.py:622
 msgid ""
 "How many new devices to provision now, in addition to any already listed "
 "above. Each device gets its own single-use setup token and QR code."
 msgstr ""
 
-#: exhibition/forms.py:627
-msgid "Select a product…"
+#: forms.py:635
+msgid "Vouchers to take from the pool"
 msgstr ""
 
-#: exhibition/forms.py:628
-msgid "Ticket product"
+#: forms.py:636
+msgid ""
+"Set to 0 to email the codes this partner already has without taking any more."
 msgstr ""
 
-#: exhibition/forms.py:629
-msgid "The product a redeemed voucher applies to."
-msgstr ""
-
-#: exhibition/forms.py:635
-msgid "Number of vouchers"
-msgstr ""
-
-#: exhibition/forms.py:640
-msgid "Maximum usages per voucher"
-msgstr ""
-
-#: exhibition/forms.py:645 exhibition/templates/exhibitors/vouchers.html:33
-#: exhibition/views.py:1995
-msgid "Price effect"
-msgstr ""
-
-#: exhibition/forms.py:651 exhibition/views.py:1996
-msgid "Value"
-msgstr ""
-
-#: exhibition/forms.py:652
-msgid "Amount or percentage, depending on the selected price effect."
-msgstr ""
-
-#: exhibition/forms.py:657 exhibition/templates/exhibitors/vouchers.html:35
-#: exhibition/views.py:1997
-msgid "Valid until"
-msgstr ""
-
-#: exhibition/forms.py:673
-msgid "Enter a value for the selected price effect."
-msgstr ""
-
-#: exhibition/forms.py:678 exhibition/models.py:295
-#: exhibition/templates/exhibitors/settings.html:205
+#: forms.py:647 models.py:326 templates/exhibitors/settings.html:289
 msgid "Level"
 msgstr ""
 
-#: exhibition/forms.py:685 exhibition/models.py:294
+#: forms.py:654 models.py:325
 msgid "Group name"
 msgstr ""
 
-#: exhibition/forms.py:718
+#: forms.py:677 models.py:225
+msgid "Exhibitor voucher pool"
+msgstr ""
+
+#: forms.py:678 models.py:232
+msgid "Sponsor voucher pool"
+msgstr ""
+
+#: forms.py:698
+msgid "— No pool selected —"
+msgstr ""
+
+#: forms.py:699
+msgid "— Use the exhibitor pool —"
+msgstr ""
+
+#: forms.py:719
 msgid "Enable call"
 msgstr ""
 
-#: exhibition/forms.py:719
+#: forms.py:720
 msgid "Hide call page after the deadline"
 msgstr ""
 
-#: exhibition/forms.py:720
+#: forms.py:721
 msgid "Make this call private (accessible only via a secret link)"
 msgstr ""
 
-#: exhibition/forms.py:724
+#: forms.py:725
 msgid ""
 "Turn the call on. Keep it enabled for private calls too, otherwise the "
 "secret link stops working."
 msgstr ""
 
-#: exhibition/forms.py:727
+#: forms.py:728
 msgid ""
 "The call page is not linked anywhere public and can only be opened with the "
 "secret link shown below."
 msgstr ""
 
-#: exhibition/forms.py:868
+#: forms.py:869
 msgid "Your answer"
 msgstr ""
 
-#: exhibition/forms.py:1024 exhibition/models.py:563
-#: exhibition/templates/exhibitors/proposal_detail.html:88
+#: forms.py:1025 models.py:611 templates/exhibitors/proposal_detail.html:88
 msgid "Language"
 msgstr ""
 
-#: exhibition/forms.py:1025
+#: forms.py:1026
 msgid "The language you are filling in this form with."
 msgstr ""
 
-#: exhibition/forms.py:1086 exhibition/models.py:151 exhibition/models.py:523
-#: exhibition/models.py:602
+#: forms.py:1087 models.py:151 models.py:571 models.py:650
 msgid "Message to the organizers"
 msgstr ""
 
-#: exhibition/forms.py:1149
+#: forms.py:1150
 msgid ""
 "The organization name is locked after acceptance. Contact the organizers to "
 "change it."
 msgstr ""
 
-#: exhibition/forms.py:1425
+#: forms.py:1426
 msgid "Approve as exhibitor"
 msgstr ""
 
-#: exhibition/forms.py:1426
+#: forms.py:1427
 msgid "Approve as sponsor"
 msgstr ""
 
-#: exhibition/forms.py:1428 exhibition/models.py:352 exhibition/models.py:596
-#: exhibition/models.py:966 exhibition/views.py:505
+#: forms.py:1429 models.py:383 models.py:644 models.py:1014 views.py:544
 msgid "Booth name"
 msgstr ""
 
-#: exhibition/forms.py:1429 exhibition/forms.py:1459 exhibition/models.py:607
+#: forms.py:1430 forms.py:1460 models.py:655
 msgid "Internal review notes"
 msgstr ""
 
-#: exhibition/forms.py:1470
+#: forms.py:1471
 msgid "Field label"
 msgstr ""
 
-#: exhibition/forms.py:1475 exhibition/forms.py:1510
+#: forms.py:1476 forms.py:1551
 msgid "Help text"
 msgstr ""
 
-#: exhibition/forms.py:1476
+#: forms.py:1477
 msgid "Shown below the field on the exhibitor form."
 msgstr ""
 
-#: exhibition/forms.py:1483
+#: forms.py:1484
 #, python-format
 msgid "Leave empty to use the default: %(label)s"
 msgstr ""
 
-#: exhibition/forms.py:1492
-msgid "Options"
-msgstr ""
-
-#: exhibition/forms.py:1493
-msgid "For choice fields, enter one option per line."
-msgstr ""
-
-#: exhibition/forms.py:1508
-msgid "Field type"
-msgstr ""
-
-#: exhibition/forms.py:1509 exhibition/models.py:878
-msgid "Custom question"
-msgstr ""
-
-#: exhibition/forms.py:1511
-#: exhibition/templates/exhibitors/call_questions.html:31
-#: exhibition/templates/exhibitors/call_questions.html:63
-msgid "Required"
-msgstr ""
-
-#: exhibition/forms.py:1535
+#: forms.py:1523
 msgid "Please provide at least one option for this question type."
 msgstr ""
 
-#: exhibition/forms.py:1576 exhibition/forms.py:1665
+#: forms.py:1549
+msgid "Field type"
+msgstr ""
+
+#: forms.py:1550 models.py:926
+msgid "Custom question"
+msgstr ""
+
+#: forms.py:1552 templates/exhibitors/call_questions.html:31
+#: templates/exhibitors/call_questions.html:63
+msgid "Required"
+msgstr ""
+
+#: forms.py:1583 forms.py:1672
 msgid "Choose social platform"
 msgstr ""
 
-#: exhibition/forms.py:1578 exhibition/forms.py:1667
+#: forms.py:1585 forms.py:1674
 msgid "Social platform"
 msgstr ""
 
-#: exhibition/forms.py:1582 exhibition/forms.py:1671
+#: forms.py:1589 forms.py:1678
 msgid "Profile or path"
 msgstr ""
 
-#: exhibition/forms.py:1596 exhibition/forms.py:1685
+#: forms.py:1603 forms.py:1692
 msgid "Profile, handle, or full URL"
 msgstr ""
 
-#: exhibition/forms.py:1616 exhibition/forms.py:1705
+#: forms.py:1623 forms.py:1712
 msgid "Please enter a profile, handle, or URL or remove this row."
 msgstr ""
 
-#: exhibition/forms.py:1622 exhibition/forms.py:1711
+#: forms.py:1629 forms.py:1718
 msgid "Please choose a social platform."
 msgstr ""
 
-#: exhibition/forms.py:1626 exhibition/forms.py:1715
+#: forms.py:1633 forms.py:1722
 msgid "Please enter a profile, handle, or URL."
 msgstr ""
 
-#: exhibition/forms.py:1648 exhibition/forms.py:1737
+#: forms.py:1655 forms.py:1744
 msgid "Link label"
 msgstr ""
 
-#: exhibition/forms.py:1654 exhibition/forms.py:1743
+#: forms.py:1661 forms.py:1750
 msgid "https://example.com"
 msgstr ""
 
-#: exhibition/forms.py:1807
+#: forms.py:1848
 msgid ""
 "Leave empty to keep this in the outbox until sent manually. Time is "
 "interpreted in the event timezone."
 msgstr ""
 
-#: exhibition/forms.py:1814 exhibition/forms.py:1877
+#: forms.py:1861 forms.py:1940
 msgid "The scheduled time must be in the future."
 msgstr ""
 
-#: exhibition/forms.py:1822
+#: forms.py:1869
 msgid "Exhibitors and sponsors"
 msgstr ""
 
-#: exhibition/forms.py:1823
+#: forms.py:1870
 msgid "Exhibitors only"
 msgstr ""
 
-#: exhibition/forms.py:1824
+#: forms.py:1871
 msgid "Sponsors only"
 msgstr ""
 
-#: exhibition/forms.py:1828
+#: forms.py:1875
 msgid "Application state"
 msgstr ""
 
-#: exhibition/forms.py:1836
+#: forms.py:1883
 msgid "Partner type"
 msgstr ""
 
-#: exhibition/forms.py:1844
+#: forms.py:1891
 msgid "Any sponsor group"
 msgstr ""
 
-#: exhibition/forms.py:1846 exhibition/models.py:1035 exhibition/models.py:1089
-#: exhibition/templates/exhibitors/_email_outbox_body.html:6
-#: exhibition/templates/exhibitors/_email_sent_body.html:6
+#: forms.py:1893 forms.py:1953 models.py:1084 models.py:1146
+#: templates/exhibitors/_email_outbox_body.html:6
+#: templates/exhibitors/_email_sent_body.html:6
 msgid "Subject"
 msgstr ""
 
-#: exhibition/forms.py:1848
+#: forms.py:1895
 msgid "Send at"
 msgstr ""
 
-#: exhibition/forms.py:1851
+#: forms.py:1898
 msgid "Leave empty to send immediately or save to the outbox."
 msgstr ""
 
-#: exhibition/forms.py:1859 exhibition/models.py:1036 exhibition/models.py:1090
+#: forms.py:1906 forms.py:1960 models.py:1085 models.py:1147
 msgid "Body"
 msgstr ""
 
-#: exhibition/forms.py:1885 exhibition/views.py:2576
-msgid "Request received (confirmation)"
-msgstr ""
-
-#: exhibition/forms.py:1886 exhibition/views.py:2577
-msgid "Request accepted"
-msgstr ""
-
-#: exhibition/forms.py:1887 exhibition/views.py:2578
-msgid "Request rejected"
-msgstr ""
-
-#: exhibition/forms.py:1888 exhibition/views.py:2579
-msgid "Exhibitor lead scanning key"
-msgstr ""
-
-#: exhibition/forms.py:1897
-#, python-format
-msgid "%(role)s — subject"
-msgstr ""
-
-#: exhibition/forms.py:1904
-#, python-format
-msgid "%(role)s — body"
-msgstr ""
-
-#: exhibition/mail.py:57
+#: mail.py:59
 #, python-brace-format
 msgid "We received your request for {event_name}"
 msgstr ""
 
-#: exhibition/mail.py:59
+#: mail.py:61
 #, python-brace-format
 msgid ""
 "Hello,\n"
@@ -621,12 +557,12 @@ msgid ""
 "The {event_name} team"
 msgstr ""
 
-#: exhibition/mail.py:69
+#: mail.py:71
 #, python-brace-format
 msgid "Your request for {event_name} has been accepted"
 msgstr ""
 
-#: exhibition/mail.py:71
+#: mail.py:73
 #, python-brace-format
 msgid ""
 "Hello,\n"
@@ -638,12 +574,12 @@ msgid ""
 "The {event_name} team"
 msgstr ""
 
-#: exhibition/mail.py:80
+#: mail.py:82
 #, python-brace-format
 msgid "Update on your request for {event_name}"
 msgstr ""
 
-#: exhibition/mail.py:82
+#: mail.py:84
 #, python-brace-format
 msgid ""
 "Hello,\n"
@@ -657,12 +593,12 @@ msgid ""
 "The {event_name} team"
 msgstr ""
 
-#: exhibition/mail.py:91
+#: mail.py:93
 #, python-brace-format
 msgid "Lead Scanning Access for {event_name}"
 msgstr ""
 
-#: exhibition/mail.py:93
+#: mail.py:95
 #, python-brace-format
 msgid ""
 "Hello {exhibitor_name},\n"
@@ -688,983 +624,1080 @@ msgid ""
 "The {event_name} Team"
 msgstr ""
 
-#: exhibition/mail.py:174
+#: mail.py:110
+#, python-brace-format
+msgid "Your vouchers for {event_name} — {exhibitor_name}"
+msgstr ""
+
+#: mail.py:112
+#, python-brace-format
+msgid ""
+"Dear {exhibitor_name},\n"
+"\n"
+"Thank you for participating in {event_name}. Please share the voucher codes "
+"below with your audience — anyone who uses one gets credited to you as a "
+"lead.\n"
+"\n"
+"{voucher_list}\n"
+"\n"
+"They can redeem a code on the event ticket shop at checkout.\n"
+"\n"
+"If you have any questions, please don't hesitate to reach out.\n"
+"\n"
+"Best regards,\n"
+"The {event_name} Team"
+msgstr ""
+
+#: mail.py:190
 msgid "This value will be replaced based on dynamic parameters."
 msgstr ""
 
-#: exhibition/models.py:137 exhibition/models.py:515
+#: mail.py:312
+#, python-format
+msgid "…and %(count)d more voucher code in the attached CSV file."
+msgid_plural "…and %(count)d more voucher codes in the attached CSV file."
+msgstr[0] ""
+msgstr[1] ""
+
+#: models.py:137 models.py:563
 msgid "Contact email"
 msgstr ""
 
-#: exhibition/models.py:156
-#: exhibition/templates/exhibitors/proposal_detail.html:132
+#: models.py:156 templates/exhibitors/proposal_detail.html:132
 msgid "Social media"
 msgstr ""
 
-#: exhibition/models.py:161
-#: exhibition/templates/exhibitors/proposal_detail.html:140
+#: models.py:161 templates/exhibitors/proposal_detail.html:140
 msgid "Extra links"
 msgstr ""
 
-#: exhibition/models.py:216
+#: models.py:212
+msgid "Vouchers per exhibitor"
+msgstr ""
+
+#: models.py:226
+msgid ""
+"The voucher tag created under Tickets → Vouchers that exhibitors draw their "
+"codes from."
+msgstr ""
+
+#: models.py:233
+msgid "Leave empty to draw sponsor codes from the exhibitor pool as well."
+msgstr ""
+
+#: models.py:239
+msgid "Attach voucher list as CSV"
+msgstr ""
+
+#: models.py:240
+msgid ""
+"Adds a spreadsheet of the recipient's own voucher codes to the voucher email."
+msgstr ""
+
+#: models.py:247
 msgid "Call headline"
 msgstr ""
 
-#: exhibition/models.py:220
+#: models.py:251
 msgid "Call text"
 msgstr ""
 
-#: exhibition/models.py:225
+#: models.py:256
 msgid "Submission deadline"
 msgstr ""
 
-#: exhibition/models.py:298
+#: models.py:329
 msgid "Show this sponsor group on the front page."
 msgstr ""
 
-#: exhibition/models.py:314 exhibition/models.py:558
-#: exhibition/templates/exhibitors/dashboard.html:73
-#: exhibition/templates/exhibitors/exhibitor_info.html:69
-#: exhibition/templates/exhibitors/proposal_list.html:19
-#: exhibition/templates/exhibitors/public_proposal_list.html:11
-#: exhibition/views.py:505
+#: models.py:345 models.py:606 templates/exhibitors/dashboard.html:73
+#: templates/exhibitors/exhibitor_info.html:79
+#: templates/exhibitors/proposal_list.html:19
+#: templates/exhibitors/public_proposal_list.html:11 views.py:544
 msgid "Name"
 msgstr ""
 
-#: exhibition/models.py:315 exhibition/models.py:559
-#: exhibition/templates/exhibitors/proposal_detail.html:117
+#: models.py:346 models.py:607 templates/exhibitors/proposal_detail.html:117
 msgid "Description"
 msgstr ""
 
-#: exhibition/models.py:316 exhibition/models.py:419 exhibition/models.py:435
-#: exhibition/models.py:565 exhibition/models.py:815 exhibition/models.py:831
-#: exhibition/models.py:844
-#: exhibition/templates/exhibitors/proposal_detail.html:103
+#: models.py:347 models.py:467 models.py:483 models.py:613 models.py:863
+#: models.py:879 models.py:892 templates/exhibitors/proposal_detail.html:103
 msgid "URL"
 msgstr ""
 
-#: exhibition/models.py:317 exhibition/models.py:566
-#: exhibition/templates/exhibitors/proposal_detail.html:77
-#: exhibition/views.py:505
+#: models.py:348 models.py:614 templates/exhibitors/proposal_detail.html:77
+#: views.py:544
 msgid "Email"
 msgstr ""
 
-#: exhibition/models.py:318 exhibition/models.py:567
-#: exhibition/templates/exhibitors/proposal_detail.html:105
+#: models.py:349 models.py:615 templates/exhibitors/proposal_detail.html:105
 msgid "Contact URL"
 msgstr ""
 
-#: exhibition/models.py:319 exhibition/models.py:568
-#: exhibition/templates/exhibitors/proposal_detail.html:107
+#: models.py:350 models.py:616 templates/exhibitors/proposal_detail.html:107
 msgid "Video URL"
 msgstr ""
 
-#: exhibition/models.py:322 exhibition/models.py:571
-#: exhibition/templates/exhibitors/proposal_detail.html:109
+#: models.py:353 models.py:619 templates/exhibitors/proposal_detail.html:109
 msgid "Slides"
 msgstr ""
 
-#: exhibition/models.py:326 exhibition/models.py:575
+#: models.py:357 models.py:623
 msgid "Slides URL"
 msgstr ""
 
-#: exhibition/models.py:328 exhibition/models.py:577
+#: models.py:359 models.py:625
 msgid "Logo URL"
 msgstr ""
 
-#: exhibition/models.py:330 exhibition/models.py:579
+#: models.py:361 models.py:627
 msgid "Header image URL"
 msgstr ""
 
-#: exhibition/models.py:434 exhibition/models.py:830
+#: models.py:482 models.py:878
 msgid "Label"
 msgstr ""
 
-#: exhibition/models.py:445
+#: models.py:493
 msgid "draft"
 msgstr ""
 
-#: exhibition/models.py:446
+#: models.py:494
 msgid "submitted"
 msgstr ""
 
-#: exhibition/models.py:447
+#: models.py:495
 msgid "accepted"
 msgstr ""
 
-#: exhibition/models.py:448
+#: models.py:496
 msgid "rejected"
 msgstr ""
 
-#: exhibition/models.py:449
+#: models.py:497
 msgid "withdrawn"
 msgstr ""
 
-#: exhibition/models.py:514
+#: models.py:562
 msgid "Organization Description"
 msgstr ""
 
-#: exhibition/models.py:516
+#: models.py:564
 msgid "Organization Website"
 msgstr ""
 
-#: exhibition/models.py:517
+#: models.py:565
 msgid "Contact Page URL"
 msgstr ""
 
-#: exhibition/models.py:518
+#: models.py:566
 msgid "Promotional Video URL"
 msgstr ""
 
-#: exhibition/models.py:519
+#: models.py:567
 msgid "Promotional Slides"
 msgstr ""
 
-#: exhibition/models.py:521
+#: models.py:569
 msgid "Header Image"
 msgstr ""
 
-#: exhibition/models.py:524 exhibition/templates/exhibitors/add.html:29
-#: exhibition/templates/exhibitors/public_proposal_form.html:38
+#: models.py:572 templates/exhibitors/add.html:29
+#: templates/exhibitors/public_proposal_form.html:38
 msgid "Social Media"
 msgstr ""
 
-#: exhibition/models.py:525 exhibition/templates/exhibitors/add.html:92
-#: exhibition/templates/exhibitors/public_proposal_form.html:91
+#: models.py:573 templates/exhibitors/add.html:92
+#: templates/exhibitors/public_proposal_form.html:91
 msgid "Extra Links"
 msgstr ""
 
-#: exhibition/models.py:841
+#: models.py:889
 msgid "Number"
 msgstr ""
 
-#: exhibition/models.py:842
+#: models.py:890
 msgid "Text (one line)"
 msgstr ""
 
-#: exhibition/models.py:843
+#: models.py:891
 msgid "Multiline text"
 msgstr ""
 
-#: exhibition/models.py:845
+#: models.py:893
 msgid "Email address"
 msgstr ""
 
-#: exhibition/models.py:846
+#: models.py:894
 msgid "Confirm Checkbox"
 msgstr ""
 
-#: exhibition/models.py:847
+#: models.py:895
 msgid "Radio button (Choose one option)"
 msgstr ""
 
-#: exhibition/models.py:848
+#: models.py:896
 msgid "Dropdown (Choose one option)"
 msgstr ""
 
-#: exhibition/models.py:849
+#: models.py:897
 msgid "Checkbox (Choose one or several options)"
 msgstr ""
 
-#: exhibition/models.py:850
+#: models.py:898
 msgid "File upload"
 msgstr ""
 
-#: exhibition/models.py:851
+#: models.py:899
 msgid "Date"
 msgstr ""
 
-#: exhibition/models.py:852
+#: models.py:900
 msgid "Time"
 msgstr ""
 
-#: exhibition/models.py:853
+#: models.py:901
 msgid "Date and time"
 msgstr ""
 
-#: exhibition/models.py:854
+#: models.py:902
 msgid "Country code (ISO 3166-1 alpha-2)"
 msgstr ""
 
-#: exhibition/models.py:855
+#: models.py:903
 msgid "Phone number"
 msgstr ""
 
-#: exhibition/models.py:883
+#: models.py:931
 msgid "help text"
 msgstr ""
 
-#: exhibition/models.py:885 exhibition/templates/exhibitors/add.html:29
-#: exhibition/templates/exhibitors/add.html:92
-#: exhibition/templates/exhibitors/public_proposal_form.html:38
-#: exhibition/templates/exhibitors/public_proposal_form.html:91
+#: models.py:933 templates/exhibitors/add.html:29
+#: templates/exhibitors/add.html:92
+#: templates/exhibitors/public_proposal_form.html:38
+#: templates/exhibitors/public_proposal_form.html:91
 msgid "required"
 msgstr ""
 
-#: exhibition/models.py:886
+#: models.py:934
 msgid "active"
 msgstr ""
 
-#: exhibition/models.py:906
+#: models.py:954
 msgid "Response"
 msgstr ""
 
-#: exhibition/models.py:938
+#: models.py:986
 msgid "Yes"
 msgstr ""
 
-#: exhibition/models.py:940
+#: models.py:988
 msgid "No"
 msgstr ""
 
-#: exhibition/models.py:1034
-#: exhibition/templates/exhibitors/_email_outbox_body.html:5
-#: exhibition/templates/exhibitors/_email_sent_body.html:5
+#: models.py:1083 templates/exhibitors/_email_outbox_body.html:5
+#: templates/exhibitors/_email_sent_body.html:5
 msgid "Recipient"
 msgstr ""
 
-#: exhibition/models.py:1045
+#: models.py:1101
 msgid "Queued email"
 msgstr ""
 
-#: exhibition/models.py:1046
+#: models.py:1102
 msgid "Queued emails"
 msgstr ""
 
-#: exhibition/models.py:1088
+#: models.py:1145
 msgid "Template name"
 msgstr ""
 
-#: exhibition/models.py:1095
+#: models.py:1152
 msgid "Custom email template"
 msgstr ""
 
-#: exhibition/models.py:1096
+#: models.py:1153
 msgid "Custom email templates"
 msgstr ""
 
-#: exhibition/signals.py:75
+#: signals.py:81
 msgid "Screen and evaluate exhibitor and sponsor requests for the event."
 msgstr ""
 
-#: exhibition/signals.py:76
+#: signals.py:82
 msgid "Request Review Dashboard"
 msgstr ""
 
-#: exhibition/signals.py:80
+#: signals.py:86
 msgid ""
 "Manage exhibitors and sponsors, maintain booth details, and create partner "
 "profiles for the event."
 msgstr ""
 
-#: exhibition/signals.py:82
+#: signals.py:88
 msgid "Exhibitors & Sponsors Dashboard"
 msgstr ""
 
-#: exhibition/signals.py:88 exhibition/templates/exhibitors/base.html:5
-#: exhibition/templates/exhibitors/base.html:125
-#: exhibition/templates/exhibitors/exhibitor_info.html:4
-#: exhibition/templates/exhibitors/exhibitor_info.html:15
+#: signals.py:94 templates/exhibitors/base.html:6
+#: templates/exhibitors/base.html:136
+#: templates/exhibitors/exhibitor_info.html:4
+#: templates/exhibitors/exhibitor_info.html:15
 msgid "Exhibitors & Sponsors"
 msgstr ""
 
-#: exhibition/signals.py:90
+#: signals.py:96
 msgid "Go to"
 msgstr ""
 
-#: exhibition/signals.py:166 exhibition/templates/exhibitors/call_base.html:4
-#: exhibition/templates/exhibitors/call_base.html:7
-#: exhibition/templates/exhibitors/public_call.html:7
-#: exhibition/templates/exhibitors/settings.html:8
-#: exhibition/templates/exhibitors/settings.html:25
+#: signals.py:172 templates/exhibitors/call_base.html:4
+#: templates/exhibitors/call_base.html:7
+#: templates/exhibitors/public_call.html:7 templates/exhibitors/settings.html:8
+#: templates/exhibitors/settings.html:27
 msgid "Call for Exhibitors"
 msgstr ""
 
-#: exhibition/signals.py:207 exhibition/signals.py:231
+#: signals.py:213 signals.py:237
 msgid "Acme Corp"
 msgstr ""
 
-#: exhibition/signals.py:225
+#: signals.py:231
 msgid "Jane Doe"
 msgstr ""
 
-#: exhibition/signals.py:293 exhibition/templates/exhibitors/base.html:62
-#: exhibition/templates/exhibitors/proposal_list.html:5
-#: exhibition/templates/exhibitors/proposal_list.html:15
+#: signals.py:305 templates/exhibitors/base.html:73
+#: templates/exhibitors/proposal_list.html:5
+#: templates/exhibitors/proposal_list.html:15
 msgid "Exhibition requests"
 msgstr ""
 
-#: exhibition/signals.py:298
+#: signals.py:310
 msgid "Exhibition request approved."
 msgstr ""
 
-#: exhibition/signals.py:299
+#: signals.py:311
 msgid "Exhibition request rejected."
 msgstr ""
 
-#: exhibition/signals.py:300
+#: signals.py:312
 msgid "Exhibition request withdrawn."
 msgstr ""
 
-#: exhibition/signals.py:301
+#: signals.py:313
 msgid "Exhibition request reopened for review."
 msgstr ""
 
-#: exhibition/signals.py:302
+#: signals.py:314
 msgid "Exhibition request changed."
 msgstr ""
 
-#: exhibition/signals.py:303
+#: signals.py:315
 msgid "Organization profile created from an approved request."
 msgstr ""
 
-#: exhibition/signals.py:304
+#: signals.py:316
 msgid "Organization profile reactivated after re-approval."
 msgstr ""
 
-#: exhibition/signals.py:305
+#: signals.py:317
 msgid "Organization profile updated from the submitter's changes."
 msgstr ""
 
-#: exhibition/signals.py:306
+#: signals.py:318
 msgid "Organization profile created."
 msgstr ""
 
-#: exhibition/signals.py:307
+#: signals.py:319
 msgid "Organization profile changed."
 msgstr ""
 
-#: exhibition/signals.py:308
+#: signals.py:320
 msgid "Organization profile deleted."
 msgstr ""
 
-#: exhibition/signals.py:309
+#: signals.py:321
 msgid "Exhibition settings changed."
 msgstr ""
 
-#: exhibition/signals.py:310
+#: signals.py:322
 msgid "Call for exhibitors settings changed."
 msgstr ""
 
-#: exhibition/signals.py:311
+#: signals.py:323
 msgid "Private call link regenerated."
 msgstr ""
 
-#: exhibition/signals.py:312
+#: signals.py:324
 msgid "Sponsor group created."
 msgstr ""
 
-#: exhibition/signals.py:313
+#: signals.py:325
 msgid "Sponsor group changed."
 msgstr ""
 
-#: exhibition/signals.py:314 exhibition/views.py:457
+#: signals.py:326 views.py:496
 msgid "Sponsor group deleted."
 msgstr ""
 
-#: exhibition/signals.py:315
+#: signals.py:327
 msgid "Exhibitor form question created."
 msgstr ""
 
-#: exhibition/signals.py:316
+#: signals.py:328
 msgid "Exhibitor form question changed."
 msgstr ""
 
-#: exhibition/signals.py:317
+#: signals.py:329
 msgid "Exhibitor form question deleted."
 msgstr ""
 
-#: exhibition/signals.py:318
+#: signals.py:330
 msgid "Email sent."
 msgstr ""
 
-#: exhibition/signals.py:337
+#: signals.py:349
 #, python-brace-format
 msgid "Updated: {fields}."
 msgstr ""
 
-#: exhibition/signals.py:360
+#: signals.py:372
 #, python-brace-format
 msgid "State changed from {old} to {new}."
 msgstr ""
 
-#: exhibition/signals.py:382
+#: signals.py:394
 #, python-brace-format
 msgid "Exhibition request {val}"
 msgstr ""
 
-#: exhibition/signals.py:391
+#: signals.py:403
 #, python-brace-format
 msgid "Organization profile {val}"
 msgstr ""
 
-#: exhibition/signals.py:400
+#: signals.py:412
 #, python-brace-format
 msgid "Exhibitor form question {val}"
 msgstr ""
 
-#: exhibition/signals.py:409
+#: signals.py:421
 #, python-brace-format
 msgid "Sponsor group {val}"
 msgstr ""
 
-#: exhibition/social_links.py:36
+#: social_links.py:36
 msgid "Facebook"
 msgstr ""
 
-#: exhibition/social_links.py:43
+#: social_links.py:43
 msgid "Flickr"
 msgstr ""
 
-#: exhibition/social_links.py:50
+#: social_links.py:50
 msgid "GitHub"
 msgstr ""
 
-#: exhibition/social_links.py:57
+#: social_links.py:57
 msgid "GitLab"
 msgstr ""
 
-#: exhibition/social_links.py:64
+#: social_links.py:64
 msgid "Gitter"
 msgstr ""
 
-#: exhibition/social_links.py:71
+#: social_links.py:71
 msgid "Google Groups"
 msgstr ""
 
-#: exhibition/social_links.py:78
+#: social_links.py:78
 msgid "Instagram"
 msgstr ""
 
-#: exhibition/social_links.py:85
+#: social_links.py:85
 msgid "LinkedIn"
 msgstr ""
 
-#: exhibition/social_links.py:92
+#: social_links.py:92
 msgid "Mastodon"
 msgstr ""
 
-#: exhibition/social_links.py:99
+#: social_links.py:99
 msgid "Patreon"
 msgstr ""
 
-#: exhibition/social_links.py:106
+#: social_links.py:106
 msgid "Telegram"
 msgstr ""
 
-#: exhibition/social_links.py:113
+#: social_links.py:113
 msgid "Vimeo"
 msgstr ""
 
-#: exhibition/social_links.py:120
+#: social_links.py:120
 msgid "VK"
 msgstr ""
 
-#: exhibition/social_links.py:127
+#: social_links.py:127
 msgid "Weibo"
 msgstr ""
 
-#: exhibition/social_links.py:134
+#: social_links.py:134
 msgid "X"
 msgstr ""
 
-#: exhibition/social_links.py:141
+#: social_links.py:141
 msgid "Xing"
 msgstr ""
 
-#: exhibition/social_links.py:148
+#: social_links.py:148
 msgid "YouTube"
 msgstr ""
 
-#: exhibition/social_links.py:155
+#: social_links.py:155
 msgid "YouTube Privacy"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:7
+#: templates/exhibitors/_email_outbox_body.html:7
 msgid "Created"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:14
+#: templates/exhibitors/_email_outbox_body.html:14
 msgid "Send selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:17
+#: templates/exhibitors/_email_outbox_body.html:17
 msgid "Discard selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:20
+#: templates/exhibitors/_email_outbox_body.html:20
 msgid "Send all"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:23
+#: templates/exhibitors/_email_outbox_body.html:23
 msgid "Discard all"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:35
+#: templates/exhibitors/_email_outbox_body.html:35
 msgid "Scheduled"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:36
-#: exhibition/templates/exhibitors/proposal_list.html:65
+#: templates/exhibitors/_email_outbox_body.html:36
+#: templates/exhibitors/proposal_list.html:65
 msgid "Actions"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:67
-msgid "Send this email"
+#: templates/exhibitors/_email_outbox_body.html:68
+msgid "Send"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:73
-msgid "Edit this email"
+#: templates/exhibitors/_email_outbox_body.html:75
+#: templates/exhibitors/_partner_row.html:54
+#: templates/exhibitors/call_questions.html:73
+#: templates/exhibitors/call_questions.html:76
+#: templates/exhibitors/dashboard.html:120
+#: templates/exhibitors/email_compose.html:55
+#: templates/exhibitors/email_custom_template_form.html:30
+#: templates/exhibitors/email_templates.html:50
+#: templates/exhibitors/email_templates.html:97
+#: templates/exhibitors/public_proposal_list.html:32
+#: templates/exhibitors/settings.html:59
+msgid "Edit"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:79
-msgid "Discard this email"
+#: templates/exhibitors/_email_outbox_body.html:82
+#: templates/exhibitors/email_bulk_discard.html:30
+#: templates/exhibitors/email_delete.html:31
+msgid "Discard"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:91
-#: exhibition/templates/exhibitors/_email_sent_body.html:34
+#: templates/exhibitors/_email_outbox_body.html:95
+#: templates/exhibitors/_email_sent_body.html:35
 msgid "No emails match your search."
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:93
+#: templates/exhibitors/_email_outbox_body.html:97
 msgid "The outbox is empty."
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_sent_body.html:7
-#: exhibition/templates/exhibitors/base.html:105
+#: templates/exhibitors/_email_sent_body.html:7
+#: templates/exhibitors/_partner_row.html:45 templates/exhibitors/base.html:116
 msgid "Sent"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_sent_body.html:36
+#: templates/exhibitors/_email_sent_body.html:37
 msgid "No emails have been sent yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:12
-#: exhibition/templates/exhibitors/public_list.html:29
+#: templates/exhibitors/_filter_form.html:12
+#: templates/exhibitors/public_list.html:29
 msgid "Search"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:18
-#: exhibition/templates/exhibitors/_filter_form.html:20
+#: templates/exhibitors/_filter_form.html:18
+#: templates/exhibitors/_filter_form.html:21
 msgid "Clear filters"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:29
+#: templates/exhibitors/_filter_form.html:30
 msgid "Filters"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:50
+#: templates/exhibitors/_filter_form.html:51
 msgid "Apply filters"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:5
+#: templates/exhibitors/_image_preview_dialog.html:11
+msgid "Close preview"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:5
 #, python-format
 msgid "Select %(name)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:33
+#: templates/exhibitors/_partner_row.html:33
 msgid "Untitled"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:40
+#: templates/exhibitors/_partner_row.html:40
+msgid "Waiting in the outbox"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:41
+msgid "In outbox"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:44
+#, python-format
+msgid "Last sent %(sent)s"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:48
+msgid "Not sent"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:55
 msgid "Copied!"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:40
+#: templates/exhibitors/_partner_row.html:55
 msgid "Copy failed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:40
+#: templates/exhibitors/_partner_row.html:55
 msgid "Key"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:41
-#: exhibition/templates/exhibitors/add.html:231
-#: exhibition/templates/exhibitors/vouchers.html:5
+#: templates/exhibitors/_partner_row.html:56 templates/exhibitors/add.html:235
+#: templates/exhibitors/base.html:42
+#: templates/exhibitors/exhibitor_info.html:95
+#: templates/exhibitors/exhibitor_info.html:125
+#: templates/exhibitors/vouchers.html:5 views.py:2933
 msgid "Vouchers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:42
-#: exhibition/templates/exhibitors/devices.html:5
+#: templates/exhibitors/_partner_row.html:57
+#: templates/exhibitors/devices.html:5
 msgid "Lead-scanning devices"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:45
+#: templates/exhibitors/_partner_row.html:58
+#: templates/exhibitors/call_question_delete.html:19
+#: templates/exhibitors/call_questions.html:74
+#: templates/exhibitors/delete.html:19
+#: templates/exhibitors/email_custom_template_delete.html:19
+#: templates/exhibitors/settings.html:335
+msgid "Delete"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:60
 msgid "Move"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_sort_header.html:7
+#: templates/exhibitors/_sort_header.html:7
 msgid "Sort ascending"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_sort_header.html:10
+#: templates/exhibitors/_sort_header.html:10
 msgid "Sort descending"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:24
+#: templates/exhibitors/add.html:24
 msgid "Profile"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:29
-#: exhibition/templates/exhibitors/add.html:92
-#: exhibition/templates/exhibitors/call_questions.html:62
-#: exhibition/templates/exhibitors/settings.html:50
+#: templates/exhibitors/add.html:29 templates/exhibitors/add.html:92
+#: templates/exhibitors/call_questions.html:62
+#: templates/exhibitors/settings.html:54
 msgid "Optional"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:80
-#: exhibition/templates/exhibitors/public_proposal_form.html:79
+#: templates/exhibitors/add.html:80
+#: templates/exhibitors/public_proposal_form.html:79
 msgid "Add social media link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:137
-#: exhibition/templates/exhibitors/public_proposal_form.html:120
+#: templates/exhibitors/add.html:137
+#: templates/exhibitors/public_proposal_form.html:120
 msgid "Add extra link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:157
-#: exhibition/templates/exhibitors/add.html:160
-#: exhibition/templates/exhibitors/public_proposal_form.html:140
-#: exhibition/templates/exhibitors/public_proposal_form.html:143
+#: templates/exhibitors/add.html:157 templates/exhibitors/add.html:161
+#: templates/exhibitors/public_proposal_form.html:140
+#: templates/exhibitors/public_proposal_form.html:144
 msgid "Logo preview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:162
-#: exhibition/templates/exhibitors/add.html:180
-#: exhibition/templates/exhibitors/public_proposal_form.html:145
-#: exhibition/templates/exhibitors/public_proposal_form.html:163
+#: templates/exhibitors/add.html:164 templates/exhibitors/add.html:184
+#: templates/exhibitors/public_proposal_form.html:147
+#: templates/exhibitors/public_proposal_form.html:167
 msgid "We could not load this image preview."
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:175
-#: exhibition/templates/exhibitors/add.html:178
-#: exhibition/templates/exhibitors/public_proposal_form.html:158
-#: exhibition/templates/exhibitors/public_proposal_form.html:161
+#: templates/exhibitors/add.html:177 templates/exhibitors/add.html:181
+#: templates/exhibitors/public_proposal_form.html:160
+#: templates/exhibitors/public_proposal_form.html:164
 msgid "Header image preview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:196
+#: templates/exhibitors/add.html:200
 msgid "Organizer only"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:237
+#: templates/exhibitors/add.html:241
 msgid "Internal notes"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:244
-#: exhibition/templates/exhibitors/email_edit.html:38
-#: exhibition/templates/exhibitors/public_proposal_form.html:182
-#: exhibition/templates/exhibitors/public_proposal_form.html:186
+#: templates/exhibitors/add.html:248 templates/exhibitors/email_edit.html:38
+#: templates/exhibitors/public_proposal_form.html:186
+#: templates/exhibitors/public_proposal_form.html:190
 msgid "Save changes"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:246
-#: exhibition/templates/exhibitors/call_default_field_form.html:21
-#: exhibition/templates/exhibitors/call_question_form.html:30
-#: exhibition/templates/exhibitors/call_questions.html:96
-#: exhibition/templates/exhibitors/email_custom_template_form.html:51
-#: exhibition/templates/exhibitors/email_templates.html:123
-#: exhibition/templates/exhibitors/proposal_detail.html:188
-#: exhibition/templates/exhibitors/settings.html:85
-#: exhibition/templates/exhibitors/settings.html:170
-#: exhibition/templates/exhibitors/settings.html:269
+#: templates/exhibitors/add.html:250
+#: templates/exhibitors/call_default_field_form.html:21
+#: templates/exhibitors/call_question_form.html:114
+#: templates/exhibitors/call_questions.html:96
+#: templates/exhibitors/email_custom_template_form.html:51
+#: templates/exhibitors/email_templates.html:123
+#: templates/exhibitors/proposal_detail.html:188
+#: templates/exhibitors/settings.html:89 templates/exhibitors/settings.html:217
+#: templates/exhibitors/settings.html:250
+#: templates/exhibitors/settings.html:359
 msgid "Save"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:255
-#: exhibition/templates/exhibitors/call_default_field_form.html:23
-#: exhibition/templates/exhibitors/call_default_field_reset.html:24
-#: exhibition/templates/exhibitors/call_question_delete.html:21
-#: exhibition/templates/exhibitors/call_question_form.html:32
-#: exhibition/templates/exhibitors/delete.html:24
-#: exhibition/templates/exhibitors/email_bulk_discard.html:27
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:21
-#: exhibition/templates/exhibitors/email_custom_template_form.html:53
-#: exhibition/templates/exhibitors/email_delete.html:28
-#: exhibition/templates/exhibitors/proposal_list.html:174
-#: exhibition/templates/exhibitors/public_proposal_form.html:176
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:16
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:21
-#: exhibition/templates/exhibitors/settings.html:194
-#: exhibition/templates/exhibitors/settings.html:270
+#: templates/exhibitors/add.html:259
+#: templates/exhibitors/call_default_field_form.html:23
+#: templates/exhibitors/call_default_field_reset.html:24
+#: templates/exhibitors/call_question_delete.html:21
+#: templates/exhibitors/call_question_form.html:116
+#: templates/exhibitors/delete.html:24
+#: templates/exhibitors/email_bulk_discard.html:27
+#: templates/exhibitors/email_custom_template_delete.html:21
+#: templates/exhibitors/email_custom_template_form.html:53
+#: templates/exhibitors/email_delete.html:28
+#: templates/exhibitors/proposal_list.html:175
+#: templates/exhibitors/public_proposal_form.html:180
+#: templates/exhibitors/public_proposal_reinstate.html:16
+#: templates/exhibitors/public_proposal_withdraw.html:21
+#: templates/exhibitors/settings.html:278
+#: templates/exhibitors/settings.html:360
+#: templates/exhibitors/voucher_bulk_send.html:96
 msgid "Cancel"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:262
-#: exhibition/templates/exhibitors/proposal_detail.html:208
+#: templates/exhibitors/add.html:266
+#: templates/exhibitors/proposal_detail.html:208
 msgid "History"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:11
+#: templates/exhibitors/base.html:17
 msgid "Overview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:18
-#: exhibition/templates/exhibitors/call_questions.html:33
+#: templates/exhibitors/base.html:24
+#: templates/exhibitors/call_questions.html:33
 msgid "Settings"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:26
-#: exhibition/templates/exhibitors/base.html:70
-#: exhibition/templates/exhibitors/dashboard.html:21
-#: exhibition/templates/exhibitors/exhibitor_info.html:4
-#: exhibition/templates/exhibitors/exhibitor_info.html:15
+#: templates/exhibitors/base.html:32 templates/exhibitors/base.html:81
+#: templates/exhibitors/dashboard.html:21
+#: templates/exhibitors/exhibitor_info.html:4
+#: templates/exhibitors/exhibitor_info.html:15
 msgid "Exhibitors"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:31
-#: exhibition/templates/exhibitors/base.html:76
-#: exhibition/templates/exhibitors/dashboard.html:29
-#: exhibition/templates/exhibitors/exhibitor_info.html:4
-#: exhibition/templates/exhibitors/exhibitor_info.html:15
+#: templates/exhibitors/base.html:37 templates/exhibitors/base.html:87
+#: templates/exhibitors/dashboard.html:29
+#: templates/exhibitors/exhibitor_info.html:4
+#: templates/exhibitors/exhibitor_info.html:15
 msgid "Sponsors"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:39
-#: exhibition/templates/exhibitors/dashboard.html:117
+#: templates/exhibitors/base.html:50 templates/exhibitors/dashboard.html:117
 msgid "Call for exhibitors"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:47
+#: templates/exhibitors/base.html:58
 msgid "Content"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:52
-#: exhibition/templates/exhibitors/call_questions.html:5
-#: exhibition/templates/exhibitors/call_questions.html:16
+#: templates/exhibitors/base.html:63 templates/exhibitors/call_questions.html:5
+#: templates/exhibitors/call_questions.html:16
 msgid "Exhibitor form"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:85
+#: templates/exhibitors/base.html:96
 msgid "Message center"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:94
+#: templates/exhibitors/base.html:105
 msgid "Compose"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:99
+#: templates/exhibitors/base.html:110
 msgid "Outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:111
+#: templates/exhibitors/base.html:122
 msgid "Templates"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:130
+#: templates/exhibitors/base.html:141
 msgid "Home"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:134
+#: templates/exhibitors/base.html:145
 msgid "Tickets"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:138
+#: templates/exhibitors/base.html:149
 msgid "Talks"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:143
+#: templates/exhibitors/base.html:154
 msgid "Access videos related to this event"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:144
+#: templates/exhibitors/base.html:155
 msgid "Videos"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_form.html:5
-#: exhibition/templates/exhibitors/call_default_field_form.html:8
-#: exhibition/templates/exhibitors/call_question_form.html:11
-#: exhibition/templates/exhibitors/call_question_form.html:14
+#: templates/exhibitors/call_default_field_form.html:5
+#: templates/exhibitors/call_default_field_form.html:8
+#: templates/exhibitors/call_question_form.html:14
+#: templates/exhibitors/call_question_form.html:17
 msgid "Form field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:4
-#: exhibition/templates/exhibitors/call_default_field_reset.html:7
+#: templates/exhibitors/call_default_field_reset.html:4
+#: templates/exhibitors/call_default_field_reset.html:7
 msgid "Reset form field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:14
+#: templates/exhibitors/call_default_field_reset.html:14
 #, python-format
 msgid ""
 "Are you sure you want to reset \"%(label)s\" back to the default "
 "\"%(default_label)s\"?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:19
+#: templates/exhibitors/call_default_field_reset.html:19
 msgid ""
 "This clears the custom label and help text. Default fields are part of the "
 "form and cannot be deleted; turn the field off with the Active toggle to "
 "hide it."
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:22
-#: exhibition/templates/exhibitors/public_list.html:32
+#: templates/exhibitors/call_default_field_reset.html:22
 msgid "Reset"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_question_delete.html:4
-#: exhibition/templates/exhibitors/call_question_delete.html:7
+#: templates/exhibitors/call_question_delete.html:4
+#: templates/exhibitors/call_question_delete.html:7
 msgid "Delete form field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_question_delete.html:14
+#: templates/exhibitors/call_question_delete.html:14
 #, python-format
 msgid "Are you sure you want to delete the question \"%(question)s\"?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_question_delete.html:19
-#: exhibition/templates/exhibitors/call_questions.html:74
-#: exhibition/templates/exhibitors/delete.html:19
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:19
-msgid "Delete"
+#: templates/exhibitors/call_question_form.html:31
+msgid "Answer options"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:23
+#: templates/exhibitors/call_question_form.html:34
+msgid "Only applicable if you choose a choice field type above."
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:48
+#, python-format
+msgid "Answer option %(id)s"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:56
+#: templates/exhibitors/call_question_form.html:58
+#: templates/exhibitors/call_question_form.html:87
+#: templates/exhibitors/call_question_form.html:89
+msgid "Move option up"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:60
+#: templates/exhibitors/call_question_form.html:62
+#: templates/exhibitors/call_question_form.html:91
+#: templates/exhibitors/call_question_form.html:93
+msgid "Move option down"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:64
+#: templates/exhibitors/call_question_form.html:66
+#: templates/exhibitors/call_question_form.html:95
+#: templates/exhibitors/call_question_form.html:97
+msgid "Delete option"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:81
+msgid "New answer option"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:106
+msgid "Add a new option"
+msgstr ""
+
+#: templates/exhibitors/call_questions.html:23
 msgid "Form fields"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:24
+#: templates/exhibitors/call_questions.html:24
 msgid ""
 "Choose which fields are shown on the exhibitor form and drag any row to "
 "reorder it."
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:29
-#: exhibition/templates/exhibitors/proposal_detail.html:38
+#: templates/exhibitors/call_questions.html:29
+#: templates/exhibitors/proposal_detail.html:38
 msgid "Field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:32
+#: templates/exhibitors/call_questions.html:32
 msgid "Answers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:42
+#: templates/exhibitors/call_questions.html:42
 msgid "Custom"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:48
+#: templates/exhibitors/call_questions.html:48
 #, python-format
 msgid "Toggle active state for %(field)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:61
+#: templates/exhibitors/call_questions.html:61
 #, python-format
 msgid "Required status for %(field)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:73
-#: exhibition/templates/exhibitors/call_questions.html:76
-#: exhibition/templates/exhibitors/dashboard.html:120
-#: exhibition/templates/exhibitors/email_compose.html:55
-#: exhibition/templates/exhibitors/email_custom_template_form.html:30
-#: exhibition/templates/exhibitors/email_templates.html:50
-#: exhibition/templates/exhibitors/email_templates.html:97
-#: exhibition/templates/exhibitors/public_proposal_list.html:32
-#: exhibition/templates/exhibitors/settings.html:55
-msgid "Edit"
-msgstr ""
-
-#: exhibition/templates/exhibitors/call_questions.html:77
+#: templates/exhibitors/call_questions.html:77
 msgid "Reset to default"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:79
+#: templates/exhibitors/call_questions.html:79
 msgid "Move field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:90
+#: templates/exhibitors/call_questions.html:90
 msgid "New custom field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:5
-#: exhibition/templates/exhibitors/dashboard.html:9
+#: templates/exhibitors/dashboard.html:5 templates/exhibitors/dashboard.html:9
 msgid "Exhibition overview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:39
+#: templates/exhibitors/dashboard.html:39
 msgid "Requests awaiting review"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:48
+#: templates/exhibitors/dashboard.html:48
 msgid "Emails in outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:61
+#: templates/exhibitors/dashboard.html:61
 msgid "Recent requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:64
+#: templates/exhibitors/dashboard.html:64
 msgid "View all"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:76
+#: templates/exhibitors/dashboard.html:76
 msgid "Submitted"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:91
-#: exhibition/templates/exhibitors/proposal_detail.html:97
-#: exhibition/templates/exhibitors/proposal_list.html:97
+#: templates/exhibitors/dashboard.html:91
+#: templates/exhibitors/proposal_detail.html:97
+#: templates/exhibitors/proposal_list.html:97
 msgid "Sponsor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:93
-#: exhibition/templates/exhibitors/proposal_detail.html:99
-#: exhibition/templates/exhibitors/proposal_list.html:99
+#: templates/exhibitors/dashboard.html:93
+#: templates/exhibitors/proposal_detail.html:99
+#: templates/exhibitors/proposal_list.html:99
 msgid "Exhibitor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:105
+#: templates/exhibitors/dashboard.html:105
 msgid "No requests have been submitted yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:128
+#: templates/exhibitors/dashboard.html:128
 msgid "The call is not published, so nobody can submit a request."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:131
+#: templates/exhibitors/dashboard.html:131
 msgid "Open"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:134
+#: templates/exhibitors/dashboard.html:134
 #, python-format
 msgid "Closes on %(deadline)s."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:139
+#: templates/exhibitors/dashboard.html:139
 msgid "No deadline set."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:142
+#: templates/exhibitors/dashboard.html:142
 msgid "Closed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:144
+#: templates/exhibitors/dashboard.html:144
 #, python-format
 msgid "The deadline passed on %(deadline)s."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:151
+#: templates/exhibitors/dashboard.html:151
 msgid "Private — reachable only with the secret link."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:157
-#: exhibition/templates/exhibitors/settings.html:90
-#: exhibition/templates/exhibitors/settings.html:94
+#: templates/exhibitors/dashboard.html:157
+#: templates/exhibitors/settings.html:94 templates/exhibitors/settings.html:98
 msgid "View call page"
 msgstr ""
 
-#: exhibition/templates/exhibitors/delete.html:11
+#: templates/exhibitors/delete.html:11
 #, python-format
 msgid ""
 "Are you sure you want to delete “%(name)s”? This action cannot be undone."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:8
+#: templates/exhibitors/devices.html:8
 #, python-format
 msgid "Lead-scanning devices for %(name)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:13
+#: templates/exhibitors/devices.html:13
 #, python-brace-format
 msgid ""
 "Provision check-in app devices for this partner. Each device gets its own "
@@ -1672,66 +1705,64 @@ msgid ""
 "through the {device_tokens} placeholder."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:21
+#: templates/exhibitors/devices.html:21
 msgid ""
 "Provisioning devices requires organizer-level permissions. Ask an organizer "
 "admin to create the devices for this partner."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:29
+#: templates/exhibitors/devices.html:29
 msgid "Provisioned devices"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:35
+#: templates/exhibitors/devices.html:35
 msgid "Device"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:36
+#: templates/exhibitors/devices.html:36
 msgid "Setup token"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:37
+#: templates/exhibitors/devices.html:37
 msgid "Status"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:47
+#: templates/exhibitors/devices.html:47
 msgid "Connected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:49
+#: templates/exhibitors/devices.html:49
 msgid "Awaiting setup"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:60
+#: templates/exhibitors/devices.html:60
 msgid ""
 "Generate new setup tokens? Any device that is already scanning will be "
 "disconnected and must be set up again."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:65
+#: templates/exhibitors/devices.html:65
 msgid "Generate new setup tokens"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:70
+#: templates/exhibitors/devices.html:70
 msgid "No devices have been provisioned for this partner yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:80
-#: exhibition/templates/exhibitors/devices.html:85
+#: templates/exhibitors/devices.html:80 templates/exhibitors/devices.html:85
 msgid "Add devices"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:87
-#: exhibition/templates/exhibitors/vouchers.html:88
+#: templates/exhibitors/devices.html:87 templates/exhibitors/vouchers.html:133
 msgid "Back"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_bulk_discard.html:4
-#: exhibition/templates/exhibitors/email_bulk_discard.html:7
+#: templates/exhibitors/email_bulk_discard.html:4
+#: templates/exhibitors/email_bulk_discard.html:7
 msgid "Discard emails"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_bulk_discard.html:19
+#: templates/exhibitors/email_bulk_discard.html:19
 #, python-format
 msgid ""
 "Are you sure you want to discard %(counter)s queued email? This cannot be "
@@ -1742,80 +1773,80 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/templates/exhibitors/email_bulk_discard.html:30
-#: exhibition/templates/exhibitors/email_delete.html:31
-msgid "Discard"
-msgstr ""
-
-#: exhibition/templates/exhibitors/email_compose.html:7
-#: exhibition/templates/exhibitors/email_compose.html:16
+#: templates/exhibitors/email_compose.html:7
+#: templates/exhibitors/email_compose.html:16
 msgid "Compose email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:21
+#: templates/exhibitors/email_compose.html:21
 msgid ""
 "Send an update to a group of applicants. One email is queued per recipient, "
 "with placeholders resolved individually."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:26
+#: templates/exhibitors/email_compose.html:26
 msgid "Load from template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:28
+#: templates/exhibitors/email_compose.html:28
 msgid "Select a saved template…"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:33
+#: templates/exhibitors/email_compose.html:33
 msgid "Load"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:41
-#: exhibition/templates/exhibitors/email_edit.html:23
+#: templates/exhibitors/email_compose.html:41
+#: templates/exhibitors/email_edit.html:23
 msgid "Recipients"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:47
+#: templates/exhibitors/email_compose.html:47
 msgid "Message"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:58
-#: exhibition/templates/exhibitors/email_custom_template_form.html:33
-#: exhibition/templates/exhibitors/email_templates.html:53
-#: exhibition/templates/exhibitors/email_templates.html:100
-#: exhibition/templates/exhibitors/settings.html:58
+#: templates/exhibitors/email_compose.html:51
+msgctxt "form"
+msgid "required"
+msgstr ""
+
+#: templates/exhibitors/email_compose.html:58
+#: templates/exhibitors/email_custom_template_form.html:33
+#: templates/exhibitors/email_templates.html:53
+#: templates/exhibitors/email_templates.html:100
+#: templates/exhibitors/settings.html:62
 msgid "Preview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:80
+#: templates/exhibitors/email_compose.html:80
 msgid "Save to outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:83
+#: templates/exhibitors/email_compose.html:83
 msgid "Send / Schedule"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:4
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:7
+#: templates/exhibitors/email_custom_template_delete.html:4
+#: templates/exhibitors/email_custom_template_delete.html:7
 msgid "Delete custom template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:14
+#: templates/exhibitors/email_custom_template_delete.html:14
 #, python-format
 msgid "Are you sure you want to delete the custom template \"%(name)s\"?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_custom_template_form.html:7
-#: exhibition/templates/exhibitors/email_custom_template_form.html:15
+#: templates/exhibitors/email_custom_template_form.html:7
+#: templates/exhibitors/email_custom_template_form.html:15
 msgid "Custom template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_delete.html:4
-#: exhibition/templates/exhibitors/email_delete.html:7
+#: templates/exhibitors/email_delete.html:4
+#: templates/exhibitors/email_delete.html:7
 msgid "Discard email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_delete.html:15
+#: templates/exhibitors/email_delete.html:15
 #, python-format
 msgid ""
 "Are you sure you want to discard the email “%(subject)s” to %(counter)s "
@@ -1826,908 +1857,1170 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/templates/exhibitors/email_delete.html:21
+#: templates/exhibitors/email_delete.html:21
 #, python-format
 msgid ""
 "Are you sure you want to discard the email “%(subject)s” to %(to)s? This "
 "cannot be undone."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:5
+#: templates/exhibitors/email_edit.html:5
 msgid "Edit email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:8
+#: templates/exhibitors/email_edit.html:8
 msgid "Preview / edit email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:14
+#: templates/exhibitors/email_edit.html:14
 msgid "Back to outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:41
+#: templates/exhibitors/email_edit.html:41
 msgid "Save & send"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_outbox.html:12
-#: exhibition/templates/exhibitors/email_outbox.html:15
+#: templates/exhibitors/email_outbox.html:12
+#: templates/exhibitors/email_outbox.html:15
 msgid "Email outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_outbox.html:20
+#: templates/exhibitors/email_outbox.html:20
 msgid ""
 "Emails waiting to be sent. Review, edit, or discard them before sending."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_sent.html:12
-#: exhibition/templates/exhibitors/email_sent.html:15
+#: templates/exhibitors/email_sent.html:12
+#: templates/exhibitors/email_sent.html:15
 msgid "Sent emails"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:7
-#: exhibition/templates/exhibitors/email_templates.html:16
+#: templates/exhibitors/email_templates.html:7
+#: templates/exhibitors/email_templates.html:16
 msgid "Email templates"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:22
+#: templates/exhibitors/email_templates.html:22
 msgid "New template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:27
+#: templates/exhibitors/email_templates.html:27
 msgid ""
 "These templates are used for the confirmation email sent when an applicant "
 "submits a request, and for the accept/reject emails you send from the outbox."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:81
+#: templates/exhibitors/email_templates.html:81
 msgid "Discard this template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:31
+#: templates/exhibitors/exhibitor_info.html:31
 msgid "No organizations match your filters."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:33
+#: templates/exhibitors/exhibitor_info.html:33
 msgid "You don't have any sponsors yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:35
+#: templates/exhibitors/exhibitor_info.html:35
 msgid "You don't have any exhibitors yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:37
+#: templates/exhibitors/exhibitor_info.html:37
 msgid "You don't have any exhibitors or sponsors yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:43
-#: exhibition/templates/exhibitors/exhibitor_info.html:52
-#: exhibition/views.py:1837
+#: templates/exhibitors/exhibitor_info.html:43
+#: templates/exhibitors/exhibitor_info.html:57 views.py:1979
 msgid "Add a Sponsor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:43
-#: exhibition/templates/exhibitors/exhibitor_info.html:52
-#: exhibition/views.py:1838
+#: templates/exhibitors/exhibitor_info.html:43
+#: templates/exhibitors/exhibitor_info.html:57 views.py:1980
 msgid "Add an Exhibitor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:43
-#: exhibition/templates/exhibitors/exhibitor_info.html:52
-#: exhibition/views.py:1839
+#: templates/exhibitors/exhibitor_info.html:43
+#: templates/exhibitors/exhibitor_info.html:57 views.py:1981
 msgid "Add an Exhibitor or Sponsor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:48
-#: exhibition/templates/exhibitors/proposal_list.html:169
+#: templates/exhibitors/exhibitor_info.html:48
+#: templates/exhibitors/proposal_list.html:170
 msgid "selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:54
+#: templates/exhibitors/exhibitor_info.html:59
 msgid "Download access keys as CSV"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:56
+#: templates/exhibitors/exhibitor_info.html:61
 msgid "Download sponsor keys"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:56
+#: templates/exhibitors/exhibitor_info.html:61
 msgid "Download exhibitor keys"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:56
+#: templates/exhibitors/exhibitor_info.html:61
 msgid "Download access keys"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:65
+#: templates/exhibitors/exhibitor_info.html:64
+msgid "Queue a voucher email for everyone in this list"
+msgstr ""
+
+#: templates/exhibitors/exhibitor_info.html:65
+msgid "Send vouchers to all"
+msgstr ""
+
+#: templates/exhibitors/exhibitor_info.html:75
 msgid ""
 "Drag-and-drop ordering is available only on the unfiltered, single-page list."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:70
+#: templates/exhibitors/exhibitor_info.html:80
 msgid "Booth"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:78
-#: exhibition/templates/exhibitors/exhibitor_info.html:106
+#: templates/exhibitors/exhibitor_info.html:88
+#: templates/exhibitors/exhibitor_info.html:117
 msgid "Select all partners"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:84
-#: exhibition/templates/exhibitors/exhibitor_info.html:112
+#: templates/exhibitors/exhibitor_info.html:94
+#: templates/exhibitors/exhibitor_info.html:123
 msgid "Group"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:12
-#: exhibition/templates/exhibitors/proposal_detail.html:15
+#: templates/exhibitors/proposal_detail.html:12
+#: templates/exhibitors/proposal_detail.html:15
 msgid "Review exhibition request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:21
+#: templates/exhibitors/proposal_detail.html:21
 msgid "Back to exhibition requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:29
+#: templates/exhibitors/proposal_detail.html:29
 #, python-format
 msgid "Changes made by the applicant after acceptance (%(when)s)"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:39
+#: templates/exhibitors/proposal_detail.html:39
 msgid "Before acceptance"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:40
+#: templates/exhibitors/proposal_detail.html:40
 msgid "After edit"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:55
+#: templates/exhibitors/proposal_detail.html:55
 msgid "The applicant edited the profile, but the tracked fields are unchanged."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:57
+#: templates/exhibitors/proposal_detail.html:57
 msgid ""
 "This profile was edited before change tracking was available, so the "
 "original values are not recorded."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:69
-#: exhibition/templates/exhibitors/proposal_list.html:20
+#: templates/exhibitors/proposal_detail.html:69
+#: templates/exhibitors/proposal_list.html:20
 msgid "Submitter"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:80
+#: templates/exhibitors/proposal_detail.html:80
 msgid "Hidden"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:121
+#: templates/exhibitors/proposal_detail.html:121
 msgid "Message to organizers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:129
+#: templates/exhibitors/proposal_detail.html:129
 msgid "Links"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:152
+#: templates/exhibitors/proposal_detail.html:152
 msgid "Download"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:154
+#: templates/exhibitors/proposal_detail.html:154
 msgid "Custom answers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:176
+#: templates/exhibitors/proposal_detail.html:176
 msgid "Review"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:192
-#: exhibition/templates/exhibitors/proposal_list.html:117
-#: exhibition/templates/exhibitors/proposal_list.html:164
+#: templates/exhibitors/proposal_detail.html:192
+#: templates/exhibitors/proposal_list.html:118
+#: templates/exhibitors/proposal_list.html:165
 msgid "Approve"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:195
-#: exhibition/templates/exhibitors/proposal_list.html:122
-#: exhibition/templates/exhibitors/proposal_list.html:165
+#: templates/exhibitors/proposal_detail.html:195
+#: templates/exhibitors/proposal_list.html:123
+#: templates/exhibitors/proposal_list.html:166
 msgid "Reject"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:200
+#: templates/exhibitors/proposal_detail.html:200
 msgid "Open profile"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:22
+#: templates/exhibitors/proposal_list.html:22
 msgid "Updated"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:33
+#: templates/exhibitors/proposal_list.html:33
 msgid "Select at least one request."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:34
+#: templates/exhibitors/proposal_list.html:34
 msgid "None of the selected requests can be approved."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:35
+#: templates/exhibitors/proposal_list.html:35
 msgid "None of the selected requests can be rejected."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:36
+#: templates/exhibitors/proposal_list.html:36
 #, python-brace-format
 msgid "{count} selected requests cannot be approved and will be skipped."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:37
+#: templates/exhibitors/proposal_list.html:37
 #, python-brace-format
 msgid "{count} selected requests cannot be rejected and will be skipped."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:41
+#: templates/exhibitors/proposal_list.html:41
 msgid "Approve selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:44
+#: templates/exhibitors/proposal_list.html:44
 msgid "Reject selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:55
+#: templates/exhibitors/proposal_list.html:55
 msgid "Select all matching requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:75
+#: templates/exhibitors/proposal_list.html:75
 msgid "Select request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:106
+#: templates/exhibitors/proposal_list.html:106
 msgid "Edited after acceptance, see detail view for changes."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:127
-#: exhibition/templates/exhibitors/proposal_list.html:166
-#: exhibition/templates/exhibitors/public_proposal_list.html:39
+#: templates/exhibitors/proposal_list.html:128
+#: templates/exhibitors/proposal_list.html:167
+#: templates/exhibitors/public_proposal_list.html:39
 msgid "Withdraw"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:132
-#: exhibition/templates/exhibitors/proposal_list.html:167
+#: templates/exhibitors/proposal_list.html:133
+#: templates/exhibitors/proposal_list.html:168
 msgid "Reopen for review"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:137
-#: exhibition/templates/exhibitors/public_proposal_list.html:34
+#: templates/exhibitors/proposal_list.html:138
+#: templates/exhibitors/public_proposal_list.html:34
 msgid "View"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:149
+#: templates/exhibitors/proposal_list.html:150
 msgid "No exhibition requests match your filters."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:151
+#: templates/exhibitors/proposal_list.html:152
 msgid "No exhibition requests have been submitted yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:159
+#: templates/exhibitors/proposal_list.html:160
 msgid "Approve the selected requests and create their partner profiles?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:160
+#: templates/exhibitors/proposal_list.html:161
 msgid "Reject the selected requests?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:161
+#: templates/exhibitors/proposal_list.html:162
 msgid "Reject this request?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:162
+#: templates/exhibitors/proposal_list.html:163
 msgid "Withdraw this request?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:163
+#: templates/exhibitors/proposal_list.html:164
 msgid "Reopen this request for review?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:168
+#: templates/exhibitors/proposal_list.html:169
 msgid "The action could not be completed. Please try again."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:170
+#: templates/exhibitors/proposal_list.html:171
 msgid ""
 "Approve every request matching the current filters, including those on other "
 "pages?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:171
+#: templates/exhibitors/proposal_list.html:172
 msgid ""
 "Reject every request matching the current filters, including those on other "
 "pages?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:172
+#: templates/exhibitors/proposal_list.html:173
 msgid "Please confirm"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:173
+#: templates/exhibitors/proposal_list.html:174
 msgid "Confirm"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:14
+#: templates/exhibitors/public_call.html:14
 msgid "Submit a request to become an exhibitor for this event."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:20
+#: templates/exhibitors/public_call.html:20
 #, python-format
 msgid "You can submit requests until %(deadline)s (%(timezone)s)."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:24
+#: templates/exhibitors/public_call.html:24
 #, python-format
 msgid "This call closed on %(deadline)s (%(timezone)s)."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:34
+#: templates/exhibitors/public_call.html:34
 msgid "View your requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:40
-#: exhibition/templates/exhibitors/public_proposal_form.html:18
-#: exhibition/templates/exhibitors/public_proposal_list.html:65
+#: templates/exhibitors/public_call.html:40
+#: templates/exhibitors/public_proposal_form.html:18
+#: templates/exhibitors/public_proposal_list.html:65
 msgid "Submit a request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:42
+#: templates/exhibitors/public_call.html:42
 msgid "Requests are closed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:21
-#: exhibition/templates/exhibitors/public_detail.html:94
+#: templates/exhibitors/public_detail.html:21
+#: templates/exhibitors/public_detail.html:93
 msgid "Previous"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:24
-#: exhibition/templates/exhibitors/public_detail.html:98
+#: templates/exhibitors/public_detail.html:24
+#: templates/exhibitors/public_detail.html:97
 msgid "Next"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:47
+#: templates/exhibitors/public_detail.html:47
 msgid "Get In Touch"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:87
-#: exhibition/templates/exhibitors/public_detail.html:103
+#: templates/exhibitors/public_detail.html:87
+#: templates/exhibitors/public_detail.html:102
 msgid "Open slides PDF"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:88
-#, python-brace-format
-msgid "Slide {current} of {total}"
-msgstr ""
-
-#: exhibition/templates/exhibitors/public_detail.html:112
+#: templates/exhibitors/public_detail.html:111
 msgid "Send email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:126
+#: templates/exhibitors/public_detail.html:125
 msgid "Visit website"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_list.html:54
+#: templates/exhibitors/public_list.html:32
+msgid "Clear"
+msgstr ""
+
+#: templates/exhibitors/public_list.html:54
 msgid "No exhibitors match your search."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_list.html:56
+#: templates/exhibitors/public_list.html:56
 msgid "No exhibitors are currently available."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:16
+#: templates/exhibitors/public_proposal_form.html:16
 msgid "Edit request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:23
-#: exhibition/views.py:883
+#: templates/exhibitors/public_proposal_form.html:23 views.py:958
 msgid "This request can no longer be edited."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:186
+#: templates/exhibitors/public_proposal_form.html:190
 msgid "Submit request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:189
+#: templates/exhibitors/public_proposal_form.html:193
 msgid "or save as draft for now"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:199
+#: templates/exhibitors/public_proposal_form.html:203
 msgid "Back to your requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:5
+#: templates/exhibitors/public_proposal_list.html:5
 msgid "Your exhibition requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:13
+#: templates/exhibitors/public_proposal_list.html:13
 msgid "Last modified"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:23
+#: templates/exhibitors/public_proposal_list.html:23
 msgid "Withdrawn"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:44
+#: templates/exhibitors/public_proposal_list.html:44
 msgid "Reinstate"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:56
+#: templates/exhibitors/public_proposal_list.html:56
 msgid "Create a new request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:61
+#: templates/exhibitors/public_proposal_list.html:61
 msgid "You have not submitted an exhibition request yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:5
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:21
+#: templates/exhibitors/public_proposal_reinstate.html:5
+#: templates/exhibitors/public_proposal_reinstate.html:21
 msgid "Reinstate request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:7
+#: templates/exhibitors/public_proposal_reinstate.html:7
 #, python-format
 msgid ""
 "Do you want to reinstate your withdrawn request “%(name)s”? It will be "
 "pending review again."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:5
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:26
+#: templates/exhibitors/public_proposal_withdraw.html:5
+#: templates/exhibitors/public_proposal_withdraw.html:26
 msgid "Withdraw request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:7
+#: templates/exhibitors/public_proposal_withdraw.html:7
 #, python-format
 msgid "Are you sure you want to withdraw your request “%(name)s”?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:13
+#: templates/exhibitors/public_proposal_withdraw.html:13
 msgid ""
 "This request has already been approved. Withdrawing it will hide the "
 "exhibitor or sponsor profile created from it from public listings."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:10
-#: exhibition/templates/exhibitors/settings.html:27
+#: templates/exhibitors/settings.html:10 templates/exhibitors/settings.html:29
 msgid "Sponsor Settings"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:12
-#: exhibition/templates/exhibitors/settings.html:29
+#: templates/exhibitors/settings.html:12 templates/exhibitors/settings.html:31
+msgid "Voucher Settings"
+msgstr ""
+
+#: templates/exhibitors/settings.html:14 templates/exhibitors/settings.html:33
 msgid "Exhibitor Settings"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:42
+#: templates/exhibitors/settings.html:46
 msgid "Publish your call"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:43
+#: templates/exhibitors/settings.html:47
 msgid "Publish a login-required application form for exhibitors."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:72
+#: templates/exhibitors/settings.html:76
 msgid ""
 "This panel renders unsaved draft text using the same styling as the live "
 "public call page."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:104
+#: templates/exhibitors/settings.html:108
 msgid "Secret call link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:107
+#: templates/exhibitors/settings.html:111
 msgid ""
 "This call is private: it is not linked anywhere public. Share the link below "
 "with the organizations you want to invite. Anyone who has it can open the "
 "call and apply."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:113
+#: templates/exhibitors/settings.html:117
 msgid "Copied"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:113
+#: templates/exhibitors/settings.html:117
 msgid "Copy to clipboard"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:114
+#: templates/exhibitors/settings.html:118
 msgid "Copy"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:119
+#: templates/exhibitors/settings.html:123
 msgid ""
 "Regenerate the secret link? The current link will stop working immediately."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:125
+#: templates/exhibitors/settings.html:129
 msgid "Regenerate link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:127
+#: templates/exhibitors/settings.html:131
 msgid "Regenerating immediately invalidates the current link."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:138
+#: templates/exhibitors/settings.html:143
+msgid "Voucher pools"
+msgstr ""
+
+#: templates/exhibitors/settings.html:147
+msgid ""
+"Create the voucher codes under Tickets → Vouchers and give them a tag, then "
+"pick that tag here. Exhibitors and sponsors are handed codes from the pool "
+"you choose. Reload this page to pick up a tag you just created."
+msgstr ""
+
+#: templates/exhibitors/settings.html:157
+msgid "Create vouchers pool"
+msgstr ""
+
+#: templates/exhibitors/settings.html:159
+msgid "(opens in a new tab)"
+msgstr ""
+
+#: templates/exhibitors/settings.html:168
+#: templates/exhibitors/settings.html:182
+#, python-format
+msgid "%(counter)s voucher in this pool is not assigned to anyone yet."
+msgid_plural ""
+"%(counter)s vouchers in this pool are not assigned to anyone yet."
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/exhibitors/settings.html:194
+msgid "How many each one gets"
+msgstr ""
+
+#: templates/exhibitors/settings.html:196
+msgid ""
+"Applies to any exhibitor or sponsor that does not belong to a sponsor group. "
+"Sponsor groups set their own number on the Sponsors page, and an individual "
+"exhibitor or sponsor can be given a different number on their own voucher "
+"page."
+msgstr ""
+
+#: templates/exhibitors/settings.html:206
+msgid "Voucher email"
+msgstr ""
+
+#: templates/exhibitors/settings.html:208
+msgid "Applies to the voucher email sent to exhibitors and sponsors alike."
+msgstr ""
+
+#: templates/exhibitors/settings.html:228
 msgid "Data access"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:139
+#: templates/exhibitors/settings.html:229
 msgid ""
 "In this section, you can control which attendee data is shared with "
 "exhibitors when an exhibitor voucher is used or when the exhibitor uses the "
 "lead scanning app."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:142
+#: templates/exhibitors/settings.html:232
 msgid "Exhibitor vouchers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:158
-msgid "Exhibitor login"
-msgstr ""
-
-#: exhibition/templates/exhibitors/settings.html:160
-msgid ""
-"The access-code email sent to exhibitors is now edited together with the "
-"plugin's other email templates."
-msgstr ""
-
-#: exhibition/templates/exhibitors/settings.html:162
-msgid "Edit email templates"
-msgstr ""
-
-#: exhibition/templates/exhibitors/settings.html:177
+#: templates/exhibitors/settings.html:257
 msgid "Group List"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:180
+#: templates/exhibitors/settings.html:260
 msgid "Add a Group"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:193
+#: templates/exhibitors/settings.html:272
+#: templates/exhibitors/settings.html:354
+msgid "Voucher defaults for this group"
+msgstr ""
+
+#: templates/exhibitors/settings.html:277
 msgid "Add"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:204
+#: templates/exhibitors/settings.html:288
 msgid "Group Name"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:206
+#: templates/exhibitors/settings.html:290
 msgid "Partners"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:207
+#: templates/exhibitors/settings.html:291
 msgid "Front Page"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:220
-#: exhibition/templates/exhibitors/settings.html:226
+#: templates/exhibitors/settings.html:304
+#: templates/exhibitors/settings.html:310
 msgid "Show this sponsor group in the Supported By section on the front page."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:251
+#: templates/exhibitors/settings.html:326
+msgid "Edit sponsor group"
+msgstr ""
+
+#: templates/exhibitors/settings.html:337
 msgid "Reorder sponsor group"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:281
+#: templates/exhibitors/settings.html:371
 msgid "You do not have any sponsor groups yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:8
+#: templates/exhibitors/voucher_bulk_send.html:4
+#: templates/exhibitors/voucher_bulk_send.html:7
+msgid "Send vouchers"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:18
+#, python-format
+msgid "A voucher email will be placed in the outbox for %(counter)s sponsor."
+msgid_plural ""
+"A voucher email will be placed in the outbox for %(counter)s sponsors."
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:24
+#, python-format
+msgid "A voucher email will be placed in the outbox for %(counter)s exhibitor."
+msgid_plural ""
+"A voucher email will be placed in the outbox for %(counter)s exhibitors."
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:37
+#, python-format
+msgid "&mdash; %(counter)s voucher will be created"
+msgid_plural "&mdash; %(counter)s vouchers will be created"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:45
+#, python-format
+msgid "&mdash; %(counter)s existing voucher"
+msgid_plural "&mdash; %(counter)s existing vouchers"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:58
+msgid "None of the sponsors in this list can be emailed yet."
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:60
+msgid "None of the exhibitors in this list can be emailed yet."
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:66
+msgid "Skipped: no email address"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:75
+msgid "Skipped: voucher count is set to 0"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:84
+msgid "Skipped: no vouchers available from their pool"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:86
+msgid ""
+"Check that a voucher pool is selected under Settings → Vouchers and that it "
+"still has unassigned codes."
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:99
+msgid "Queue emails"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:8
 #, python-format
 msgid "Vouchers for %(name)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:13
+#: templates/exhibitors/vouchers.html:13
 msgid ""
-"Issue ticket vouchers for this partner to hand out. Whoever redeems one on "
-"the ticket shop becomes a lead this partner can retrieve, as long as voucher "
+"Hand this exhibitor or sponsor codes from the voucher pool. Whoever redeems "
+"one on the ticket shop becomes a lead they can retrieve, as long as voucher "
 "data access is enabled for them."
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:20
-msgid "Issued vouchers"
+#: templates/exhibitors/vouchers.html:20
+msgid "Assigned vouchers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:24
+#: templates/exhibitors/vouchers.html:24
 msgid "Download codes (CSV)"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:31
+#: templates/exhibitors/vouchers.html:31
 msgid "Code"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:32 exhibition/views.py:1994
+#: templates/exhibitors/vouchers.html:32 utils.py:495
 msgid "Product"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:34 exhibition/views.py:1998
+#: templates/exhibitors/vouchers.html:33 utils.py:496
+msgid "Price effect"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:34 utils.py:499
 msgid "Redeemed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:56
+#: templates/exhibitors/vouchers.html:35 utils.py:498
+msgid "Valid until"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:56
 msgid "Already redeemed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:67
-msgid "No vouchers have been issued for this partner yet."
+#: templates/exhibitors/vouchers.html:62
+msgid "Return to pool"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:76
-msgid "Issue new vouchers"
+#: templates/exhibitors/vouchers.html:74
+msgid "No vouchers have been assigned to this partner yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:86
-msgid "Create vouchers"
+#: templates/exhibitors/vouchers.html:82
+msgid "Take more from the pool"
 msgstr ""
 
-#: exhibition/templates/sponsors/presale_supported_by.html:4
+#: templates/exhibitors/vouchers.html:84
+msgid ""
+"Codes come from the voucher pool chosen under Settings. The email always "
+"carries this partner's complete list of codes, so you can assign some now "
+"and send them together with more later. It is placed in the outbox for you "
+"to review before it goes out."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:92
+#, python-format
+msgid "%(counter)s voucher is left unassigned in the pool."
+msgid_plural "%(counter)s vouchers are left unassigned in the pool."
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/exhibitors/vouchers.html:100 views.py:2230
+msgid "No voucher pool is selected yet. Choose one under Settings → Vouchers."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:106
+msgid "A voucher email for this partner is waiting in the outbox."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:108
+msgid "Go to outbox"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:114
+#, python-format
+msgid "Vouchers were last emailed to this partner on %(sent)s."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:120
+msgid ""
+"This partner has no email address on file, so vouchers cannot be emailed."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:127
+msgid "Assign and prepare email"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:130
+msgid "Assign without emailing"
+msgstr ""
+
+#: templates/sponsors/presale_supported_by.html:4
 msgid "Supported By"
 msgstr ""
 
-#: exhibition/views.py:324
+#: utils.py:493
+msgid "Voucher code"
+msgstr ""
+
+#: utils.py:494
+msgid "Redeem link"
+msgstr ""
+
+#: utils.py:497
+msgid "Value"
+msgstr ""
+
+#: utils.py:500
+msgid "Maximum usages"
+msgstr ""
+
+#: views.py:342
 msgid "Company name"
 msgstr ""
 
-#: exhibition/views.py:325
+#: views.py:343
 msgid "Job title"
 msgstr ""
 
-#: exhibition/views.py:326
+#: views.py:344
 msgid "Address"
 msgstr ""
 
-#: exhibition/views.py:333
+#: views.py:351
 msgid "Attendee Name"
 msgstr ""
 
-#: exhibition/views.py:338
+#: views.py:356
 msgid "Attendee Email"
 msgstr ""
 
-#: exhibition/views.py:377
+#: views.py:395 views.py:412
 msgid "Settings have been saved."
 msgstr ""
 
-#: exhibition/views.py:393
+#: views.py:428
 msgid "Call settings have been saved."
 msgstr ""
 
-#: exhibition/views.py:401
+#: views.py:436
 msgid ""
 "A new secret call link has been generated. The old link no longer works."
 msgstr ""
 
-#: exhibition/views.py:416
+#: views.py:451
 msgid "Sponsor group added."
 msgstr ""
 
-#: exhibition/views.py:437
+#: views.py:454 views.py:477 views.py:853 views.py:1169 views.py:1796
+#: views.py:1918 views.py:2564 views.py:3025
+msgid "We could not save your changes. See below for details."
+msgstr ""
+
+#: views.py:474
 msgid "Sponsor group updated."
 msgstr ""
 
-#: exhibition/views.py:452
+#: views.py:491
 msgid "This sponsor group cannot be deleted while it is assigned to partners."
 msgstr ""
 
-#: exhibition/views.py:460
+#: views.py:499
 msgid "Unknown action."
 msgstr ""
 
-#: exhibition/views.py:505
+#: views.py:544
 msgid "Access key"
 msgstr ""
 
-#: exhibition/views.py:745 exhibition/views.py:1060
+#: views.py:819 views.py:1135
 msgid "Add at least one social media link."
 msgstr ""
 
-#: exhibition/views.py:754 exhibition/views.py:1069
+#: views.py:828 views.py:1144
 msgid "Add at least one extra link."
 msgstr ""
 
-#: exhibition/views.py:809
+#: views.py:884
 msgid "The call for exhibitors is closed."
 msgstr ""
 
-#: exhibition/views.py:837
+#: views.py:912
 msgid "Your request has been saved."
 msgstr ""
 
-#: exhibition/views.py:920 exhibition/views.py:1776
+#: views.py:995 views.py:1914
 msgid "Your changes have been saved."
 msgstr ""
 
-#: exhibition/views.py:953
+#: views.py:1028
 msgid "This proposal can no longer be withdrawn."
 msgstr ""
 
-#: exhibition/views.py:961
+#: views.py:1036
 msgid "Your request has been withdrawn."
 msgstr ""
 
-#: exhibition/views.py:963
+#: views.py:1038
 msgid "This request can no longer be withdrawn."
 msgstr ""
 
-#: exhibition/views.py:989 exhibition/views.py:999
+#: views.py:1064 views.py:1074
 msgid "This request can no longer be reinstated."
 msgstr ""
 
-#: exhibition/views.py:997
+#: views.py:1072
 msgid "Your request has been reinstated and is pending review again."
 msgstr ""
 
-#: exhibition/views.py:1121
+#: views.py:1197
 msgid "Invalid request body."
 msgstr ""
 
-#: exhibition/views.py:1124 exhibition/views.py:1129
+#: views.py:1200 views.py:1205
 msgid "Invalid sponsor group IDs."
 msgstr ""
 
-#: exhibition/views.py:1133
+#: views.py:1209
 msgid "Sponsor group IDs must be unique."
 msgstr ""
 
-#: exhibition/views.py:1141
+#: views.py:1217
 msgid "Reorder request must include each sponsor group exactly once."
 msgstr ""
 
-#: exhibition/views.py:1346
+#: views.py:1422
 msgid "This request can no longer be changed to that state."
 msgstr ""
 
-#: exhibition/views.py:1350
+#: views.py:1426
 msgid "Review details saved."
 msgstr ""
 
-#: exhibition/views.py:1359
+#: views.py:1435
 msgid ""
 "Request approved and partner profile created. An acceptance email was placed "
 "in the outbox."
 msgstr ""
 
-#: exhibition/views.py:1369
+#: views.py:1445
 msgid "Request rejected. A rejection email was placed in the outbox."
 msgstr ""
 
-#: exhibition/views.py:1372
+#: views.py:1448
 msgid "Request withdrawn."
 msgstr ""
 
-#: exhibition/views.py:1375
+#: views.py:1451
 msgid "Request reopened for review."
 msgstr ""
 
-#: exhibition/views.py:1407
+#: views.py:1483
 msgid "No valid action was selected."
 msgstr ""
 
-#: exhibition/views.py:1454
+#: views.py:1530
 #, python-format
 msgid "%(count)d request was approved."
 msgid_plural "%(count)d requests were approved."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1455
+#: views.py:1531
 #, python-format
 msgid "%(count)d request was rejected."
 msgid_plural "%(count)d requests were rejected."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1456
+#: views.py:1532
 #, python-format
 msgid "%(count)d request was withdrawn."
 msgid_plural "%(count)d requests were withdrawn."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1457
+#: views.py:1533
 #, python-format
 msgid "%(count)d request was reopened."
 msgid_plural "%(count)d requests were reopened."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1461
+#: views.py:1537
 msgid "No proposals were updated."
 msgstr ""
 
-#: exhibition/views.py:1464
+#: views.py:1540
 #, python-format
 msgid "%(skipped)d was skipped because it was already processed."
 msgid_plural "%(skipped)d were skipped because they were already processed."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1605
+#: views.py:1681
 msgid "Exhibitor form settings have been saved."
 msgstr ""
 
-#: exhibition/views.py:1730
+#: views.py:1868
 msgid "The requested form field does not exist."
 msgstr ""
 
-#: exhibition/views.py:1791
+#: views.py:1933
 msgid "The field has been reset to its default."
 msgstr ""
 
-#: exhibition/views.py:1829 exhibition/views.py:1900
+#: views.py:1971 views.py:2042
 msgid "An access-credentials email was placed in the outbox."
 msgstr ""
 
-#: exhibition/views.py:1907
+#: views.py:2049
 msgid "Edit Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1908
+#: views.py:2050
 msgid "Edit Exhibitor"
 msgstr ""
 
-#: exhibition/views.py:1909
+#: views.py:2051
 msgid "Edit Exhibitor & Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1910
+#: views.py:2052
 msgid "Edit Exhibitor or Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1940
+#: views.py:2082
 msgid "Delete Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1941
+#: views.py:2083
 msgid "Delete Exhibitor"
 msgstr ""
 
-#: exhibition/views.py:1942
+#: views.py:2084
 msgid "Delete Exhibitor & Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1943
+#: views.py:2085
 msgid "Delete Exhibitor or Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1992
-msgid "Voucher code"
+#: views.py:2164
+msgid "This voucher has already been redeemed and cannot be returned."
 msgstr ""
 
-#: exhibition/views.py:1993
-msgid "Redeem link"
+#: views.py:2170
+msgid ""
+"This code was already included in a voucher email to this partner, so it "
+"cannot be returned to the pool. Delete it under Tickets → Vouchers instead."
 msgstr ""
 
-#: exhibition/views.py:1999
-msgid "Maximum usages"
+#: views.py:2176
+msgid "Voucher returned to the pool."
 msgstr ""
 
-#: exhibition/views.py:2035
-msgid "This voucher has already been redeemed and cannot be removed."
+#: views.py:2207
+msgid "Enter how many vouchers to take from the pool."
 msgstr ""
 
-#: exhibition/views.py:2040
-msgid "Voucher removed."
-msgstr ""
-
-#: exhibition/views.py:2060
+#: views.py:2215
 #, python-format
-msgid "%(count)d voucher created."
-msgid_plural "%(count)d vouchers created."
+msgid "%(count)d voucher taken from the pool."
+msgid_plural "%(count)d vouchers taken from the pool."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2112
+#: views.py:2232
+#, python-format
+msgid ""
+"The pool only has %(remaining)d voucher(s) left, so %(count)d cannot be "
+"taken."
+msgstr ""
+
+#: views.py:2244
+msgid "No email address is on file, so vouchers cannot be emailed."
+msgstr ""
+
+#: views.py:2253
+msgid "This partner holds no vouchers yet, so there is nothing to email."
+msgstr ""
+
+#: views.py:2259
+#, python-format
+msgid "An email with %(count)d voucher code was placed in the outbox."
+msgid_plural "An email with %(count)d voucher codes was placed in the outbox."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2347
+msgid "There is nobody to send vouchers to in this list."
+msgstr ""
+
+#: views.py:2354
+#, python-format
+msgid "%(count)d voucher email was placed in the outbox."
+msgid_plural "%(count)d voucher emails were placed in the outbox."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2371
+#, python-format
+msgid ""
+"%(count)d was skipped because no unassigned codes were available from their "
+"pool."
+msgid_plural ""
+"%(count)d were skipped because no unassigned codes were available from their "
+"pool."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2386
+#, python-format
+msgid "%(count)d sponsor was skipped because it has no email address."
+msgid_plural ""
+"%(count)d sponsors were skipped because they have no email address."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2392
+#, python-format
+msgid "%(count)d exhibitor was skipped because it has no email address."
+msgid_plural ""
+"%(count)d exhibitors were skipped because they have no email address."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2401
+#, python-format
+msgid "%(count)d sponsor was skipped because their voucher count is set to 0."
+msgid_plural ""
+"%(count)d sponsors were skipped because their voucher count is set to 0."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2407
+#, python-format
+msgid ""
+"%(count)d exhibitor was skipped because their voucher count is set to 0."
+msgid_plural ""
+"%(count)d exhibitors were skipped because their voucher count is set to 0."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2461
 #, python-format
 msgid "%(count)d device added."
 msgid_plural "%(count)d devices added."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2123
+#: views.py:2472
 #, python-format
 msgid ""
 "New setup tokens generated. %(count)d device that was already scanning is "
@@ -2738,79 +3031,95 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2132
+#: views.py:2481
 msgid "New setup tokens generated."
 msgstr ""
 
-#: exhibition/views.py:2194
+#: views.py:2543
 msgid "No applicants matched the selected filters."
 msgstr ""
 
-#: exhibition/views.py:2202
+#: views.py:2551
 #, python-format
 msgid "%(count)d emails have been scheduled."
 msgstr ""
 
-#: exhibition/views.py:2206
+#: views.py:2555
 #, python-format
 msgid "%(count)d emails have been sent."
 msgstr ""
 
-#: exhibition/views.py:2210
+#: views.py:2559
 #, python-format
 msgid "%(count)d emails have been placed in the outbox."
 msgstr ""
 
-#: exhibition/views.py:2385
+#: views.py:2738
 msgid "The emails have been saved and sent."
 msgstr ""
 
-#: exhibition/views.py:2389
+#: views.py:2742
 msgid "The emails have been saved."
 msgstr ""
 
-#: exhibition/views.py:2395
+#: views.py:2748
 msgid "The email has been saved and sent."
 msgstr ""
 
-#: exhibition/views.py:2399
+#: views.py:2752
 msgid "The email has been saved."
 msgstr ""
 
-#: exhibition/views.py:2423 exhibition/views.py:2497
+#: views.py:2776 views.py:2850
 #, python-format
 msgid "%(count)d email has been sent."
 msgid_plural "%(count)d emails have been sent."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2459
+#: views.py:2812
 msgid "The email has been discarded."
 msgstr ""
 
-#: exhibition/views.py:2501 exhibition/views.py:2514 exhibition/views.py:2519
+#: views.py:2854 views.py:2867 views.py:2872
 msgid "No emails were selected."
 msgstr ""
 
-#: exhibition/views.py:2510
+#: views.py:2863
 #, python-format
 msgid "%(count)d email has been discarded."
 msgid_plural "%(count)d emails have been discarded."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2594
+#: views.py:2929
+msgid "Request received (confirmation)"
+msgstr ""
+
+#: views.py:2930
+msgid "Request accepted"
+msgstr ""
+
+#: views.py:2931
+msgid "Request rejected"
+msgstr ""
+
+#: views.py:2932
+msgid "Exhibitor lead scanning key"
+msgstr ""
+
+#: views.py:2948
 msgid "Email templates have been saved."
 msgstr ""
 
-#: exhibition/views.py:2617 exhibition/views.py:2621
+#: views.py:2971 views.py:2975
 msgid "Unknown template."
 msgstr ""
 
-#: exhibition/views.py:2667
+#: views.py:3021
 msgid "Custom template has been created."
 msgstr ""
 
-#: exhibition/views.py:2683
+#: views.py:3041
 msgid "Custom template has been deleted."
 msgstr ""

--- a/exhibition/locale/pt_BR/LC_MESSAGES/django.po
+++ b/exhibition/locale/pt_BR/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-29 10:33+0000\n"
+"POT-Creation-Date: 2026-09-11 11:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,595 +18,531 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: exhibition/apps.py:14 exhibition/apps.py:17 exhibition/signals.py:157
-#: exhibition/templates/exhibitors/public_list.html:6
-#: exhibition/templates/exhibitors/public_list.html:14
-#: exhibition/templates/exhibitors/public_list.html:16
+#: apps.py:14 apps.py:17 signals.py:163 templates/exhibitors/public_list.html:6
+#: templates/exhibitors/public_list.html:14
+#: templates/exhibitors/public_list.html:16
 msgid "Exhibition"
 msgstr ""
 
-#: exhibition/apps.py:19
+#: apps.py:19
 msgid "This plugin enables to add and control exhibitors in eventyay"
 msgstr ""
 
-#: exhibition/filters.py:9
+#: filters.py:9
 msgid "Any"
 msgstr ""
 
-#: exhibition/filters.py:10
+#: filters.py:10
 msgid "Enabled"
 msgstr ""
 
-#: exhibition/filters.py:11 exhibition/templates/exhibitors/dashboard.html:127
+#: filters.py:11 templates/exhibitors/dashboard.html:127
 msgid "Disabled"
 msgstr ""
 
-#: exhibition/filters.py:15
+#: filters.py:15
 msgid "All types"
 msgstr ""
 
-#: exhibition/filters.py:16
+#: filters.py:16
 msgid "Exhibitor only"
 msgstr ""
 
-#: exhibition/filters.py:17
+#: filters.py:17
 msgid "Sponsor only"
 msgstr ""
 
-#: exhibition/filters.py:18 exhibition/templates/exhibitors/dashboard.html:89
-#: exhibition/templates/exhibitors/proposal_detail.html:95
-#: exhibition/templates/exhibitors/proposal_list.html:95
+#: filters.py:18 templates/exhibitors/dashboard.html:89
+#: templates/exhibitors/proposal_detail.html:95
+#: templates/exhibitors/proposal_list.html:95
 msgid "Exhibitor and sponsor"
 msgstr ""
 
-#: exhibition/filters.py:80 exhibition/filters.py:81
+#: filters.py:80 filters.py:81
 msgid "Search requests…"
 msgstr ""
 
-#: exhibition/filters.py:81
+#: filters.py:81
 msgid "Search requests"
 msgstr ""
 
-#: exhibition/filters.py:85 exhibition/templates/exhibitors/dashboard.html:75
-#: exhibition/templates/exhibitors/proposal_detail.html:85
-#: exhibition/templates/exhibitors/proposal_list.html:21
-#: exhibition/templates/exhibitors/public_proposal_list.html:12
+#: filters.py:85 templates/exhibitors/dashboard.html:75
+#: templates/exhibitors/proposal_detail.html:85
+#: templates/exhibitors/proposal_list.html:21
+#: templates/exhibitors/public_proposal_list.html:12
 msgid "State"
 msgstr ""
 
-#: exhibition/filters.py:86
+#: filters.py:86
 msgid "All states"
 msgstr ""
 
-#: exhibition/filters.py:90 exhibition/templates/exhibitors/dashboard.html:74
-#: exhibition/templates/exhibitors/proposal_detail.html:91
-#: exhibition/templates/exhibitors/proposal_list.html:62
+#: filters.py:90 templates/exhibitors/dashboard.html:74
+#: templates/exhibitors/proposal_detail.html:91
+#: templates/exhibitors/proposal_list.html:62
 msgid "Type"
 msgstr ""
 
-#: exhibition/filters.py:99 exhibition/filters.py:102
+#: filters.py:99 filters.py:102
 msgid "Search by name…"
 msgstr ""
 
-#: exhibition/filters.py:103
+#: filters.py:103
 msgid "Search requests by name"
 msgstr ""
 
-#: exhibition/filters.py:132 exhibition/filters.py:133
+#: filters.py:132 filters.py:133
 msgid "Search organizations…"
 msgstr ""
 
-#: exhibition/filters.py:133
+#: filters.py:133
 msgid "Search organizations"
 msgstr ""
 
-#: exhibition/filters.py:137
+#: filters.py:137
 msgid "Visibility"
 msgstr ""
 
-#: exhibition/filters.py:139
+#: filters.py:139
 msgid "All organizations"
 msgstr ""
 
-#: exhibition/filters.py:140 exhibition/forms.py:1512
-#: exhibition/templates/exhibitors/call_questions.html:30
+#: filters.py:140 forms.py:1553 templates/exhibitors/call_questions.html:30
 msgid "Active"
 msgstr ""
 
-#: exhibition/filters.py:141
+#: filters.py:141
 msgid "Inactive"
 msgstr ""
 
-#: exhibition/filters.py:146 exhibition/filters.py:207 exhibition/forms.py:207
-#: exhibition/forms.py:1410 exhibition/forms.py:1841
+#: filters.py:146 filters.py:207 forms.py:212 forms.py:1411 forms.py:1888
 msgid "Sponsor group"
 msgstr ""
 
-#: exhibition/filters.py:149 exhibition/filters.py:210
+#: filters.py:149 filters.py:210
 msgid "All groups"
 msgstr ""
 
-#: exhibition/filters.py:152 exhibition/templates/exhibitors/add.html:222
+#: filters.py:152 templates/exhibitors/add.html:226
 msgid "Lead scanning"
 msgstr ""
 
-#: exhibition/filters.py:157
+#: filters.py:157
 msgid "Lead access"
 msgstr ""
 
-#: exhibition/filters.py:162
+#: filters.py:162
 msgid "Voucher access"
 msgstr ""
 
-#: exhibition/filters.py:202 exhibition/filters.py:203
+#: filters.py:202 filters.py:203
 msgid "Search exhibitors…"
 msgstr ""
 
-#: exhibition/filters.py:203
+#: filters.py:203
 msgid "Search exhibitors"
 msgstr ""
 
-#: exhibition/filters.py:240 exhibition/filters.py:241
+#: filters.py:240 filters.py:241
 msgid "Search emails…"
 msgstr ""
 
-#: exhibition/filters.py:241
+#: filters.py:241
 msgid "Search emails"
 msgstr ""
 
-#: exhibition/forms.py:67
+#: forms.py:72
 #, python-format
 msgid "Times are in the event timezone: %(tz)s."
 msgstr ""
 
-#: exhibition/forms.py:128 exhibition/forms.py:139 exhibition/forms.py:933
-#: exhibition/forms.py:944
+#: forms.py:133 forms.py:144 forms.py:934 forms.py:945
 msgid "— No selection —"
 msgstr ""
 
-#: exhibition/forms.py:211
+#: forms.py:216
 msgid "Can view voucher redemptions"
 msgstr ""
 
-#: exhibition/forms.py:213 exhibition/forms.py:397
+#: forms.py:218 forms.py:402
 msgid ""
 "Lets this exhibitor or sponsor retrieve the attendees who redeemed vouchers "
 "issued to them. Separate from lead scanning, which covers attendees scanned "
 "at the booth."
 msgstr ""
 
-#: exhibition/forms.py:219
+#: forms.py:224
 msgid "Can view and export collected leads"
 msgstr ""
 
-#: exhibition/forms.py:221
+#: forms.py:226
 msgid ""
 "Lets this exhibitor retrieve the full list of leads they have already "
 "scanned. Turn this off to let them keep scanning without seeing the "
 "collected attendee data."
 msgstr ""
 
-#: exhibition/forms.py:226
+#: forms.py:231
 msgid "Lead scanning behavior"
 msgstr ""
 
-#: exhibition/forms.py:231
+#: forms.py:236
 msgid ""
 "Every attendee is one lead, even when scanned from multiple devices. Notes "
 "and ratings are shared between devices."
 msgstr ""
 
-#: exhibition/forms.py:238
+#: forms.py:243
 msgid ""
 "Every attendee is a new lead when scanned from a new device. Notes and "
 "ratings are specific to the device."
 msgstr ""
 
-#: exhibition/forms.py:251
+#: forms.py:256
 msgid "Comment"
 msgstr ""
 
-#: exhibition/forms.py:253
+#: forms.py:258
 msgid ""
 "The text entered in this field will not be visible to the user and is "
 "available for your convenience."
 msgstr ""
 
-#: exhibition/forms.py:258 exhibition/forms.py:1427 exhibition/views.py:505
+#: forms.py:263 forms.py:1428 views.py:544
 msgid "Booth ID"
 msgstr ""
 
-#: exhibition/forms.py:291 exhibition/forms.py:1027 exhibition/forms.py:1076
-#: exhibition/models.py:130
+#: forms.py:296 forms.py:1028 forms.py:1077 models.py:130
 msgid "Organization name"
 msgstr ""
 
-#: exhibition/forms.py:292 exhibition/forms.py:1030 exhibition/forms.py:1077
-#: exhibition/models.py:136
+#: forms.py:297 forms.py:1031 forms.py:1078 models.py:136
 msgid "Organization description"
 msgstr ""
 
-#: exhibition/forms.py:293 exhibition/forms.py:1078
+#: forms.py:298 forms.py:1079
 msgid "E-mail"
 msgstr ""
 
-#: exhibition/forms.py:294 exhibition/forms.py:1079 exhibition/models.py:139
+#: forms.py:299 forms.py:1080 models.py:139
 msgid "Contact page URL"
 msgstr ""
 
-#: exhibition/forms.py:295 exhibition/forms.py:1080 exhibition/models.py:140
+#: forms.py:300 forms.py:1081 models.py:140
 msgid "Promotional video URL"
 msgstr ""
 
-#: exhibition/forms.py:296 exhibition/forms.py:1081 exhibition/models.py:141
+#: forms.py:301 forms.py:1082 models.py:141
 msgid "Promotional slides"
 msgstr ""
 
-#: exhibition/forms.py:297 exhibition/forms.py:1082 exhibition/models.py:142
-#: exhibition/models.py:520
-#: exhibition/templates/exhibitors/proposal_detail.html:111
+#: forms.py:302 forms.py:1083 models.py:142 models.py:568
+#: templates/exhibitors/proposal_detail.html:111
 msgid "Logo"
 msgstr ""
 
-#: exhibition/forms.py:298 exhibition/forms.py:1083 exhibition/models.py:145
-#: exhibition/templates/exhibitors/proposal_detail.html:113
+#: forms.py:303 forms.py:1084 models.py:145
+#: templates/exhibitors/proposal_detail.html:113
 msgid "Header image"
 msgstr ""
 
-#: exhibition/forms.py:299 exhibition/forms.py:1084 exhibition/models.py:138
+#: forms.py:304 forms.py:1085 models.py:138
 msgid "Organization website"
 msgstr ""
 
-#: exhibition/forms.py:300
+#: forms.py:305
 msgid "Mark this partner as an exhibitor"
 msgstr ""
 
-#: exhibition/forms.py:301
+#: forms.py:306
 msgid "Mark this partner as an event sponsor"
 msgstr ""
 
-#: exhibition/forms.py:302 exhibition/forms.py:1036 exhibition/forms.py:1085
-#: exhibition/models.py:148 exhibition/models.py:522
+#: forms.py:307 forms.py:1037 forms.py:1086 models.py:148 models.py:570
 msgid "Preferred booth name"
 msgstr ""
 
-#: exhibition/forms.py:303
+#: forms.py:308
 msgid "Can scan attendee badges"
 msgstr ""
 
-#: exhibition/forms.py:307
+#: forms.py:312
 msgid ""
 "Lets this exhibitor sign in to the lead scanning app and scan attendees at "
 "their booth. Turn this off to block scanning entirely."
 msgstr ""
 
-#: exhibition/forms.py:348 exhibition/forms.py:1441
+#: forms.py:353 forms.py:1442
 msgid "No sponsor group"
 msgstr ""
 
-#: exhibition/forms.py:385
+#: forms.py:390
 msgid ""
 "Lets this exhibitor retrieve the attendees who redeemed vouchers issued to "
 "them. Separate from lead scanning, which covers attendees scanned at the "
 "booth."
 msgstr ""
 
-#: exhibition/forms.py:389
+#: forms.py:394
 msgid ""
 "Lets this sponsor retrieve the attendees who redeemed vouchers issued to "
 "them. Separate from lead scanning, which covers attendees scanned at the "
 "booth."
 msgstr ""
 
-#: exhibition/forms.py:393
+#: forms.py:398
 msgid ""
 "Lets this exhibitor and sponsor retrieve the attendees who redeemed vouchers "
 "issued to them. Separate from lead scanning, which covers attendees scanned "
 "at the booth."
 msgstr ""
 
-#: exhibition/forms.py:466 exhibition/forms.py:553 exhibition/forms.py:1361
-#: exhibition/forms.py:1375
+#: forms.py:471 forms.py:558 forms.py:1362 forms.py:1376 forms.py:1855
+#: forms.py:1924 forms.py:1930 forms.py:1932 forms.py:1934
 msgid "This field is required."
 msgstr ""
 
-#: exhibition/forms.py:511 exhibition/forms.py:516
+#: forms.py:516 forms.py:521
 msgid "Slides upload must be a PDF file."
 msgstr ""
 
-#: exhibition/forms.py:540
+#: forms.py:545
 msgid "A partner must be marked as an exhibitor, a sponsor, or both."
 msgstr ""
 
-#: exhibition/forms.py:615
+#: forms.py:620
 msgid "Devices to add"
 msgstr ""
 
-#: exhibition/forms.py:617
+#: forms.py:622
 msgid ""
 "How many new devices to provision now, in addition to any already listed "
 "above. Each device gets its own single-use setup token and QR code."
 msgstr ""
 
-#: exhibition/forms.py:627
-msgid "Select a product…"
+#: forms.py:635
+msgid "Vouchers to take from the pool"
 msgstr ""
 
-#: exhibition/forms.py:628
-msgid "Ticket product"
+#: forms.py:636
+msgid ""
+"Set to 0 to email the codes this partner already has without taking any more."
 msgstr ""
 
-#: exhibition/forms.py:629
-msgid "The product a redeemed voucher applies to."
-msgstr ""
-
-#: exhibition/forms.py:635
-msgid "Number of vouchers"
-msgstr ""
-
-#: exhibition/forms.py:640
-msgid "Maximum usages per voucher"
-msgstr ""
-
-#: exhibition/forms.py:645 exhibition/templates/exhibitors/vouchers.html:33
-#: exhibition/views.py:1995
-msgid "Price effect"
-msgstr ""
-
-#: exhibition/forms.py:651 exhibition/views.py:1996
-msgid "Value"
-msgstr ""
-
-#: exhibition/forms.py:652
-msgid "Amount or percentage, depending on the selected price effect."
-msgstr ""
-
-#: exhibition/forms.py:657 exhibition/templates/exhibitors/vouchers.html:35
-#: exhibition/views.py:1997
-msgid "Valid until"
-msgstr ""
-
-#: exhibition/forms.py:673
-msgid "Enter a value for the selected price effect."
-msgstr ""
-
-#: exhibition/forms.py:678 exhibition/models.py:295
-#: exhibition/templates/exhibitors/settings.html:205
+#: forms.py:647 models.py:326 templates/exhibitors/settings.html:289
 msgid "Level"
 msgstr ""
 
-#: exhibition/forms.py:685 exhibition/models.py:294
+#: forms.py:654 models.py:325
 msgid "Group name"
 msgstr ""
 
-#: exhibition/forms.py:718
+#: forms.py:677 models.py:225
+msgid "Exhibitor voucher pool"
+msgstr ""
+
+#: forms.py:678 models.py:232
+msgid "Sponsor voucher pool"
+msgstr ""
+
+#: forms.py:698
+msgid "— No pool selected —"
+msgstr ""
+
+#: forms.py:699
+msgid "— Use the exhibitor pool —"
+msgstr ""
+
+#: forms.py:719
 msgid "Enable call"
 msgstr ""
 
-#: exhibition/forms.py:719
+#: forms.py:720
 msgid "Hide call page after the deadline"
 msgstr ""
 
-#: exhibition/forms.py:720
+#: forms.py:721
 msgid "Make this call private (accessible only via a secret link)"
 msgstr ""
 
-#: exhibition/forms.py:724
+#: forms.py:725
 msgid ""
 "Turn the call on. Keep it enabled for private calls too, otherwise the "
 "secret link stops working."
 msgstr ""
 
-#: exhibition/forms.py:727
+#: forms.py:728
 msgid ""
 "The call page is not linked anywhere public and can only be opened with the "
 "secret link shown below."
 msgstr ""
 
-#: exhibition/forms.py:868
+#: forms.py:869
 msgid "Your answer"
 msgstr ""
 
-#: exhibition/forms.py:1024 exhibition/models.py:563
-#: exhibition/templates/exhibitors/proposal_detail.html:88
+#: forms.py:1025 models.py:611 templates/exhibitors/proposal_detail.html:88
 msgid "Language"
 msgstr ""
 
-#: exhibition/forms.py:1025
+#: forms.py:1026
 msgid "The language you are filling in this form with."
 msgstr ""
 
-#: exhibition/forms.py:1086 exhibition/models.py:151 exhibition/models.py:523
-#: exhibition/models.py:602
+#: forms.py:1087 models.py:151 models.py:571 models.py:650
 msgid "Message to the organizers"
 msgstr ""
 
-#: exhibition/forms.py:1149
+#: forms.py:1150
 msgid ""
 "The organization name is locked after acceptance. Contact the organizers to "
 "change it."
 msgstr ""
 
-#: exhibition/forms.py:1425
+#: forms.py:1426
 msgid "Approve as exhibitor"
 msgstr ""
 
-#: exhibition/forms.py:1426
+#: forms.py:1427
 msgid "Approve as sponsor"
 msgstr ""
 
-#: exhibition/forms.py:1428 exhibition/models.py:352 exhibition/models.py:596
-#: exhibition/models.py:966 exhibition/views.py:505
+#: forms.py:1429 models.py:383 models.py:644 models.py:1014 views.py:544
 msgid "Booth name"
 msgstr ""
 
-#: exhibition/forms.py:1429 exhibition/forms.py:1459 exhibition/models.py:607
+#: forms.py:1430 forms.py:1460 models.py:655
 msgid "Internal review notes"
 msgstr ""
 
-#: exhibition/forms.py:1470
+#: forms.py:1471
 msgid "Field label"
 msgstr ""
 
-#: exhibition/forms.py:1475 exhibition/forms.py:1510
+#: forms.py:1476 forms.py:1551
 msgid "Help text"
 msgstr ""
 
-#: exhibition/forms.py:1476
+#: forms.py:1477
 msgid "Shown below the field on the exhibitor form."
 msgstr ""
 
-#: exhibition/forms.py:1483
+#: forms.py:1484
 #, python-format
 msgid "Leave empty to use the default: %(label)s"
 msgstr ""
 
-#: exhibition/forms.py:1492
-msgid "Options"
-msgstr ""
-
-#: exhibition/forms.py:1493
-msgid "For choice fields, enter one option per line."
-msgstr ""
-
-#: exhibition/forms.py:1508
-msgid "Field type"
-msgstr ""
-
-#: exhibition/forms.py:1509 exhibition/models.py:878
-msgid "Custom question"
-msgstr ""
-
-#: exhibition/forms.py:1511
-#: exhibition/templates/exhibitors/call_questions.html:31
-#: exhibition/templates/exhibitors/call_questions.html:63
-msgid "Required"
-msgstr ""
-
-#: exhibition/forms.py:1535
+#: forms.py:1523
 msgid "Please provide at least one option for this question type."
 msgstr ""
 
-#: exhibition/forms.py:1576 exhibition/forms.py:1665
+#: forms.py:1549
+msgid "Field type"
+msgstr ""
+
+#: forms.py:1550 models.py:926
+msgid "Custom question"
+msgstr ""
+
+#: forms.py:1552 templates/exhibitors/call_questions.html:31
+#: templates/exhibitors/call_questions.html:63
+msgid "Required"
+msgstr ""
+
+#: forms.py:1583 forms.py:1672
 msgid "Choose social platform"
 msgstr ""
 
-#: exhibition/forms.py:1578 exhibition/forms.py:1667
+#: forms.py:1585 forms.py:1674
 msgid "Social platform"
 msgstr ""
 
-#: exhibition/forms.py:1582 exhibition/forms.py:1671
+#: forms.py:1589 forms.py:1678
 msgid "Profile or path"
 msgstr ""
 
-#: exhibition/forms.py:1596 exhibition/forms.py:1685
+#: forms.py:1603 forms.py:1692
 msgid "Profile, handle, or full URL"
 msgstr ""
 
-#: exhibition/forms.py:1616 exhibition/forms.py:1705
+#: forms.py:1623 forms.py:1712
 msgid "Please enter a profile, handle, or URL or remove this row."
 msgstr ""
 
-#: exhibition/forms.py:1622 exhibition/forms.py:1711
+#: forms.py:1629 forms.py:1718
 msgid "Please choose a social platform."
 msgstr ""
 
-#: exhibition/forms.py:1626 exhibition/forms.py:1715
+#: forms.py:1633 forms.py:1722
 msgid "Please enter a profile, handle, or URL."
 msgstr ""
 
-#: exhibition/forms.py:1648 exhibition/forms.py:1737
+#: forms.py:1655 forms.py:1744
 msgid "Link label"
 msgstr ""
 
-#: exhibition/forms.py:1654 exhibition/forms.py:1743
+#: forms.py:1661 forms.py:1750
 msgid "https://example.com"
 msgstr ""
 
-#: exhibition/forms.py:1807
+#: forms.py:1848
 msgid ""
 "Leave empty to keep this in the outbox until sent manually. Time is "
 "interpreted in the event timezone."
 msgstr ""
 
-#: exhibition/forms.py:1814 exhibition/forms.py:1877
+#: forms.py:1861 forms.py:1940
 msgid "The scheduled time must be in the future."
 msgstr ""
 
-#: exhibition/forms.py:1822
+#: forms.py:1869
 msgid "Exhibitors and sponsors"
 msgstr ""
 
-#: exhibition/forms.py:1823
+#: forms.py:1870
 msgid "Exhibitors only"
 msgstr ""
 
-#: exhibition/forms.py:1824
+#: forms.py:1871
 msgid "Sponsors only"
 msgstr ""
 
-#: exhibition/forms.py:1828
+#: forms.py:1875
 msgid "Application state"
 msgstr ""
 
-#: exhibition/forms.py:1836
+#: forms.py:1883
 msgid "Partner type"
 msgstr ""
 
-#: exhibition/forms.py:1844
+#: forms.py:1891
 msgid "Any sponsor group"
 msgstr ""
 
-#: exhibition/forms.py:1846 exhibition/models.py:1035 exhibition/models.py:1089
-#: exhibition/templates/exhibitors/_email_outbox_body.html:6
-#: exhibition/templates/exhibitors/_email_sent_body.html:6
+#: forms.py:1893 forms.py:1953 models.py:1084 models.py:1146
+#: templates/exhibitors/_email_outbox_body.html:6
+#: templates/exhibitors/_email_sent_body.html:6
 msgid "Subject"
 msgstr ""
 
-#: exhibition/forms.py:1848
+#: forms.py:1895
 msgid "Send at"
 msgstr ""
 
-#: exhibition/forms.py:1851
+#: forms.py:1898
 msgid "Leave empty to send immediately or save to the outbox."
 msgstr ""
 
-#: exhibition/forms.py:1859 exhibition/models.py:1036 exhibition/models.py:1090
+#: forms.py:1906 forms.py:1960 models.py:1085 models.py:1147
 msgid "Body"
 msgstr ""
 
-#: exhibition/forms.py:1885 exhibition/views.py:2576
-msgid "Request received (confirmation)"
-msgstr ""
-
-#: exhibition/forms.py:1886 exhibition/views.py:2577
-msgid "Request accepted"
-msgstr ""
-
-#: exhibition/forms.py:1887 exhibition/views.py:2578
-msgid "Request rejected"
-msgstr ""
-
-#: exhibition/forms.py:1888 exhibition/views.py:2579
-msgid "Exhibitor lead scanning key"
-msgstr ""
-
-#: exhibition/forms.py:1897
-#, python-format
-msgid "%(role)s — subject"
-msgstr ""
-
-#: exhibition/forms.py:1904
-#, python-format
-msgid "%(role)s — body"
-msgstr ""
-
-#: exhibition/mail.py:57
+#: mail.py:59
 #, python-brace-format
 msgid "We received your request for {event_name}"
 msgstr ""
 
-#: exhibition/mail.py:59
+#: mail.py:61
 #, python-brace-format
 msgid ""
 "Hello,\n"
@@ -621,12 +557,12 @@ msgid ""
 "The {event_name} team"
 msgstr ""
 
-#: exhibition/mail.py:69
+#: mail.py:71
 #, python-brace-format
 msgid "Your request for {event_name} has been accepted"
 msgstr ""
 
-#: exhibition/mail.py:71
+#: mail.py:73
 #, python-brace-format
 msgid ""
 "Hello,\n"
@@ -638,12 +574,12 @@ msgid ""
 "The {event_name} team"
 msgstr ""
 
-#: exhibition/mail.py:80
+#: mail.py:82
 #, python-brace-format
 msgid "Update on your request for {event_name}"
 msgstr ""
 
-#: exhibition/mail.py:82
+#: mail.py:84
 #, python-brace-format
 msgid ""
 "Hello,\n"
@@ -657,12 +593,12 @@ msgid ""
 "The {event_name} team"
 msgstr ""
 
-#: exhibition/mail.py:91
+#: mail.py:93
 #, python-brace-format
 msgid "Lead Scanning Access for {event_name}"
 msgstr ""
 
-#: exhibition/mail.py:93
+#: mail.py:95
 #, python-brace-format
 msgid ""
 "Hello {exhibitor_name},\n"
@@ -688,983 +624,1080 @@ msgid ""
 "The {event_name} Team"
 msgstr ""
 
-#: exhibition/mail.py:174
+#: mail.py:110
+#, python-brace-format
+msgid "Your vouchers for {event_name} — {exhibitor_name}"
+msgstr ""
+
+#: mail.py:112
+#, python-brace-format
+msgid ""
+"Dear {exhibitor_name},\n"
+"\n"
+"Thank you for participating in {event_name}. Please share the voucher codes "
+"below with your audience — anyone who uses one gets credited to you as a "
+"lead.\n"
+"\n"
+"{voucher_list}\n"
+"\n"
+"They can redeem a code on the event ticket shop at checkout.\n"
+"\n"
+"If you have any questions, please don't hesitate to reach out.\n"
+"\n"
+"Best regards,\n"
+"The {event_name} Team"
+msgstr ""
+
+#: mail.py:190
 msgid "This value will be replaced based on dynamic parameters."
 msgstr ""
 
-#: exhibition/models.py:137 exhibition/models.py:515
+#: mail.py:312
+#, python-format
+msgid "…and %(count)d more voucher code in the attached CSV file."
+msgid_plural "…and %(count)d more voucher codes in the attached CSV file."
+msgstr[0] ""
+msgstr[1] ""
+
+#: models.py:137 models.py:563
 msgid "Contact email"
 msgstr ""
 
-#: exhibition/models.py:156
-#: exhibition/templates/exhibitors/proposal_detail.html:132
+#: models.py:156 templates/exhibitors/proposal_detail.html:132
 msgid "Social media"
 msgstr ""
 
-#: exhibition/models.py:161
-#: exhibition/templates/exhibitors/proposal_detail.html:140
+#: models.py:161 templates/exhibitors/proposal_detail.html:140
 msgid "Extra links"
 msgstr ""
 
-#: exhibition/models.py:216
+#: models.py:212
+msgid "Vouchers per exhibitor"
+msgstr ""
+
+#: models.py:226
+msgid ""
+"The voucher tag created under Tickets → Vouchers that exhibitors draw their "
+"codes from."
+msgstr ""
+
+#: models.py:233
+msgid "Leave empty to draw sponsor codes from the exhibitor pool as well."
+msgstr ""
+
+#: models.py:239
+msgid "Attach voucher list as CSV"
+msgstr ""
+
+#: models.py:240
+msgid ""
+"Adds a spreadsheet of the recipient's own voucher codes to the voucher email."
+msgstr ""
+
+#: models.py:247
 msgid "Call headline"
 msgstr ""
 
-#: exhibition/models.py:220
+#: models.py:251
 msgid "Call text"
 msgstr ""
 
-#: exhibition/models.py:225
+#: models.py:256
 msgid "Submission deadline"
 msgstr ""
 
-#: exhibition/models.py:298
+#: models.py:329
 msgid "Show this sponsor group on the front page."
 msgstr ""
 
-#: exhibition/models.py:314 exhibition/models.py:558
-#: exhibition/templates/exhibitors/dashboard.html:73
-#: exhibition/templates/exhibitors/exhibitor_info.html:69
-#: exhibition/templates/exhibitors/proposal_list.html:19
-#: exhibition/templates/exhibitors/public_proposal_list.html:11
-#: exhibition/views.py:505
+#: models.py:345 models.py:606 templates/exhibitors/dashboard.html:73
+#: templates/exhibitors/exhibitor_info.html:79
+#: templates/exhibitors/proposal_list.html:19
+#: templates/exhibitors/public_proposal_list.html:11 views.py:544
 msgid "Name"
 msgstr ""
 
-#: exhibition/models.py:315 exhibition/models.py:559
-#: exhibition/templates/exhibitors/proposal_detail.html:117
+#: models.py:346 models.py:607 templates/exhibitors/proposal_detail.html:117
 msgid "Description"
 msgstr ""
 
-#: exhibition/models.py:316 exhibition/models.py:419 exhibition/models.py:435
-#: exhibition/models.py:565 exhibition/models.py:815 exhibition/models.py:831
-#: exhibition/models.py:844
-#: exhibition/templates/exhibitors/proposal_detail.html:103
+#: models.py:347 models.py:467 models.py:483 models.py:613 models.py:863
+#: models.py:879 models.py:892 templates/exhibitors/proposal_detail.html:103
 msgid "URL"
 msgstr ""
 
-#: exhibition/models.py:317 exhibition/models.py:566
-#: exhibition/templates/exhibitors/proposal_detail.html:77
-#: exhibition/views.py:505
+#: models.py:348 models.py:614 templates/exhibitors/proposal_detail.html:77
+#: views.py:544
 msgid "Email"
 msgstr ""
 
-#: exhibition/models.py:318 exhibition/models.py:567
-#: exhibition/templates/exhibitors/proposal_detail.html:105
+#: models.py:349 models.py:615 templates/exhibitors/proposal_detail.html:105
 msgid "Contact URL"
 msgstr ""
 
-#: exhibition/models.py:319 exhibition/models.py:568
-#: exhibition/templates/exhibitors/proposal_detail.html:107
+#: models.py:350 models.py:616 templates/exhibitors/proposal_detail.html:107
 msgid "Video URL"
 msgstr ""
 
-#: exhibition/models.py:322 exhibition/models.py:571
-#: exhibition/templates/exhibitors/proposal_detail.html:109
+#: models.py:353 models.py:619 templates/exhibitors/proposal_detail.html:109
 msgid "Slides"
 msgstr ""
 
-#: exhibition/models.py:326 exhibition/models.py:575
+#: models.py:357 models.py:623
 msgid "Slides URL"
 msgstr ""
 
-#: exhibition/models.py:328 exhibition/models.py:577
+#: models.py:359 models.py:625
 msgid "Logo URL"
 msgstr ""
 
-#: exhibition/models.py:330 exhibition/models.py:579
+#: models.py:361 models.py:627
 msgid "Header image URL"
 msgstr ""
 
-#: exhibition/models.py:434 exhibition/models.py:830
+#: models.py:482 models.py:878
 msgid "Label"
 msgstr ""
 
-#: exhibition/models.py:445
+#: models.py:493
 msgid "draft"
 msgstr ""
 
-#: exhibition/models.py:446
+#: models.py:494
 msgid "submitted"
 msgstr ""
 
-#: exhibition/models.py:447
+#: models.py:495
 msgid "accepted"
 msgstr ""
 
-#: exhibition/models.py:448
+#: models.py:496
 msgid "rejected"
 msgstr ""
 
-#: exhibition/models.py:449
+#: models.py:497
 msgid "withdrawn"
 msgstr ""
 
-#: exhibition/models.py:514
+#: models.py:562
 msgid "Organization Description"
 msgstr ""
 
-#: exhibition/models.py:516
+#: models.py:564
 msgid "Organization Website"
 msgstr ""
 
-#: exhibition/models.py:517
+#: models.py:565
 msgid "Contact Page URL"
 msgstr ""
 
-#: exhibition/models.py:518
+#: models.py:566
 msgid "Promotional Video URL"
 msgstr ""
 
-#: exhibition/models.py:519
+#: models.py:567
 msgid "Promotional Slides"
 msgstr ""
 
-#: exhibition/models.py:521
+#: models.py:569
 msgid "Header Image"
 msgstr ""
 
-#: exhibition/models.py:524 exhibition/templates/exhibitors/add.html:29
-#: exhibition/templates/exhibitors/public_proposal_form.html:38
+#: models.py:572 templates/exhibitors/add.html:29
+#: templates/exhibitors/public_proposal_form.html:38
 msgid "Social Media"
 msgstr ""
 
-#: exhibition/models.py:525 exhibition/templates/exhibitors/add.html:92
-#: exhibition/templates/exhibitors/public_proposal_form.html:91
+#: models.py:573 templates/exhibitors/add.html:92
+#: templates/exhibitors/public_proposal_form.html:91
 msgid "Extra Links"
 msgstr ""
 
-#: exhibition/models.py:841
+#: models.py:889
 msgid "Number"
 msgstr ""
 
-#: exhibition/models.py:842
+#: models.py:890
 msgid "Text (one line)"
 msgstr ""
 
-#: exhibition/models.py:843
+#: models.py:891
 msgid "Multiline text"
 msgstr ""
 
-#: exhibition/models.py:845
+#: models.py:893
 msgid "Email address"
 msgstr ""
 
-#: exhibition/models.py:846
+#: models.py:894
 msgid "Confirm Checkbox"
 msgstr ""
 
-#: exhibition/models.py:847
+#: models.py:895
 msgid "Radio button (Choose one option)"
 msgstr ""
 
-#: exhibition/models.py:848
+#: models.py:896
 msgid "Dropdown (Choose one option)"
 msgstr ""
 
-#: exhibition/models.py:849
+#: models.py:897
 msgid "Checkbox (Choose one or several options)"
 msgstr ""
 
-#: exhibition/models.py:850
+#: models.py:898
 msgid "File upload"
 msgstr ""
 
-#: exhibition/models.py:851
+#: models.py:899
 msgid "Date"
 msgstr ""
 
-#: exhibition/models.py:852
+#: models.py:900
 msgid "Time"
 msgstr ""
 
-#: exhibition/models.py:853
+#: models.py:901
 msgid "Date and time"
 msgstr ""
 
-#: exhibition/models.py:854
+#: models.py:902
 msgid "Country code (ISO 3166-1 alpha-2)"
 msgstr ""
 
-#: exhibition/models.py:855
+#: models.py:903
 msgid "Phone number"
 msgstr ""
 
-#: exhibition/models.py:883
+#: models.py:931
 msgid "help text"
 msgstr ""
 
-#: exhibition/models.py:885 exhibition/templates/exhibitors/add.html:29
-#: exhibition/templates/exhibitors/add.html:92
-#: exhibition/templates/exhibitors/public_proposal_form.html:38
-#: exhibition/templates/exhibitors/public_proposal_form.html:91
+#: models.py:933 templates/exhibitors/add.html:29
+#: templates/exhibitors/add.html:92
+#: templates/exhibitors/public_proposal_form.html:38
+#: templates/exhibitors/public_proposal_form.html:91
 msgid "required"
 msgstr ""
 
-#: exhibition/models.py:886
+#: models.py:934
 msgid "active"
 msgstr ""
 
-#: exhibition/models.py:906
+#: models.py:954
 msgid "Response"
 msgstr ""
 
-#: exhibition/models.py:938
+#: models.py:986
 msgid "Yes"
 msgstr ""
 
-#: exhibition/models.py:940
+#: models.py:988
 msgid "No"
 msgstr ""
 
-#: exhibition/models.py:1034
-#: exhibition/templates/exhibitors/_email_outbox_body.html:5
-#: exhibition/templates/exhibitors/_email_sent_body.html:5
+#: models.py:1083 templates/exhibitors/_email_outbox_body.html:5
+#: templates/exhibitors/_email_sent_body.html:5
 msgid "Recipient"
 msgstr ""
 
-#: exhibition/models.py:1045
+#: models.py:1101
 msgid "Queued email"
 msgstr ""
 
-#: exhibition/models.py:1046
+#: models.py:1102
 msgid "Queued emails"
 msgstr ""
 
-#: exhibition/models.py:1088
+#: models.py:1145
 msgid "Template name"
 msgstr ""
 
-#: exhibition/models.py:1095
+#: models.py:1152
 msgid "Custom email template"
 msgstr ""
 
-#: exhibition/models.py:1096
+#: models.py:1153
 msgid "Custom email templates"
 msgstr ""
 
-#: exhibition/signals.py:75
+#: signals.py:81
 msgid "Screen and evaluate exhibitor and sponsor requests for the event."
 msgstr ""
 
-#: exhibition/signals.py:76
+#: signals.py:82
 msgid "Request Review Dashboard"
 msgstr ""
 
-#: exhibition/signals.py:80
+#: signals.py:86
 msgid ""
 "Manage exhibitors and sponsors, maintain booth details, and create partner "
 "profiles for the event."
 msgstr ""
 
-#: exhibition/signals.py:82
+#: signals.py:88
 msgid "Exhibitors & Sponsors Dashboard"
 msgstr ""
 
-#: exhibition/signals.py:88 exhibition/templates/exhibitors/base.html:5
-#: exhibition/templates/exhibitors/base.html:125
-#: exhibition/templates/exhibitors/exhibitor_info.html:4
-#: exhibition/templates/exhibitors/exhibitor_info.html:15
+#: signals.py:94 templates/exhibitors/base.html:6
+#: templates/exhibitors/base.html:136
+#: templates/exhibitors/exhibitor_info.html:4
+#: templates/exhibitors/exhibitor_info.html:15
 msgid "Exhibitors & Sponsors"
 msgstr ""
 
-#: exhibition/signals.py:90
+#: signals.py:96
 msgid "Go to"
 msgstr ""
 
-#: exhibition/signals.py:166 exhibition/templates/exhibitors/call_base.html:4
-#: exhibition/templates/exhibitors/call_base.html:7
-#: exhibition/templates/exhibitors/public_call.html:7
-#: exhibition/templates/exhibitors/settings.html:8
-#: exhibition/templates/exhibitors/settings.html:25
+#: signals.py:172 templates/exhibitors/call_base.html:4
+#: templates/exhibitors/call_base.html:7
+#: templates/exhibitors/public_call.html:7 templates/exhibitors/settings.html:8
+#: templates/exhibitors/settings.html:27
 msgid "Call for Exhibitors"
 msgstr ""
 
-#: exhibition/signals.py:207 exhibition/signals.py:231
+#: signals.py:213 signals.py:237
 msgid "Acme Corp"
 msgstr ""
 
-#: exhibition/signals.py:225
+#: signals.py:231
 msgid "Jane Doe"
 msgstr ""
 
-#: exhibition/signals.py:293 exhibition/templates/exhibitors/base.html:62
-#: exhibition/templates/exhibitors/proposal_list.html:5
-#: exhibition/templates/exhibitors/proposal_list.html:15
+#: signals.py:305 templates/exhibitors/base.html:73
+#: templates/exhibitors/proposal_list.html:5
+#: templates/exhibitors/proposal_list.html:15
 msgid "Exhibition requests"
 msgstr ""
 
-#: exhibition/signals.py:298
+#: signals.py:310
 msgid "Exhibition request approved."
 msgstr ""
 
-#: exhibition/signals.py:299
+#: signals.py:311
 msgid "Exhibition request rejected."
 msgstr ""
 
-#: exhibition/signals.py:300
+#: signals.py:312
 msgid "Exhibition request withdrawn."
 msgstr ""
 
-#: exhibition/signals.py:301
+#: signals.py:313
 msgid "Exhibition request reopened for review."
 msgstr ""
 
-#: exhibition/signals.py:302
+#: signals.py:314
 msgid "Exhibition request changed."
 msgstr ""
 
-#: exhibition/signals.py:303
+#: signals.py:315
 msgid "Organization profile created from an approved request."
 msgstr ""
 
-#: exhibition/signals.py:304
+#: signals.py:316
 msgid "Organization profile reactivated after re-approval."
 msgstr ""
 
-#: exhibition/signals.py:305
+#: signals.py:317
 msgid "Organization profile updated from the submitter's changes."
 msgstr ""
 
-#: exhibition/signals.py:306
+#: signals.py:318
 msgid "Organization profile created."
 msgstr ""
 
-#: exhibition/signals.py:307
+#: signals.py:319
 msgid "Organization profile changed."
 msgstr ""
 
-#: exhibition/signals.py:308
+#: signals.py:320
 msgid "Organization profile deleted."
 msgstr ""
 
-#: exhibition/signals.py:309
+#: signals.py:321
 msgid "Exhibition settings changed."
 msgstr ""
 
-#: exhibition/signals.py:310
+#: signals.py:322
 msgid "Call for exhibitors settings changed."
 msgstr ""
 
-#: exhibition/signals.py:311
+#: signals.py:323
 msgid "Private call link regenerated."
 msgstr ""
 
-#: exhibition/signals.py:312
+#: signals.py:324
 msgid "Sponsor group created."
 msgstr ""
 
-#: exhibition/signals.py:313
+#: signals.py:325
 msgid "Sponsor group changed."
 msgstr ""
 
-#: exhibition/signals.py:314 exhibition/views.py:457
+#: signals.py:326 views.py:496
 msgid "Sponsor group deleted."
 msgstr ""
 
-#: exhibition/signals.py:315
+#: signals.py:327
 msgid "Exhibitor form question created."
 msgstr ""
 
-#: exhibition/signals.py:316
+#: signals.py:328
 msgid "Exhibitor form question changed."
 msgstr ""
 
-#: exhibition/signals.py:317
+#: signals.py:329
 msgid "Exhibitor form question deleted."
 msgstr ""
 
-#: exhibition/signals.py:318
+#: signals.py:330
 msgid "Email sent."
 msgstr ""
 
-#: exhibition/signals.py:337
+#: signals.py:349
 #, python-brace-format
 msgid "Updated: {fields}."
 msgstr ""
 
-#: exhibition/signals.py:360
+#: signals.py:372
 #, python-brace-format
 msgid "State changed from {old} to {new}."
 msgstr ""
 
-#: exhibition/signals.py:382
+#: signals.py:394
 #, python-brace-format
 msgid "Exhibition request {val}"
 msgstr ""
 
-#: exhibition/signals.py:391
+#: signals.py:403
 #, python-brace-format
 msgid "Organization profile {val}"
 msgstr ""
 
-#: exhibition/signals.py:400
+#: signals.py:412
 #, python-brace-format
 msgid "Exhibitor form question {val}"
 msgstr ""
 
-#: exhibition/signals.py:409
+#: signals.py:421
 #, python-brace-format
 msgid "Sponsor group {val}"
 msgstr ""
 
-#: exhibition/social_links.py:36
+#: social_links.py:36
 msgid "Facebook"
 msgstr ""
 
-#: exhibition/social_links.py:43
+#: social_links.py:43
 msgid "Flickr"
 msgstr ""
 
-#: exhibition/social_links.py:50
+#: social_links.py:50
 msgid "GitHub"
 msgstr ""
 
-#: exhibition/social_links.py:57
+#: social_links.py:57
 msgid "GitLab"
 msgstr ""
 
-#: exhibition/social_links.py:64
+#: social_links.py:64
 msgid "Gitter"
 msgstr ""
 
-#: exhibition/social_links.py:71
+#: social_links.py:71
 msgid "Google Groups"
 msgstr ""
 
-#: exhibition/social_links.py:78
+#: social_links.py:78
 msgid "Instagram"
 msgstr ""
 
-#: exhibition/social_links.py:85
+#: social_links.py:85
 msgid "LinkedIn"
 msgstr ""
 
-#: exhibition/social_links.py:92
+#: social_links.py:92
 msgid "Mastodon"
 msgstr ""
 
-#: exhibition/social_links.py:99
+#: social_links.py:99
 msgid "Patreon"
 msgstr ""
 
-#: exhibition/social_links.py:106
+#: social_links.py:106
 msgid "Telegram"
 msgstr ""
 
-#: exhibition/social_links.py:113
+#: social_links.py:113
 msgid "Vimeo"
 msgstr ""
 
-#: exhibition/social_links.py:120
+#: social_links.py:120
 msgid "VK"
 msgstr ""
 
-#: exhibition/social_links.py:127
+#: social_links.py:127
 msgid "Weibo"
 msgstr ""
 
-#: exhibition/social_links.py:134
+#: social_links.py:134
 msgid "X"
 msgstr ""
 
-#: exhibition/social_links.py:141
+#: social_links.py:141
 msgid "Xing"
 msgstr ""
 
-#: exhibition/social_links.py:148
+#: social_links.py:148
 msgid "YouTube"
 msgstr ""
 
-#: exhibition/social_links.py:155
+#: social_links.py:155
 msgid "YouTube Privacy"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:7
+#: templates/exhibitors/_email_outbox_body.html:7
 msgid "Created"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:14
+#: templates/exhibitors/_email_outbox_body.html:14
 msgid "Send selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:17
+#: templates/exhibitors/_email_outbox_body.html:17
 msgid "Discard selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:20
+#: templates/exhibitors/_email_outbox_body.html:20
 msgid "Send all"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:23
+#: templates/exhibitors/_email_outbox_body.html:23
 msgid "Discard all"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:35
+#: templates/exhibitors/_email_outbox_body.html:35
 msgid "Scheduled"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:36
-#: exhibition/templates/exhibitors/proposal_list.html:65
+#: templates/exhibitors/_email_outbox_body.html:36
+#: templates/exhibitors/proposal_list.html:65
 msgid "Actions"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:67
-msgid "Send this email"
+#: templates/exhibitors/_email_outbox_body.html:68
+msgid "Send"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:73
-msgid "Edit this email"
+#: templates/exhibitors/_email_outbox_body.html:75
+#: templates/exhibitors/_partner_row.html:54
+#: templates/exhibitors/call_questions.html:73
+#: templates/exhibitors/call_questions.html:76
+#: templates/exhibitors/dashboard.html:120
+#: templates/exhibitors/email_compose.html:55
+#: templates/exhibitors/email_custom_template_form.html:30
+#: templates/exhibitors/email_templates.html:50
+#: templates/exhibitors/email_templates.html:97
+#: templates/exhibitors/public_proposal_list.html:32
+#: templates/exhibitors/settings.html:59
+msgid "Edit"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:79
-msgid "Discard this email"
+#: templates/exhibitors/_email_outbox_body.html:82
+#: templates/exhibitors/email_bulk_discard.html:30
+#: templates/exhibitors/email_delete.html:31
+msgid "Discard"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:91
-#: exhibition/templates/exhibitors/_email_sent_body.html:34
+#: templates/exhibitors/_email_outbox_body.html:95
+#: templates/exhibitors/_email_sent_body.html:35
 msgid "No emails match your search."
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:93
+#: templates/exhibitors/_email_outbox_body.html:97
 msgid "The outbox is empty."
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_sent_body.html:7
-#: exhibition/templates/exhibitors/base.html:105
+#: templates/exhibitors/_email_sent_body.html:7
+#: templates/exhibitors/_partner_row.html:45 templates/exhibitors/base.html:116
 msgid "Sent"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_sent_body.html:36
+#: templates/exhibitors/_email_sent_body.html:37
 msgid "No emails have been sent yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:12
-#: exhibition/templates/exhibitors/public_list.html:29
+#: templates/exhibitors/_filter_form.html:12
+#: templates/exhibitors/public_list.html:29
 msgid "Search"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:18
-#: exhibition/templates/exhibitors/_filter_form.html:20
+#: templates/exhibitors/_filter_form.html:18
+#: templates/exhibitors/_filter_form.html:21
 msgid "Clear filters"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:29
+#: templates/exhibitors/_filter_form.html:30
 msgid "Filters"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:50
+#: templates/exhibitors/_filter_form.html:51
 msgid "Apply filters"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:5
+#: templates/exhibitors/_image_preview_dialog.html:11
+msgid "Close preview"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:5
 #, python-format
 msgid "Select %(name)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:33
+#: templates/exhibitors/_partner_row.html:33
 msgid "Untitled"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:40
+#: templates/exhibitors/_partner_row.html:40
+msgid "Waiting in the outbox"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:41
+msgid "In outbox"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:44
+#, python-format
+msgid "Last sent %(sent)s"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:48
+msgid "Not sent"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:55
 msgid "Copied!"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:40
+#: templates/exhibitors/_partner_row.html:55
 msgid "Copy failed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:40
+#: templates/exhibitors/_partner_row.html:55
 msgid "Key"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:41
-#: exhibition/templates/exhibitors/add.html:231
-#: exhibition/templates/exhibitors/vouchers.html:5
+#: templates/exhibitors/_partner_row.html:56 templates/exhibitors/add.html:235
+#: templates/exhibitors/base.html:42
+#: templates/exhibitors/exhibitor_info.html:95
+#: templates/exhibitors/exhibitor_info.html:125
+#: templates/exhibitors/vouchers.html:5 views.py:2933
 msgid "Vouchers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:42
-#: exhibition/templates/exhibitors/devices.html:5
+#: templates/exhibitors/_partner_row.html:57
+#: templates/exhibitors/devices.html:5
 msgid "Lead-scanning devices"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:45
+#: templates/exhibitors/_partner_row.html:58
+#: templates/exhibitors/call_question_delete.html:19
+#: templates/exhibitors/call_questions.html:74
+#: templates/exhibitors/delete.html:19
+#: templates/exhibitors/email_custom_template_delete.html:19
+#: templates/exhibitors/settings.html:335
+msgid "Delete"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:60
 msgid "Move"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_sort_header.html:7
+#: templates/exhibitors/_sort_header.html:7
 msgid "Sort ascending"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_sort_header.html:10
+#: templates/exhibitors/_sort_header.html:10
 msgid "Sort descending"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:24
+#: templates/exhibitors/add.html:24
 msgid "Profile"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:29
-#: exhibition/templates/exhibitors/add.html:92
-#: exhibition/templates/exhibitors/call_questions.html:62
-#: exhibition/templates/exhibitors/settings.html:50
+#: templates/exhibitors/add.html:29 templates/exhibitors/add.html:92
+#: templates/exhibitors/call_questions.html:62
+#: templates/exhibitors/settings.html:54
 msgid "Optional"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:80
-#: exhibition/templates/exhibitors/public_proposal_form.html:79
+#: templates/exhibitors/add.html:80
+#: templates/exhibitors/public_proposal_form.html:79
 msgid "Add social media link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:137
-#: exhibition/templates/exhibitors/public_proposal_form.html:120
+#: templates/exhibitors/add.html:137
+#: templates/exhibitors/public_proposal_form.html:120
 msgid "Add extra link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:157
-#: exhibition/templates/exhibitors/add.html:160
-#: exhibition/templates/exhibitors/public_proposal_form.html:140
-#: exhibition/templates/exhibitors/public_proposal_form.html:143
+#: templates/exhibitors/add.html:157 templates/exhibitors/add.html:161
+#: templates/exhibitors/public_proposal_form.html:140
+#: templates/exhibitors/public_proposal_form.html:144
 msgid "Logo preview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:162
-#: exhibition/templates/exhibitors/add.html:180
-#: exhibition/templates/exhibitors/public_proposal_form.html:145
-#: exhibition/templates/exhibitors/public_proposal_form.html:163
+#: templates/exhibitors/add.html:164 templates/exhibitors/add.html:184
+#: templates/exhibitors/public_proposal_form.html:147
+#: templates/exhibitors/public_proposal_form.html:167
 msgid "We could not load this image preview."
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:175
-#: exhibition/templates/exhibitors/add.html:178
-#: exhibition/templates/exhibitors/public_proposal_form.html:158
-#: exhibition/templates/exhibitors/public_proposal_form.html:161
+#: templates/exhibitors/add.html:177 templates/exhibitors/add.html:181
+#: templates/exhibitors/public_proposal_form.html:160
+#: templates/exhibitors/public_proposal_form.html:164
 msgid "Header image preview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:196
+#: templates/exhibitors/add.html:200
 msgid "Organizer only"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:237
+#: templates/exhibitors/add.html:241
 msgid "Internal notes"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:244
-#: exhibition/templates/exhibitors/email_edit.html:38
-#: exhibition/templates/exhibitors/public_proposal_form.html:182
-#: exhibition/templates/exhibitors/public_proposal_form.html:186
+#: templates/exhibitors/add.html:248 templates/exhibitors/email_edit.html:38
+#: templates/exhibitors/public_proposal_form.html:186
+#: templates/exhibitors/public_proposal_form.html:190
 msgid "Save changes"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:246
-#: exhibition/templates/exhibitors/call_default_field_form.html:21
-#: exhibition/templates/exhibitors/call_question_form.html:30
-#: exhibition/templates/exhibitors/call_questions.html:96
-#: exhibition/templates/exhibitors/email_custom_template_form.html:51
-#: exhibition/templates/exhibitors/email_templates.html:123
-#: exhibition/templates/exhibitors/proposal_detail.html:188
-#: exhibition/templates/exhibitors/settings.html:85
-#: exhibition/templates/exhibitors/settings.html:170
-#: exhibition/templates/exhibitors/settings.html:269
+#: templates/exhibitors/add.html:250
+#: templates/exhibitors/call_default_field_form.html:21
+#: templates/exhibitors/call_question_form.html:114
+#: templates/exhibitors/call_questions.html:96
+#: templates/exhibitors/email_custom_template_form.html:51
+#: templates/exhibitors/email_templates.html:123
+#: templates/exhibitors/proposal_detail.html:188
+#: templates/exhibitors/settings.html:89 templates/exhibitors/settings.html:217
+#: templates/exhibitors/settings.html:250
+#: templates/exhibitors/settings.html:359
 msgid "Save"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:255
-#: exhibition/templates/exhibitors/call_default_field_form.html:23
-#: exhibition/templates/exhibitors/call_default_field_reset.html:24
-#: exhibition/templates/exhibitors/call_question_delete.html:21
-#: exhibition/templates/exhibitors/call_question_form.html:32
-#: exhibition/templates/exhibitors/delete.html:24
-#: exhibition/templates/exhibitors/email_bulk_discard.html:27
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:21
-#: exhibition/templates/exhibitors/email_custom_template_form.html:53
-#: exhibition/templates/exhibitors/email_delete.html:28
-#: exhibition/templates/exhibitors/proposal_list.html:174
-#: exhibition/templates/exhibitors/public_proposal_form.html:176
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:16
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:21
-#: exhibition/templates/exhibitors/settings.html:194
-#: exhibition/templates/exhibitors/settings.html:270
+#: templates/exhibitors/add.html:259
+#: templates/exhibitors/call_default_field_form.html:23
+#: templates/exhibitors/call_default_field_reset.html:24
+#: templates/exhibitors/call_question_delete.html:21
+#: templates/exhibitors/call_question_form.html:116
+#: templates/exhibitors/delete.html:24
+#: templates/exhibitors/email_bulk_discard.html:27
+#: templates/exhibitors/email_custom_template_delete.html:21
+#: templates/exhibitors/email_custom_template_form.html:53
+#: templates/exhibitors/email_delete.html:28
+#: templates/exhibitors/proposal_list.html:175
+#: templates/exhibitors/public_proposal_form.html:180
+#: templates/exhibitors/public_proposal_reinstate.html:16
+#: templates/exhibitors/public_proposal_withdraw.html:21
+#: templates/exhibitors/settings.html:278
+#: templates/exhibitors/settings.html:360
+#: templates/exhibitors/voucher_bulk_send.html:96
 msgid "Cancel"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:262
-#: exhibition/templates/exhibitors/proposal_detail.html:208
+#: templates/exhibitors/add.html:266
+#: templates/exhibitors/proposal_detail.html:208
 msgid "History"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:11
+#: templates/exhibitors/base.html:17
 msgid "Overview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:18
-#: exhibition/templates/exhibitors/call_questions.html:33
+#: templates/exhibitors/base.html:24
+#: templates/exhibitors/call_questions.html:33
 msgid "Settings"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:26
-#: exhibition/templates/exhibitors/base.html:70
-#: exhibition/templates/exhibitors/dashboard.html:21
-#: exhibition/templates/exhibitors/exhibitor_info.html:4
-#: exhibition/templates/exhibitors/exhibitor_info.html:15
+#: templates/exhibitors/base.html:32 templates/exhibitors/base.html:81
+#: templates/exhibitors/dashboard.html:21
+#: templates/exhibitors/exhibitor_info.html:4
+#: templates/exhibitors/exhibitor_info.html:15
 msgid "Exhibitors"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:31
-#: exhibition/templates/exhibitors/base.html:76
-#: exhibition/templates/exhibitors/dashboard.html:29
-#: exhibition/templates/exhibitors/exhibitor_info.html:4
-#: exhibition/templates/exhibitors/exhibitor_info.html:15
+#: templates/exhibitors/base.html:37 templates/exhibitors/base.html:87
+#: templates/exhibitors/dashboard.html:29
+#: templates/exhibitors/exhibitor_info.html:4
+#: templates/exhibitors/exhibitor_info.html:15
 msgid "Sponsors"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:39
-#: exhibition/templates/exhibitors/dashboard.html:117
+#: templates/exhibitors/base.html:50 templates/exhibitors/dashboard.html:117
 msgid "Call for exhibitors"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:47
+#: templates/exhibitors/base.html:58
 msgid "Content"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:52
-#: exhibition/templates/exhibitors/call_questions.html:5
-#: exhibition/templates/exhibitors/call_questions.html:16
+#: templates/exhibitors/base.html:63 templates/exhibitors/call_questions.html:5
+#: templates/exhibitors/call_questions.html:16
 msgid "Exhibitor form"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:85
+#: templates/exhibitors/base.html:96
 msgid "Message center"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:94
+#: templates/exhibitors/base.html:105
 msgid "Compose"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:99
+#: templates/exhibitors/base.html:110
 msgid "Outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:111
+#: templates/exhibitors/base.html:122
 msgid "Templates"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:130
+#: templates/exhibitors/base.html:141
 msgid "Home"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:134
+#: templates/exhibitors/base.html:145
 msgid "Tickets"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:138
+#: templates/exhibitors/base.html:149
 msgid "Talks"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:143
+#: templates/exhibitors/base.html:154
 msgid "Access videos related to this event"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:144
+#: templates/exhibitors/base.html:155
 msgid "Videos"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_form.html:5
-#: exhibition/templates/exhibitors/call_default_field_form.html:8
-#: exhibition/templates/exhibitors/call_question_form.html:11
-#: exhibition/templates/exhibitors/call_question_form.html:14
+#: templates/exhibitors/call_default_field_form.html:5
+#: templates/exhibitors/call_default_field_form.html:8
+#: templates/exhibitors/call_question_form.html:14
+#: templates/exhibitors/call_question_form.html:17
 msgid "Form field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:4
-#: exhibition/templates/exhibitors/call_default_field_reset.html:7
+#: templates/exhibitors/call_default_field_reset.html:4
+#: templates/exhibitors/call_default_field_reset.html:7
 msgid "Reset form field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:14
+#: templates/exhibitors/call_default_field_reset.html:14
 #, python-format
 msgid ""
 "Are you sure you want to reset \"%(label)s\" back to the default "
 "\"%(default_label)s\"?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:19
+#: templates/exhibitors/call_default_field_reset.html:19
 msgid ""
 "This clears the custom label and help text. Default fields are part of the "
 "form and cannot be deleted; turn the field off with the Active toggle to "
 "hide it."
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:22
-#: exhibition/templates/exhibitors/public_list.html:32
+#: templates/exhibitors/call_default_field_reset.html:22
 msgid "Reset"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_question_delete.html:4
-#: exhibition/templates/exhibitors/call_question_delete.html:7
+#: templates/exhibitors/call_question_delete.html:4
+#: templates/exhibitors/call_question_delete.html:7
 msgid "Delete form field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_question_delete.html:14
+#: templates/exhibitors/call_question_delete.html:14
 #, python-format
 msgid "Are you sure you want to delete the question \"%(question)s\"?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_question_delete.html:19
-#: exhibition/templates/exhibitors/call_questions.html:74
-#: exhibition/templates/exhibitors/delete.html:19
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:19
-msgid "Delete"
+#: templates/exhibitors/call_question_form.html:31
+msgid "Answer options"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:23
+#: templates/exhibitors/call_question_form.html:34
+msgid "Only applicable if you choose a choice field type above."
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:48
+#, python-format
+msgid "Answer option %(id)s"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:56
+#: templates/exhibitors/call_question_form.html:58
+#: templates/exhibitors/call_question_form.html:87
+#: templates/exhibitors/call_question_form.html:89
+msgid "Move option up"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:60
+#: templates/exhibitors/call_question_form.html:62
+#: templates/exhibitors/call_question_form.html:91
+#: templates/exhibitors/call_question_form.html:93
+msgid "Move option down"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:64
+#: templates/exhibitors/call_question_form.html:66
+#: templates/exhibitors/call_question_form.html:95
+#: templates/exhibitors/call_question_form.html:97
+msgid "Delete option"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:81
+msgid "New answer option"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:106
+msgid "Add a new option"
+msgstr ""
+
+#: templates/exhibitors/call_questions.html:23
 msgid "Form fields"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:24
+#: templates/exhibitors/call_questions.html:24
 msgid ""
 "Choose which fields are shown on the exhibitor form and drag any row to "
 "reorder it."
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:29
-#: exhibition/templates/exhibitors/proposal_detail.html:38
+#: templates/exhibitors/call_questions.html:29
+#: templates/exhibitors/proposal_detail.html:38
 msgid "Field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:32
+#: templates/exhibitors/call_questions.html:32
 msgid "Answers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:42
+#: templates/exhibitors/call_questions.html:42
 msgid "Custom"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:48
+#: templates/exhibitors/call_questions.html:48
 #, python-format
 msgid "Toggle active state for %(field)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:61
+#: templates/exhibitors/call_questions.html:61
 #, python-format
 msgid "Required status for %(field)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:73
-#: exhibition/templates/exhibitors/call_questions.html:76
-#: exhibition/templates/exhibitors/dashboard.html:120
-#: exhibition/templates/exhibitors/email_compose.html:55
-#: exhibition/templates/exhibitors/email_custom_template_form.html:30
-#: exhibition/templates/exhibitors/email_templates.html:50
-#: exhibition/templates/exhibitors/email_templates.html:97
-#: exhibition/templates/exhibitors/public_proposal_list.html:32
-#: exhibition/templates/exhibitors/settings.html:55
-msgid "Edit"
-msgstr ""
-
-#: exhibition/templates/exhibitors/call_questions.html:77
+#: templates/exhibitors/call_questions.html:77
 msgid "Reset to default"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:79
+#: templates/exhibitors/call_questions.html:79
 msgid "Move field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:90
+#: templates/exhibitors/call_questions.html:90
 msgid "New custom field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:5
-#: exhibition/templates/exhibitors/dashboard.html:9
+#: templates/exhibitors/dashboard.html:5 templates/exhibitors/dashboard.html:9
 msgid "Exhibition overview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:39
+#: templates/exhibitors/dashboard.html:39
 msgid "Requests awaiting review"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:48
+#: templates/exhibitors/dashboard.html:48
 msgid "Emails in outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:61
+#: templates/exhibitors/dashboard.html:61
 msgid "Recent requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:64
+#: templates/exhibitors/dashboard.html:64
 msgid "View all"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:76
+#: templates/exhibitors/dashboard.html:76
 msgid "Submitted"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:91
-#: exhibition/templates/exhibitors/proposal_detail.html:97
-#: exhibition/templates/exhibitors/proposal_list.html:97
+#: templates/exhibitors/dashboard.html:91
+#: templates/exhibitors/proposal_detail.html:97
+#: templates/exhibitors/proposal_list.html:97
 msgid "Sponsor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:93
-#: exhibition/templates/exhibitors/proposal_detail.html:99
-#: exhibition/templates/exhibitors/proposal_list.html:99
+#: templates/exhibitors/dashboard.html:93
+#: templates/exhibitors/proposal_detail.html:99
+#: templates/exhibitors/proposal_list.html:99
 msgid "Exhibitor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:105
+#: templates/exhibitors/dashboard.html:105
 msgid "No requests have been submitted yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:128
+#: templates/exhibitors/dashboard.html:128
 msgid "The call is not published, so nobody can submit a request."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:131
+#: templates/exhibitors/dashboard.html:131
 msgid "Open"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:134
+#: templates/exhibitors/dashboard.html:134
 #, python-format
 msgid "Closes on %(deadline)s."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:139
+#: templates/exhibitors/dashboard.html:139
 msgid "No deadline set."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:142
+#: templates/exhibitors/dashboard.html:142
 msgid "Closed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:144
+#: templates/exhibitors/dashboard.html:144
 #, python-format
 msgid "The deadline passed on %(deadline)s."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:151
+#: templates/exhibitors/dashboard.html:151
 msgid "Private — reachable only with the secret link."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:157
-#: exhibition/templates/exhibitors/settings.html:90
-#: exhibition/templates/exhibitors/settings.html:94
+#: templates/exhibitors/dashboard.html:157
+#: templates/exhibitors/settings.html:94 templates/exhibitors/settings.html:98
 msgid "View call page"
 msgstr ""
 
-#: exhibition/templates/exhibitors/delete.html:11
+#: templates/exhibitors/delete.html:11
 #, python-format
 msgid ""
 "Are you sure you want to delete “%(name)s”? This action cannot be undone."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:8
+#: templates/exhibitors/devices.html:8
 #, python-format
 msgid "Lead-scanning devices for %(name)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:13
+#: templates/exhibitors/devices.html:13
 #, python-brace-format
 msgid ""
 "Provision check-in app devices for this partner. Each device gets its own "
@@ -1672,66 +1705,64 @@ msgid ""
 "through the {device_tokens} placeholder."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:21
+#: templates/exhibitors/devices.html:21
 msgid ""
 "Provisioning devices requires organizer-level permissions. Ask an organizer "
 "admin to create the devices for this partner."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:29
+#: templates/exhibitors/devices.html:29
 msgid "Provisioned devices"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:35
+#: templates/exhibitors/devices.html:35
 msgid "Device"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:36
+#: templates/exhibitors/devices.html:36
 msgid "Setup token"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:37
+#: templates/exhibitors/devices.html:37
 msgid "Status"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:47
+#: templates/exhibitors/devices.html:47
 msgid "Connected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:49
+#: templates/exhibitors/devices.html:49
 msgid "Awaiting setup"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:60
+#: templates/exhibitors/devices.html:60
 msgid ""
 "Generate new setup tokens? Any device that is already scanning will be "
 "disconnected and must be set up again."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:65
+#: templates/exhibitors/devices.html:65
 msgid "Generate new setup tokens"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:70
+#: templates/exhibitors/devices.html:70
 msgid "No devices have been provisioned for this partner yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:80
-#: exhibition/templates/exhibitors/devices.html:85
+#: templates/exhibitors/devices.html:80 templates/exhibitors/devices.html:85
 msgid "Add devices"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:87
-#: exhibition/templates/exhibitors/vouchers.html:88
+#: templates/exhibitors/devices.html:87 templates/exhibitors/vouchers.html:133
 msgid "Back"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_bulk_discard.html:4
-#: exhibition/templates/exhibitors/email_bulk_discard.html:7
+#: templates/exhibitors/email_bulk_discard.html:4
+#: templates/exhibitors/email_bulk_discard.html:7
 msgid "Discard emails"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_bulk_discard.html:19
+#: templates/exhibitors/email_bulk_discard.html:19
 #, python-format
 msgid ""
 "Are you sure you want to discard %(counter)s queued email? This cannot be "
@@ -1742,80 +1773,80 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/templates/exhibitors/email_bulk_discard.html:30
-#: exhibition/templates/exhibitors/email_delete.html:31
-msgid "Discard"
-msgstr ""
-
-#: exhibition/templates/exhibitors/email_compose.html:7
-#: exhibition/templates/exhibitors/email_compose.html:16
+#: templates/exhibitors/email_compose.html:7
+#: templates/exhibitors/email_compose.html:16
 msgid "Compose email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:21
+#: templates/exhibitors/email_compose.html:21
 msgid ""
 "Send an update to a group of applicants. One email is queued per recipient, "
 "with placeholders resolved individually."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:26
+#: templates/exhibitors/email_compose.html:26
 msgid "Load from template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:28
+#: templates/exhibitors/email_compose.html:28
 msgid "Select a saved template…"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:33
+#: templates/exhibitors/email_compose.html:33
 msgid "Load"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:41
-#: exhibition/templates/exhibitors/email_edit.html:23
+#: templates/exhibitors/email_compose.html:41
+#: templates/exhibitors/email_edit.html:23
 msgid "Recipients"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:47
+#: templates/exhibitors/email_compose.html:47
 msgid "Message"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:58
-#: exhibition/templates/exhibitors/email_custom_template_form.html:33
-#: exhibition/templates/exhibitors/email_templates.html:53
-#: exhibition/templates/exhibitors/email_templates.html:100
-#: exhibition/templates/exhibitors/settings.html:58
+#: templates/exhibitors/email_compose.html:51
+msgctxt "form"
+msgid "required"
+msgstr ""
+
+#: templates/exhibitors/email_compose.html:58
+#: templates/exhibitors/email_custom_template_form.html:33
+#: templates/exhibitors/email_templates.html:53
+#: templates/exhibitors/email_templates.html:100
+#: templates/exhibitors/settings.html:62
 msgid "Preview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:80
+#: templates/exhibitors/email_compose.html:80
 msgid "Save to outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:83
+#: templates/exhibitors/email_compose.html:83
 msgid "Send / Schedule"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:4
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:7
+#: templates/exhibitors/email_custom_template_delete.html:4
+#: templates/exhibitors/email_custom_template_delete.html:7
 msgid "Delete custom template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:14
+#: templates/exhibitors/email_custom_template_delete.html:14
 #, python-format
 msgid "Are you sure you want to delete the custom template \"%(name)s\"?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_custom_template_form.html:7
-#: exhibition/templates/exhibitors/email_custom_template_form.html:15
+#: templates/exhibitors/email_custom_template_form.html:7
+#: templates/exhibitors/email_custom_template_form.html:15
 msgid "Custom template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_delete.html:4
-#: exhibition/templates/exhibitors/email_delete.html:7
+#: templates/exhibitors/email_delete.html:4
+#: templates/exhibitors/email_delete.html:7
 msgid "Discard email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_delete.html:15
+#: templates/exhibitors/email_delete.html:15
 #, python-format
 msgid ""
 "Are you sure you want to discard the email “%(subject)s” to %(counter)s "
@@ -1826,908 +1857,1170 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/templates/exhibitors/email_delete.html:21
+#: templates/exhibitors/email_delete.html:21
 #, python-format
 msgid ""
 "Are you sure you want to discard the email “%(subject)s” to %(to)s? This "
 "cannot be undone."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:5
+#: templates/exhibitors/email_edit.html:5
 msgid "Edit email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:8
+#: templates/exhibitors/email_edit.html:8
 msgid "Preview / edit email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:14
+#: templates/exhibitors/email_edit.html:14
 msgid "Back to outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:41
+#: templates/exhibitors/email_edit.html:41
 msgid "Save & send"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_outbox.html:12
-#: exhibition/templates/exhibitors/email_outbox.html:15
+#: templates/exhibitors/email_outbox.html:12
+#: templates/exhibitors/email_outbox.html:15
 msgid "Email outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_outbox.html:20
+#: templates/exhibitors/email_outbox.html:20
 msgid ""
 "Emails waiting to be sent. Review, edit, or discard them before sending."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_sent.html:12
-#: exhibition/templates/exhibitors/email_sent.html:15
+#: templates/exhibitors/email_sent.html:12
+#: templates/exhibitors/email_sent.html:15
 msgid "Sent emails"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:7
-#: exhibition/templates/exhibitors/email_templates.html:16
+#: templates/exhibitors/email_templates.html:7
+#: templates/exhibitors/email_templates.html:16
 msgid "Email templates"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:22
+#: templates/exhibitors/email_templates.html:22
 msgid "New template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:27
+#: templates/exhibitors/email_templates.html:27
 msgid ""
 "These templates are used for the confirmation email sent when an applicant "
 "submits a request, and for the accept/reject emails you send from the outbox."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:81
+#: templates/exhibitors/email_templates.html:81
 msgid "Discard this template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:31
+#: templates/exhibitors/exhibitor_info.html:31
 msgid "No organizations match your filters."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:33
+#: templates/exhibitors/exhibitor_info.html:33
 msgid "You don't have any sponsors yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:35
+#: templates/exhibitors/exhibitor_info.html:35
 msgid "You don't have any exhibitors yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:37
+#: templates/exhibitors/exhibitor_info.html:37
 msgid "You don't have any exhibitors or sponsors yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:43
-#: exhibition/templates/exhibitors/exhibitor_info.html:52
-#: exhibition/views.py:1837
+#: templates/exhibitors/exhibitor_info.html:43
+#: templates/exhibitors/exhibitor_info.html:57 views.py:1979
 msgid "Add a Sponsor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:43
-#: exhibition/templates/exhibitors/exhibitor_info.html:52
-#: exhibition/views.py:1838
+#: templates/exhibitors/exhibitor_info.html:43
+#: templates/exhibitors/exhibitor_info.html:57 views.py:1980
 msgid "Add an Exhibitor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:43
-#: exhibition/templates/exhibitors/exhibitor_info.html:52
-#: exhibition/views.py:1839
+#: templates/exhibitors/exhibitor_info.html:43
+#: templates/exhibitors/exhibitor_info.html:57 views.py:1981
 msgid "Add an Exhibitor or Sponsor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:48
-#: exhibition/templates/exhibitors/proposal_list.html:169
+#: templates/exhibitors/exhibitor_info.html:48
+#: templates/exhibitors/proposal_list.html:170
 msgid "selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:54
+#: templates/exhibitors/exhibitor_info.html:59
 msgid "Download access keys as CSV"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:56
+#: templates/exhibitors/exhibitor_info.html:61
 msgid "Download sponsor keys"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:56
+#: templates/exhibitors/exhibitor_info.html:61
 msgid "Download exhibitor keys"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:56
+#: templates/exhibitors/exhibitor_info.html:61
 msgid "Download access keys"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:65
+#: templates/exhibitors/exhibitor_info.html:64
+msgid "Queue a voucher email for everyone in this list"
+msgstr ""
+
+#: templates/exhibitors/exhibitor_info.html:65
+msgid "Send vouchers to all"
+msgstr ""
+
+#: templates/exhibitors/exhibitor_info.html:75
 msgid ""
 "Drag-and-drop ordering is available only on the unfiltered, single-page list."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:70
+#: templates/exhibitors/exhibitor_info.html:80
 msgid "Booth"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:78
-#: exhibition/templates/exhibitors/exhibitor_info.html:106
+#: templates/exhibitors/exhibitor_info.html:88
+#: templates/exhibitors/exhibitor_info.html:117
 msgid "Select all partners"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:84
-#: exhibition/templates/exhibitors/exhibitor_info.html:112
+#: templates/exhibitors/exhibitor_info.html:94
+#: templates/exhibitors/exhibitor_info.html:123
 msgid "Group"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:12
-#: exhibition/templates/exhibitors/proposal_detail.html:15
+#: templates/exhibitors/proposal_detail.html:12
+#: templates/exhibitors/proposal_detail.html:15
 msgid "Review exhibition request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:21
+#: templates/exhibitors/proposal_detail.html:21
 msgid "Back to exhibition requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:29
+#: templates/exhibitors/proposal_detail.html:29
 #, python-format
 msgid "Changes made by the applicant after acceptance (%(when)s)"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:39
+#: templates/exhibitors/proposal_detail.html:39
 msgid "Before acceptance"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:40
+#: templates/exhibitors/proposal_detail.html:40
 msgid "After edit"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:55
+#: templates/exhibitors/proposal_detail.html:55
 msgid "The applicant edited the profile, but the tracked fields are unchanged."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:57
+#: templates/exhibitors/proposal_detail.html:57
 msgid ""
 "This profile was edited before change tracking was available, so the "
 "original values are not recorded."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:69
-#: exhibition/templates/exhibitors/proposal_list.html:20
+#: templates/exhibitors/proposal_detail.html:69
+#: templates/exhibitors/proposal_list.html:20
 msgid "Submitter"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:80
+#: templates/exhibitors/proposal_detail.html:80
 msgid "Hidden"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:121
+#: templates/exhibitors/proposal_detail.html:121
 msgid "Message to organizers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:129
+#: templates/exhibitors/proposal_detail.html:129
 msgid "Links"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:152
+#: templates/exhibitors/proposal_detail.html:152
 msgid "Download"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:154
+#: templates/exhibitors/proposal_detail.html:154
 msgid "Custom answers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:176
+#: templates/exhibitors/proposal_detail.html:176
 msgid "Review"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:192
-#: exhibition/templates/exhibitors/proposal_list.html:117
-#: exhibition/templates/exhibitors/proposal_list.html:164
+#: templates/exhibitors/proposal_detail.html:192
+#: templates/exhibitors/proposal_list.html:118
+#: templates/exhibitors/proposal_list.html:165
 msgid "Approve"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:195
-#: exhibition/templates/exhibitors/proposal_list.html:122
-#: exhibition/templates/exhibitors/proposal_list.html:165
+#: templates/exhibitors/proposal_detail.html:195
+#: templates/exhibitors/proposal_list.html:123
+#: templates/exhibitors/proposal_list.html:166
 msgid "Reject"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:200
+#: templates/exhibitors/proposal_detail.html:200
 msgid "Open profile"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:22
+#: templates/exhibitors/proposal_list.html:22
 msgid "Updated"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:33
+#: templates/exhibitors/proposal_list.html:33
 msgid "Select at least one request."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:34
+#: templates/exhibitors/proposal_list.html:34
 msgid "None of the selected requests can be approved."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:35
+#: templates/exhibitors/proposal_list.html:35
 msgid "None of the selected requests can be rejected."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:36
+#: templates/exhibitors/proposal_list.html:36
 #, python-brace-format
 msgid "{count} selected requests cannot be approved and will be skipped."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:37
+#: templates/exhibitors/proposal_list.html:37
 #, python-brace-format
 msgid "{count} selected requests cannot be rejected and will be skipped."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:41
+#: templates/exhibitors/proposal_list.html:41
 msgid "Approve selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:44
+#: templates/exhibitors/proposal_list.html:44
 msgid "Reject selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:55
+#: templates/exhibitors/proposal_list.html:55
 msgid "Select all matching requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:75
+#: templates/exhibitors/proposal_list.html:75
 msgid "Select request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:106
+#: templates/exhibitors/proposal_list.html:106
 msgid "Edited after acceptance, see detail view for changes."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:127
-#: exhibition/templates/exhibitors/proposal_list.html:166
-#: exhibition/templates/exhibitors/public_proposal_list.html:39
+#: templates/exhibitors/proposal_list.html:128
+#: templates/exhibitors/proposal_list.html:167
+#: templates/exhibitors/public_proposal_list.html:39
 msgid "Withdraw"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:132
-#: exhibition/templates/exhibitors/proposal_list.html:167
+#: templates/exhibitors/proposal_list.html:133
+#: templates/exhibitors/proposal_list.html:168
 msgid "Reopen for review"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:137
-#: exhibition/templates/exhibitors/public_proposal_list.html:34
+#: templates/exhibitors/proposal_list.html:138
+#: templates/exhibitors/public_proposal_list.html:34
 msgid "View"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:149
+#: templates/exhibitors/proposal_list.html:150
 msgid "No exhibition requests match your filters."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:151
+#: templates/exhibitors/proposal_list.html:152
 msgid "No exhibition requests have been submitted yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:159
+#: templates/exhibitors/proposal_list.html:160
 msgid "Approve the selected requests and create their partner profiles?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:160
+#: templates/exhibitors/proposal_list.html:161
 msgid "Reject the selected requests?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:161
+#: templates/exhibitors/proposal_list.html:162
 msgid "Reject this request?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:162
+#: templates/exhibitors/proposal_list.html:163
 msgid "Withdraw this request?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:163
+#: templates/exhibitors/proposal_list.html:164
 msgid "Reopen this request for review?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:168
+#: templates/exhibitors/proposal_list.html:169
 msgid "The action could not be completed. Please try again."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:170
+#: templates/exhibitors/proposal_list.html:171
 msgid ""
 "Approve every request matching the current filters, including those on other "
 "pages?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:171
+#: templates/exhibitors/proposal_list.html:172
 msgid ""
 "Reject every request matching the current filters, including those on other "
 "pages?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:172
+#: templates/exhibitors/proposal_list.html:173
 msgid "Please confirm"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:173
+#: templates/exhibitors/proposal_list.html:174
 msgid "Confirm"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:14
+#: templates/exhibitors/public_call.html:14
 msgid "Submit a request to become an exhibitor for this event."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:20
+#: templates/exhibitors/public_call.html:20
 #, python-format
 msgid "You can submit requests until %(deadline)s (%(timezone)s)."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:24
+#: templates/exhibitors/public_call.html:24
 #, python-format
 msgid "This call closed on %(deadline)s (%(timezone)s)."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:34
+#: templates/exhibitors/public_call.html:34
 msgid "View your requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:40
-#: exhibition/templates/exhibitors/public_proposal_form.html:18
-#: exhibition/templates/exhibitors/public_proposal_list.html:65
+#: templates/exhibitors/public_call.html:40
+#: templates/exhibitors/public_proposal_form.html:18
+#: templates/exhibitors/public_proposal_list.html:65
 msgid "Submit a request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:42
+#: templates/exhibitors/public_call.html:42
 msgid "Requests are closed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:21
-#: exhibition/templates/exhibitors/public_detail.html:94
+#: templates/exhibitors/public_detail.html:21
+#: templates/exhibitors/public_detail.html:93
 msgid "Previous"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:24
-#: exhibition/templates/exhibitors/public_detail.html:98
+#: templates/exhibitors/public_detail.html:24
+#: templates/exhibitors/public_detail.html:97
 msgid "Next"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:47
+#: templates/exhibitors/public_detail.html:47
 msgid "Get In Touch"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:87
-#: exhibition/templates/exhibitors/public_detail.html:103
+#: templates/exhibitors/public_detail.html:87
+#: templates/exhibitors/public_detail.html:102
 msgid "Open slides PDF"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:88
-#, python-brace-format
-msgid "Slide {current} of {total}"
-msgstr ""
-
-#: exhibition/templates/exhibitors/public_detail.html:112
+#: templates/exhibitors/public_detail.html:111
 msgid "Send email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:126
+#: templates/exhibitors/public_detail.html:125
 msgid "Visit website"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_list.html:54
+#: templates/exhibitors/public_list.html:32
+msgid "Clear"
+msgstr ""
+
+#: templates/exhibitors/public_list.html:54
 msgid "No exhibitors match your search."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_list.html:56
+#: templates/exhibitors/public_list.html:56
 msgid "No exhibitors are currently available."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:16
+#: templates/exhibitors/public_proposal_form.html:16
 msgid "Edit request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:23
-#: exhibition/views.py:883
+#: templates/exhibitors/public_proposal_form.html:23 views.py:958
 msgid "This request can no longer be edited."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:186
+#: templates/exhibitors/public_proposal_form.html:190
 msgid "Submit request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:189
+#: templates/exhibitors/public_proposal_form.html:193
 msgid "or save as draft for now"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:199
+#: templates/exhibitors/public_proposal_form.html:203
 msgid "Back to your requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:5
+#: templates/exhibitors/public_proposal_list.html:5
 msgid "Your exhibition requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:13
+#: templates/exhibitors/public_proposal_list.html:13
 msgid "Last modified"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:23
+#: templates/exhibitors/public_proposal_list.html:23
 msgid "Withdrawn"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:44
+#: templates/exhibitors/public_proposal_list.html:44
 msgid "Reinstate"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:56
+#: templates/exhibitors/public_proposal_list.html:56
 msgid "Create a new request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:61
+#: templates/exhibitors/public_proposal_list.html:61
 msgid "You have not submitted an exhibition request yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:5
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:21
+#: templates/exhibitors/public_proposal_reinstate.html:5
+#: templates/exhibitors/public_proposal_reinstate.html:21
 msgid "Reinstate request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:7
+#: templates/exhibitors/public_proposal_reinstate.html:7
 #, python-format
 msgid ""
 "Do you want to reinstate your withdrawn request “%(name)s”? It will be "
 "pending review again."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:5
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:26
+#: templates/exhibitors/public_proposal_withdraw.html:5
+#: templates/exhibitors/public_proposal_withdraw.html:26
 msgid "Withdraw request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:7
+#: templates/exhibitors/public_proposal_withdraw.html:7
 #, python-format
 msgid "Are you sure you want to withdraw your request “%(name)s”?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:13
+#: templates/exhibitors/public_proposal_withdraw.html:13
 msgid ""
 "This request has already been approved. Withdrawing it will hide the "
 "exhibitor or sponsor profile created from it from public listings."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:10
-#: exhibition/templates/exhibitors/settings.html:27
+#: templates/exhibitors/settings.html:10 templates/exhibitors/settings.html:29
 msgid "Sponsor Settings"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:12
-#: exhibition/templates/exhibitors/settings.html:29
+#: templates/exhibitors/settings.html:12 templates/exhibitors/settings.html:31
+msgid "Voucher Settings"
+msgstr ""
+
+#: templates/exhibitors/settings.html:14 templates/exhibitors/settings.html:33
 msgid "Exhibitor Settings"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:42
+#: templates/exhibitors/settings.html:46
 msgid "Publish your call"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:43
+#: templates/exhibitors/settings.html:47
 msgid "Publish a login-required application form for exhibitors."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:72
+#: templates/exhibitors/settings.html:76
 msgid ""
 "This panel renders unsaved draft text using the same styling as the live "
 "public call page."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:104
+#: templates/exhibitors/settings.html:108
 msgid "Secret call link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:107
+#: templates/exhibitors/settings.html:111
 msgid ""
 "This call is private: it is not linked anywhere public. Share the link below "
 "with the organizations you want to invite. Anyone who has it can open the "
 "call and apply."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:113
+#: templates/exhibitors/settings.html:117
 msgid "Copied"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:113
+#: templates/exhibitors/settings.html:117
 msgid "Copy to clipboard"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:114
+#: templates/exhibitors/settings.html:118
 msgid "Copy"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:119
+#: templates/exhibitors/settings.html:123
 msgid ""
 "Regenerate the secret link? The current link will stop working immediately."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:125
+#: templates/exhibitors/settings.html:129
 msgid "Regenerate link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:127
+#: templates/exhibitors/settings.html:131
 msgid "Regenerating immediately invalidates the current link."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:138
+#: templates/exhibitors/settings.html:143
+msgid "Voucher pools"
+msgstr ""
+
+#: templates/exhibitors/settings.html:147
+msgid ""
+"Create the voucher codes under Tickets → Vouchers and give them a tag, then "
+"pick that tag here. Exhibitors and sponsors are handed codes from the pool "
+"you choose. Reload this page to pick up a tag you just created."
+msgstr ""
+
+#: templates/exhibitors/settings.html:157
+msgid "Create vouchers pool"
+msgstr ""
+
+#: templates/exhibitors/settings.html:159
+msgid "(opens in a new tab)"
+msgstr ""
+
+#: templates/exhibitors/settings.html:168
+#: templates/exhibitors/settings.html:182
+#, python-format
+msgid "%(counter)s voucher in this pool is not assigned to anyone yet."
+msgid_plural ""
+"%(counter)s vouchers in this pool are not assigned to anyone yet."
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/exhibitors/settings.html:194
+msgid "How many each one gets"
+msgstr ""
+
+#: templates/exhibitors/settings.html:196
+msgid ""
+"Applies to any exhibitor or sponsor that does not belong to a sponsor group. "
+"Sponsor groups set their own number on the Sponsors page, and an individual "
+"exhibitor or sponsor can be given a different number on their own voucher "
+"page."
+msgstr ""
+
+#: templates/exhibitors/settings.html:206
+msgid "Voucher email"
+msgstr ""
+
+#: templates/exhibitors/settings.html:208
+msgid "Applies to the voucher email sent to exhibitors and sponsors alike."
+msgstr ""
+
+#: templates/exhibitors/settings.html:228
 msgid "Data access"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:139
+#: templates/exhibitors/settings.html:229
 msgid ""
 "In this section, you can control which attendee data is shared with "
 "exhibitors when an exhibitor voucher is used or when the exhibitor uses the "
 "lead scanning app."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:142
+#: templates/exhibitors/settings.html:232
 msgid "Exhibitor vouchers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:158
-msgid "Exhibitor login"
-msgstr ""
-
-#: exhibition/templates/exhibitors/settings.html:160
-msgid ""
-"The access-code email sent to exhibitors is now edited together with the "
-"plugin's other email templates."
-msgstr ""
-
-#: exhibition/templates/exhibitors/settings.html:162
-msgid "Edit email templates"
-msgstr ""
-
-#: exhibition/templates/exhibitors/settings.html:177
+#: templates/exhibitors/settings.html:257
 msgid "Group List"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:180
+#: templates/exhibitors/settings.html:260
 msgid "Add a Group"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:193
+#: templates/exhibitors/settings.html:272
+#: templates/exhibitors/settings.html:354
+msgid "Voucher defaults for this group"
+msgstr ""
+
+#: templates/exhibitors/settings.html:277
 msgid "Add"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:204
+#: templates/exhibitors/settings.html:288
 msgid "Group Name"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:206
+#: templates/exhibitors/settings.html:290
 msgid "Partners"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:207
+#: templates/exhibitors/settings.html:291
 msgid "Front Page"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:220
-#: exhibition/templates/exhibitors/settings.html:226
+#: templates/exhibitors/settings.html:304
+#: templates/exhibitors/settings.html:310
 msgid "Show this sponsor group in the Supported By section on the front page."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:251
+#: templates/exhibitors/settings.html:326
+msgid "Edit sponsor group"
+msgstr ""
+
+#: templates/exhibitors/settings.html:337
 msgid "Reorder sponsor group"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:281
+#: templates/exhibitors/settings.html:371
 msgid "You do not have any sponsor groups yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:8
+#: templates/exhibitors/voucher_bulk_send.html:4
+#: templates/exhibitors/voucher_bulk_send.html:7
+msgid "Send vouchers"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:18
+#, python-format
+msgid "A voucher email will be placed in the outbox for %(counter)s sponsor."
+msgid_plural ""
+"A voucher email will be placed in the outbox for %(counter)s sponsors."
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:24
+#, python-format
+msgid "A voucher email will be placed in the outbox for %(counter)s exhibitor."
+msgid_plural ""
+"A voucher email will be placed in the outbox for %(counter)s exhibitors."
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:37
+#, python-format
+msgid "&mdash; %(counter)s voucher will be created"
+msgid_plural "&mdash; %(counter)s vouchers will be created"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:45
+#, python-format
+msgid "&mdash; %(counter)s existing voucher"
+msgid_plural "&mdash; %(counter)s existing vouchers"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:58
+msgid "None of the sponsors in this list can be emailed yet."
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:60
+msgid "None of the exhibitors in this list can be emailed yet."
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:66
+msgid "Skipped: no email address"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:75
+msgid "Skipped: voucher count is set to 0"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:84
+msgid "Skipped: no vouchers available from their pool"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:86
+msgid ""
+"Check that a voucher pool is selected under Settings → Vouchers and that it "
+"still has unassigned codes."
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:99
+msgid "Queue emails"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:8
 #, python-format
 msgid "Vouchers for %(name)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:13
+#: templates/exhibitors/vouchers.html:13
 msgid ""
-"Issue ticket vouchers for this partner to hand out. Whoever redeems one on "
-"the ticket shop becomes a lead this partner can retrieve, as long as voucher "
+"Hand this exhibitor or sponsor codes from the voucher pool. Whoever redeems "
+"one on the ticket shop becomes a lead they can retrieve, as long as voucher "
 "data access is enabled for them."
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:20
-msgid "Issued vouchers"
+#: templates/exhibitors/vouchers.html:20
+msgid "Assigned vouchers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:24
+#: templates/exhibitors/vouchers.html:24
 msgid "Download codes (CSV)"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:31
+#: templates/exhibitors/vouchers.html:31
 msgid "Code"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:32 exhibition/views.py:1994
+#: templates/exhibitors/vouchers.html:32 utils.py:495
 msgid "Product"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:34 exhibition/views.py:1998
+#: templates/exhibitors/vouchers.html:33 utils.py:496
+msgid "Price effect"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:34 utils.py:499
 msgid "Redeemed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:56
+#: templates/exhibitors/vouchers.html:35 utils.py:498
+msgid "Valid until"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:56
 msgid "Already redeemed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:67
-msgid "No vouchers have been issued for this partner yet."
+#: templates/exhibitors/vouchers.html:62
+msgid "Return to pool"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:76
-msgid "Issue new vouchers"
+#: templates/exhibitors/vouchers.html:74
+msgid "No vouchers have been assigned to this partner yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:86
-msgid "Create vouchers"
+#: templates/exhibitors/vouchers.html:82
+msgid "Take more from the pool"
 msgstr ""
 
-#: exhibition/templates/sponsors/presale_supported_by.html:4
+#: templates/exhibitors/vouchers.html:84
+msgid ""
+"Codes come from the voucher pool chosen under Settings. The email always "
+"carries this partner's complete list of codes, so you can assign some now "
+"and send them together with more later. It is placed in the outbox for you "
+"to review before it goes out."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:92
+#, python-format
+msgid "%(counter)s voucher is left unassigned in the pool."
+msgid_plural "%(counter)s vouchers are left unassigned in the pool."
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/exhibitors/vouchers.html:100 views.py:2230
+msgid "No voucher pool is selected yet. Choose one under Settings → Vouchers."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:106
+msgid "A voucher email for this partner is waiting in the outbox."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:108
+msgid "Go to outbox"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:114
+#, python-format
+msgid "Vouchers were last emailed to this partner on %(sent)s."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:120
+msgid ""
+"This partner has no email address on file, so vouchers cannot be emailed."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:127
+msgid "Assign and prepare email"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:130
+msgid "Assign without emailing"
+msgstr ""
+
+#: templates/sponsors/presale_supported_by.html:4
 msgid "Supported By"
 msgstr ""
 
-#: exhibition/views.py:324
+#: utils.py:493
+msgid "Voucher code"
+msgstr ""
+
+#: utils.py:494
+msgid "Redeem link"
+msgstr ""
+
+#: utils.py:497
+msgid "Value"
+msgstr ""
+
+#: utils.py:500
+msgid "Maximum usages"
+msgstr ""
+
+#: views.py:342
 msgid "Company name"
 msgstr ""
 
-#: exhibition/views.py:325
+#: views.py:343
 msgid "Job title"
 msgstr ""
 
-#: exhibition/views.py:326
+#: views.py:344
 msgid "Address"
 msgstr ""
 
-#: exhibition/views.py:333
+#: views.py:351
 msgid "Attendee Name"
 msgstr ""
 
-#: exhibition/views.py:338
+#: views.py:356
 msgid "Attendee Email"
 msgstr ""
 
-#: exhibition/views.py:377
+#: views.py:395 views.py:412
 msgid "Settings have been saved."
 msgstr ""
 
-#: exhibition/views.py:393
+#: views.py:428
 msgid "Call settings have been saved."
 msgstr ""
 
-#: exhibition/views.py:401
+#: views.py:436
 msgid ""
 "A new secret call link has been generated. The old link no longer works."
 msgstr ""
 
-#: exhibition/views.py:416
+#: views.py:451
 msgid "Sponsor group added."
 msgstr ""
 
-#: exhibition/views.py:437
+#: views.py:454 views.py:477 views.py:853 views.py:1169 views.py:1796
+#: views.py:1918 views.py:2564 views.py:3025
+msgid "We could not save your changes. See below for details."
+msgstr ""
+
+#: views.py:474
 msgid "Sponsor group updated."
 msgstr ""
 
-#: exhibition/views.py:452
+#: views.py:491
 msgid "This sponsor group cannot be deleted while it is assigned to partners."
 msgstr ""
 
-#: exhibition/views.py:460
+#: views.py:499
 msgid "Unknown action."
 msgstr ""
 
-#: exhibition/views.py:505
+#: views.py:544
 msgid "Access key"
 msgstr ""
 
-#: exhibition/views.py:745 exhibition/views.py:1060
+#: views.py:819 views.py:1135
 msgid "Add at least one social media link."
 msgstr ""
 
-#: exhibition/views.py:754 exhibition/views.py:1069
+#: views.py:828 views.py:1144
 msgid "Add at least one extra link."
 msgstr ""
 
-#: exhibition/views.py:809
+#: views.py:884
 msgid "The call for exhibitors is closed."
 msgstr ""
 
-#: exhibition/views.py:837
+#: views.py:912
 msgid "Your request has been saved."
 msgstr ""
 
-#: exhibition/views.py:920 exhibition/views.py:1776
+#: views.py:995 views.py:1914
 msgid "Your changes have been saved."
 msgstr ""
 
-#: exhibition/views.py:953
+#: views.py:1028
 msgid "This proposal can no longer be withdrawn."
 msgstr ""
 
-#: exhibition/views.py:961
+#: views.py:1036
 msgid "Your request has been withdrawn."
 msgstr ""
 
-#: exhibition/views.py:963
+#: views.py:1038
 msgid "This request can no longer be withdrawn."
 msgstr ""
 
-#: exhibition/views.py:989 exhibition/views.py:999
+#: views.py:1064 views.py:1074
 msgid "This request can no longer be reinstated."
 msgstr ""
 
-#: exhibition/views.py:997
+#: views.py:1072
 msgid "Your request has been reinstated and is pending review again."
 msgstr ""
 
-#: exhibition/views.py:1121
+#: views.py:1197
 msgid "Invalid request body."
 msgstr ""
 
-#: exhibition/views.py:1124 exhibition/views.py:1129
+#: views.py:1200 views.py:1205
 msgid "Invalid sponsor group IDs."
 msgstr ""
 
-#: exhibition/views.py:1133
+#: views.py:1209
 msgid "Sponsor group IDs must be unique."
 msgstr ""
 
-#: exhibition/views.py:1141
+#: views.py:1217
 msgid "Reorder request must include each sponsor group exactly once."
 msgstr ""
 
-#: exhibition/views.py:1346
+#: views.py:1422
 msgid "This request can no longer be changed to that state."
 msgstr ""
 
-#: exhibition/views.py:1350
+#: views.py:1426
 msgid "Review details saved."
 msgstr ""
 
-#: exhibition/views.py:1359
+#: views.py:1435
 msgid ""
 "Request approved and partner profile created. An acceptance email was placed "
 "in the outbox."
 msgstr ""
 
-#: exhibition/views.py:1369
+#: views.py:1445
 msgid "Request rejected. A rejection email was placed in the outbox."
 msgstr ""
 
-#: exhibition/views.py:1372
+#: views.py:1448
 msgid "Request withdrawn."
 msgstr ""
 
-#: exhibition/views.py:1375
+#: views.py:1451
 msgid "Request reopened for review."
 msgstr ""
 
-#: exhibition/views.py:1407
+#: views.py:1483
 msgid "No valid action was selected."
 msgstr ""
 
-#: exhibition/views.py:1454
+#: views.py:1530
 #, python-format
 msgid "%(count)d request was approved."
 msgid_plural "%(count)d requests were approved."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1455
+#: views.py:1531
 #, python-format
 msgid "%(count)d request was rejected."
 msgid_plural "%(count)d requests were rejected."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1456
+#: views.py:1532
 #, python-format
 msgid "%(count)d request was withdrawn."
 msgid_plural "%(count)d requests were withdrawn."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1457
+#: views.py:1533
 #, python-format
 msgid "%(count)d request was reopened."
 msgid_plural "%(count)d requests were reopened."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1461
+#: views.py:1537
 msgid "No proposals were updated."
 msgstr ""
 
-#: exhibition/views.py:1464
+#: views.py:1540
 #, python-format
 msgid "%(skipped)d was skipped because it was already processed."
 msgid_plural "%(skipped)d were skipped because they were already processed."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1605
+#: views.py:1681
 msgid "Exhibitor form settings have been saved."
 msgstr ""
 
-#: exhibition/views.py:1730
+#: views.py:1868
 msgid "The requested form field does not exist."
 msgstr ""
 
-#: exhibition/views.py:1791
+#: views.py:1933
 msgid "The field has been reset to its default."
 msgstr ""
 
-#: exhibition/views.py:1829 exhibition/views.py:1900
+#: views.py:1971 views.py:2042
 msgid "An access-credentials email was placed in the outbox."
 msgstr ""
 
-#: exhibition/views.py:1907
+#: views.py:2049
 msgid "Edit Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1908
+#: views.py:2050
 msgid "Edit Exhibitor"
 msgstr ""
 
-#: exhibition/views.py:1909
+#: views.py:2051
 msgid "Edit Exhibitor & Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1910
+#: views.py:2052
 msgid "Edit Exhibitor or Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1940
+#: views.py:2082
 msgid "Delete Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1941
+#: views.py:2083
 msgid "Delete Exhibitor"
 msgstr ""
 
-#: exhibition/views.py:1942
+#: views.py:2084
 msgid "Delete Exhibitor & Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1943
+#: views.py:2085
 msgid "Delete Exhibitor or Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1992
-msgid "Voucher code"
+#: views.py:2164
+msgid "This voucher has already been redeemed and cannot be returned."
 msgstr ""
 
-#: exhibition/views.py:1993
-msgid "Redeem link"
+#: views.py:2170
+msgid ""
+"This code was already included in a voucher email to this partner, so it "
+"cannot be returned to the pool. Delete it under Tickets → Vouchers instead."
 msgstr ""
 
-#: exhibition/views.py:1999
-msgid "Maximum usages"
+#: views.py:2176
+msgid "Voucher returned to the pool."
 msgstr ""
 
-#: exhibition/views.py:2035
-msgid "This voucher has already been redeemed and cannot be removed."
+#: views.py:2207
+msgid "Enter how many vouchers to take from the pool."
 msgstr ""
 
-#: exhibition/views.py:2040
-msgid "Voucher removed."
-msgstr ""
-
-#: exhibition/views.py:2060
+#: views.py:2215
 #, python-format
-msgid "%(count)d voucher created."
-msgid_plural "%(count)d vouchers created."
+msgid "%(count)d voucher taken from the pool."
+msgid_plural "%(count)d vouchers taken from the pool."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2112
+#: views.py:2232
+#, python-format
+msgid ""
+"The pool only has %(remaining)d voucher(s) left, so %(count)d cannot be "
+"taken."
+msgstr ""
+
+#: views.py:2244
+msgid "No email address is on file, so vouchers cannot be emailed."
+msgstr ""
+
+#: views.py:2253
+msgid "This partner holds no vouchers yet, so there is nothing to email."
+msgstr ""
+
+#: views.py:2259
+#, python-format
+msgid "An email with %(count)d voucher code was placed in the outbox."
+msgid_plural "An email with %(count)d voucher codes was placed in the outbox."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2347
+msgid "There is nobody to send vouchers to in this list."
+msgstr ""
+
+#: views.py:2354
+#, python-format
+msgid "%(count)d voucher email was placed in the outbox."
+msgid_plural "%(count)d voucher emails were placed in the outbox."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2371
+#, python-format
+msgid ""
+"%(count)d was skipped because no unassigned codes were available from their "
+"pool."
+msgid_plural ""
+"%(count)d were skipped because no unassigned codes were available from their "
+"pool."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2386
+#, python-format
+msgid "%(count)d sponsor was skipped because it has no email address."
+msgid_plural ""
+"%(count)d sponsors were skipped because they have no email address."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2392
+#, python-format
+msgid "%(count)d exhibitor was skipped because it has no email address."
+msgid_plural ""
+"%(count)d exhibitors were skipped because they have no email address."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2401
+#, python-format
+msgid "%(count)d sponsor was skipped because their voucher count is set to 0."
+msgid_plural ""
+"%(count)d sponsors were skipped because their voucher count is set to 0."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2407
+#, python-format
+msgid ""
+"%(count)d exhibitor was skipped because their voucher count is set to 0."
+msgid_plural ""
+"%(count)d exhibitors were skipped because their voucher count is set to 0."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2461
 #, python-format
 msgid "%(count)d device added."
 msgid_plural "%(count)d devices added."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2123
+#: views.py:2472
 #, python-format
 msgid ""
 "New setup tokens generated. %(count)d device that was already scanning is "
@@ -2738,79 +3031,95 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2132
+#: views.py:2481
 msgid "New setup tokens generated."
 msgstr ""
 
-#: exhibition/views.py:2194
+#: views.py:2543
 msgid "No applicants matched the selected filters."
 msgstr ""
 
-#: exhibition/views.py:2202
+#: views.py:2551
 #, python-format
 msgid "%(count)d emails have been scheduled."
 msgstr ""
 
-#: exhibition/views.py:2206
+#: views.py:2555
 #, python-format
 msgid "%(count)d emails have been sent."
 msgstr ""
 
-#: exhibition/views.py:2210
+#: views.py:2559
 #, python-format
 msgid "%(count)d emails have been placed in the outbox."
 msgstr ""
 
-#: exhibition/views.py:2385
+#: views.py:2738
 msgid "The emails have been saved and sent."
 msgstr ""
 
-#: exhibition/views.py:2389
+#: views.py:2742
 msgid "The emails have been saved."
 msgstr ""
 
-#: exhibition/views.py:2395
+#: views.py:2748
 msgid "The email has been saved and sent."
 msgstr ""
 
-#: exhibition/views.py:2399
+#: views.py:2752
 msgid "The email has been saved."
 msgstr ""
 
-#: exhibition/views.py:2423 exhibition/views.py:2497
+#: views.py:2776 views.py:2850
 #, python-format
 msgid "%(count)d email has been sent."
 msgid_plural "%(count)d emails have been sent."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2459
+#: views.py:2812
 msgid "The email has been discarded."
 msgstr ""
 
-#: exhibition/views.py:2501 exhibition/views.py:2514 exhibition/views.py:2519
+#: views.py:2854 views.py:2867 views.py:2872
 msgid "No emails were selected."
 msgstr ""
 
-#: exhibition/views.py:2510
+#: views.py:2863
 #, python-format
 msgid "%(count)d email has been discarded."
 msgid_plural "%(count)d emails have been discarded."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2594
+#: views.py:2929
+msgid "Request received (confirmation)"
+msgstr ""
+
+#: views.py:2930
+msgid "Request accepted"
+msgstr ""
+
+#: views.py:2931
+msgid "Request rejected"
+msgstr ""
+
+#: views.py:2932
+msgid "Exhibitor lead scanning key"
+msgstr ""
+
+#: views.py:2948
 msgid "Email templates have been saved."
 msgstr ""
 
-#: exhibition/views.py:2617 exhibition/views.py:2621
+#: views.py:2971 views.py:2975
 msgid "Unknown template."
 msgstr ""
 
-#: exhibition/views.py:2667
+#: views.py:3021
 msgid "Custom template has been created."
 msgstr ""
 
-#: exhibition/views.py:2683
+#: views.py:3041
 msgid "Custom template has been deleted."
 msgstr ""

--- a/exhibition/locale/ru/LC_MESSAGES/django.po
+++ b/exhibition/locale/ru/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 10:11+0000\n"
+"POT-Creation-Date: 2026-09-11 11:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -20,595 +20,531 @@ msgstr ""
 "n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || "
 "(n%100>=11 && n%100<=14)? 2 : 3);\n"
 
-#: exhibition/apps.py:14 exhibition/apps.py:17 exhibition/signals.py:157
-#: exhibition/templates/exhibitors/public_list.html:6
-#: exhibition/templates/exhibitors/public_list.html:14
-#: exhibition/templates/exhibitors/public_list.html:16
+#: apps.py:14 apps.py:17 signals.py:163 templates/exhibitors/public_list.html:6
+#: templates/exhibitors/public_list.html:14
+#: templates/exhibitors/public_list.html:16
 msgid "Exhibition"
 msgstr ""
 
-#: exhibition/apps.py:19
+#: apps.py:19
 msgid "This plugin enables to add and control exhibitors in eventyay"
 msgstr ""
 
-#: exhibition/filters.py:9
+#: filters.py:9
 msgid "Any"
 msgstr ""
 
-#: exhibition/filters.py:10
+#: filters.py:10
 msgid "Enabled"
 msgstr ""
 
-#: exhibition/filters.py:11 exhibition/templates/exhibitors/dashboard.html:127
+#: filters.py:11 templates/exhibitors/dashboard.html:127
 msgid "Disabled"
 msgstr ""
 
-#: exhibition/filters.py:15
+#: filters.py:15
 msgid "All types"
 msgstr ""
 
-#: exhibition/filters.py:16
+#: filters.py:16
 msgid "Exhibitor only"
 msgstr ""
 
-#: exhibition/filters.py:17
+#: filters.py:17
 msgid "Sponsor only"
 msgstr ""
 
-#: exhibition/filters.py:18 exhibition/templates/exhibitors/dashboard.html:89
-#: exhibition/templates/exhibitors/proposal_detail.html:95
-#: exhibition/templates/exhibitors/proposal_list.html:95
+#: filters.py:18 templates/exhibitors/dashboard.html:89
+#: templates/exhibitors/proposal_detail.html:95
+#: templates/exhibitors/proposal_list.html:95
 msgid "Exhibitor and sponsor"
 msgstr ""
 
-#: exhibition/filters.py:80 exhibition/filters.py:81
+#: filters.py:80 filters.py:81
 msgid "Search requests…"
 msgstr ""
 
-#: exhibition/filters.py:81
+#: filters.py:81
 msgid "Search requests"
 msgstr ""
 
-#: exhibition/filters.py:85 exhibition/templates/exhibitors/dashboard.html:75
-#: exhibition/templates/exhibitors/proposal_detail.html:85
-#: exhibition/templates/exhibitors/proposal_list.html:21
-#: exhibition/templates/exhibitors/public_proposal_list.html:12
+#: filters.py:85 templates/exhibitors/dashboard.html:75
+#: templates/exhibitors/proposal_detail.html:85
+#: templates/exhibitors/proposal_list.html:21
+#: templates/exhibitors/public_proposal_list.html:12
 msgid "State"
 msgstr ""
 
-#: exhibition/filters.py:86
+#: filters.py:86
 msgid "All states"
 msgstr ""
 
-#: exhibition/filters.py:90 exhibition/templates/exhibitors/dashboard.html:74
-#: exhibition/templates/exhibitors/proposal_detail.html:91
-#: exhibition/templates/exhibitors/proposal_list.html:62
+#: filters.py:90 templates/exhibitors/dashboard.html:74
+#: templates/exhibitors/proposal_detail.html:91
+#: templates/exhibitors/proposal_list.html:62
 msgid "Type"
 msgstr ""
 
-#: exhibition/filters.py:99 exhibition/filters.py:102
+#: filters.py:99 filters.py:102
 msgid "Search by name…"
 msgstr ""
 
-#: exhibition/filters.py:103
+#: filters.py:103
 msgid "Search requests by name"
 msgstr ""
 
-#: exhibition/filters.py:132 exhibition/filters.py:133
+#: filters.py:132 filters.py:133
 msgid "Search organizations…"
 msgstr ""
 
-#: exhibition/filters.py:133
+#: filters.py:133
 msgid "Search organizations"
 msgstr ""
 
-#: exhibition/filters.py:137
+#: filters.py:137
 msgid "Visibility"
 msgstr ""
 
-#: exhibition/filters.py:139
+#: filters.py:139
 msgid "All organizations"
 msgstr ""
 
-#: exhibition/filters.py:140 exhibition/forms.py:1512
-#: exhibition/templates/exhibitors/call_questions.html:30
+#: filters.py:140 forms.py:1553 templates/exhibitors/call_questions.html:30
 msgid "Active"
 msgstr ""
 
-#: exhibition/filters.py:141
+#: filters.py:141
 msgid "Inactive"
 msgstr ""
 
-#: exhibition/filters.py:146 exhibition/filters.py:207 exhibition/forms.py:207
-#: exhibition/forms.py:1410 exhibition/forms.py:1841
+#: filters.py:146 filters.py:207 forms.py:212 forms.py:1411 forms.py:1888
 msgid "Sponsor group"
 msgstr ""
 
-#: exhibition/filters.py:149 exhibition/filters.py:210
+#: filters.py:149 filters.py:210
 msgid "All groups"
 msgstr ""
 
-#: exhibition/filters.py:152 exhibition/templates/exhibitors/add.html:222
+#: filters.py:152 templates/exhibitors/add.html:226
 msgid "Lead scanning"
 msgstr ""
 
-#: exhibition/filters.py:157
+#: filters.py:157
 msgid "Lead access"
 msgstr ""
 
-#: exhibition/filters.py:162
+#: filters.py:162
 msgid "Voucher access"
 msgstr ""
 
-#: exhibition/filters.py:202 exhibition/filters.py:203
+#: filters.py:202 filters.py:203
 msgid "Search exhibitors…"
 msgstr ""
 
-#: exhibition/filters.py:203
+#: filters.py:203
 msgid "Search exhibitors"
 msgstr ""
 
-#: exhibition/filters.py:240 exhibition/filters.py:241
+#: filters.py:240 filters.py:241
 msgid "Search emails…"
 msgstr ""
 
-#: exhibition/filters.py:241
+#: filters.py:241
 msgid "Search emails"
 msgstr ""
 
-#: exhibition/forms.py:67
+#: forms.py:72
 #, python-format
 msgid "Times are in the event timezone: %(tz)s."
 msgstr ""
 
-#: exhibition/forms.py:128 exhibition/forms.py:139 exhibition/forms.py:933
-#: exhibition/forms.py:944
+#: forms.py:133 forms.py:144 forms.py:934 forms.py:945
 msgid "— No selection —"
 msgstr ""
 
-#: exhibition/forms.py:211
+#: forms.py:216
 msgid "Can view voucher redemptions"
 msgstr ""
 
-#: exhibition/forms.py:213 exhibition/forms.py:397
+#: forms.py:218 forms.py:402
 msgid ""
 "Lets this exhibitor or sponsor retrieve the attendees who redeemed vouchers "
 "issued to them. Separate from lead scanning, which covers attendees scanned "
 "at the booth."
 msgstr ""
 
-#: exhibition/forms.py:219
+#: forms.py:224
 msgid "Can view and export collected leads"
 msgstr ""
 
-#: exhibition/forms.py:221
+#: forms.py:226
 msgid ""
 "Lets this exhibitor retrieve the full list of leads they have already "
 "scanned. Turn this off to let them keep scanning without seeing the "
 "collected attendee data."
 msgstr ""
 
-#: exhibition/forms.py:226
+#: forms.py:231
 msgid "Lead scanning behavior"
 msgstr ""
 
-#: exhibition/forms.py:231
+#: forms.py:236
 msgid ""
 "Every attendee is one lead, even when scanned from multiple devices. Notes "
 "and ratings are shared between devices."
 msgstr ""
 
-#: exhibition/forms.py:238
+#: forms.py:243
 msgid ""
 "Every attendee is a new lead when scanned from a new device. Notes and "
 "ratings are specific to the device."
 msgstr ""
 
-#: exhibition/forms.py:251
+#: forms.py:256
 msgid "Comment"
 msgstr ""
 
-#: exhibition/forms.py:253
+#: forms.py:258
 msgid ""
 "The text entered in this field will not be visible to the user and is "
 "available for your convenience."
 msgstr ""
 
-#: exhibition/forms.py:258 exhibition/forms.py:1427 exhibition/views.py:505
+#: forms.py:263 forms.py:1428 views.py:544
 msgid "Booth ID"
 msgstr ""
 
-#: exhibition/forms.py:291 exhibition/forms.py:1027 exhibition/forms.py:1076
-#: exhibition/models.py:130
+#: forms.py:296 forms.py:1028 forms.py:1077 models.py:130
 msgid "Organization name"
 msgstr ""
 
-#: exhibition/forms.py:292 exhibition/forms.py:1030 exhibition/forms.py:1077
-#: exhibition/models.py:136
+#: forms.py:297 forms.py:1031 forms.py:1078 models.py:136
 msgid "Organization description"
 msgstr ""
 
-#: exhibition/forms.py:293 exhibition/forms.py:1078
+#: forms.py:298 forms.py:1079
 msgid "E-mail"
 msgstr ""
 
-#: exhibition/forms.py:294 exhibition/forms.py:1079 exhibition/models.py:139
+#: forms.py:299 forms.py:1080 models.py:139
 msgid "Contact page URL"
 msgstr ""
 
-#: exhibition/forms.py:295 exhibition/forms.py:1080 exhibition/models.py:140
+#: forms.py:300 forms.py:1081 models.py:140
 msgid "Promotional video URL"
 msgstr ""
 
-#: exhibition/forms.py:296 exhibition/forms.py:1081 exhibition/models.py:141
+#: forms.py:301 forms.py:1082 models.py:141
 msgid "Promotional slides"
 msgstr ""
 
-#: exhibition/forms.py:297 exhibition/forms.py:1082 exhibition/models.py:142
-#: exhibition/models.py:520
-#: exhibition/templates/exhibitors/proposal_detail.html:111
+#: forms.py:302 forms.py:1083 models.py:142 models.py:568
+#: templates/exhibitors/proposal_detail.html:111
 msgid "Logo"
 msgstr ""
 
-#: exhibition/forms.py:298 exhibition/forms.py:1083 exhibition/models.py:145
-#: exhibition/templates/exhibitors/proposal_detail.html:113
+#: forms.py:303 forms.py:1084 models.py:145
+#: templates/exhibitors/proposal_detail.html:113
 msgid "Header image"
 msgstr ""
 
-#: exhibition/forms.py:299 exhibition/forms.py:1084 exhibition/models.py:138
+#: forms.py:304 forms.py:1085 models.py:138
 msgid "Organization website"
 msgstr ""
 
-#: exhibition/forms.py:300
+#: forms.py:305
 msgid "Mark this partner as an exhibitor"
 msgstr ""
 
-#: exhibition/forms.py:301
+#: forms.py:306
 msgid "Mark this partner as an event sponsor"
 msgstr ""
 
-#: exhibition/forms.py:302 exhibition/forms.py:1036 exhibition/forms.py:1085
-#: exhibition/models.py:148 exhibition/models.py:522
+#: forms.py:307 forms.py:1037 forms.py:1086 models.py:148 models.py:570
 msgid "Preferred booth name"
 msgstr ""
 
-#: exhibition/forms.py:303
+#: forms.py:308
 msgid "Can scan attendee badges"
 msgstr ""
 
-#: exhibition/forms.py:307
+#: forms.py:312
 msgid ""
 "Lets this exhibitor sign in to the lead scanning app and scan attendees at "
 "their booth. Turn this off to block scanning entirely."
 msgstr ""
 
-#: exhibition/forms.py:348 exhibition/forms.py:1441
+#: forms.py:353 forms.py:1442
 msgid "No sponsor group"
 msgstr ""
 
-#: exhibition/forms.py:385
+#: forms.py:390
 msgid ""
 "Lets this exhibitor retrieve the attendees who redeemed vouchers issued to "
 "them. Separate from lead scanning, which covers attendees scanned at the "
 "booth."
 msgstr ""
 
-#: exhibition/forms.py:389
+#: forms.py:394
 msgid ""
 "Lets this sponsor retrieve the attendees who redeemed vouchers issued to "
 "them. Separate from lead scanning, which covers attendees scanned at the "
 "booth."
 msgstr ""
 
-#: exhibition/forms.py:393
+#: forms.py:398
 msgid ""
 "Lets this exhibitor and sponsor retrieve the attendees who redeemed vouchers "
 "issued to them. Separate from lead scanning, which covers attendees scanned "
 "at the booth."
 msgstr ""
 
-#: exhibition/forms.py:466 exhibition/forms.py:553 exhibition/forms.py:1361
-#: exhibition/forms.py:1375
+#: forms.py:471 forms.py:558 forms.py:1362 forms.py:1376 forms.py:1855
+#: forms.py:1924 forms.py:1930 forms.py:1932 forms.py:1934
 msgid "This field is required."
 msgstr ""
 
-#: exhibition/forms.py:511 exhibition/forms.py:516
+#: forms.py:516 forms.py:521
 msgid "Slides upload must be a PDF file."
 msgstr ""
 
-#: exhibition/forms.py:540
+#: forms.py:545
 msgid "A partner must be marked as an exhibitor, a sponsor, or both."
 msgstr ""
 
-#: exhibition/forms.py:615
+#: forms.py:620
 msgid "Devices to add"
 msgstr ""
 
-#: exhibition/forms.py:617
+#: forms.py:622
 msgid ""
 "How many new devices to provision now, in addition to any already listed "
 "above. Each device gets its own single-use setup token and QR code."
 msgstr ""
 
-#: exhibition/forms.py:627
-msgid "Select a product…"
+#: forms.py:635
+msgid "Vouchers to take from the pool"
 msgstr ""
 
-#: exhibition/forms.py:628
-msgid "Ticket product"
+#: forms.py:636
+msgid ""
+"Set to 0 to email the codes this partner already has without taking any more."
 msgstr ""
 
-#: exhibition/forms.py:629
-msgid "The product a redeemed voucher applies to."
-msgstr ""
-
-#: exhibition/forms.py:635
-msgid "Number of vouchers"
-msgstr ""
-
-#: exhibition/forms.py:640
-msgid "Maximum usages per voucher"
-msgstr ""
-
-#: exhibition/forms.py:645 exhibition/templates/exhibitors/vouchers.html:33
-#: exhibition/views.py:1995
-msgid "Price effect"
-msgstr ""
-
-#: exhibition/forms.py:651 exhibition/views.py:1996
-msgid "Value"
-msgstr ""
-
-#: exhibition/forms.py:652
-msgid "Amount or percentage, depending on the selected price effect."
-msgstr ""
-
-#: exhibition/forms.py:657 exhibition/templates/exhibitors/vouchers.html:35
-#: exhibition/views.py:1997
-msgid "Valid until"
-msgstr ""
-
-#: exhibition/forms.py:673
-msgid "Enter a value for the selected price effect."
-msgstr ""
-
-#: exhibition/forms.py:678 exhibition/models.py:295
-#: exhibition/templates/exhibitors/settings.html:205
+#: forms.py:647 models.py:326 templates/exhibitors/settings.html:289
 msgid "Level"
 msgstr ""
 
-#: exhibition/forms.py:685 exhibition/models.py:294
+#: forms.py:654 models.py:325
 msgid "Group name"
 msgstr ""
 
-#: exhibition/forms.py:718
+#: forms.py:677 models.py:225
+msgid "Exhibitor voucher pool"
+msgstr ""
+
+#: forms.py:678 models.py:232
+msgid "Sponsor voucher pool"
+msgstr ""
+
+#: forms.py:698
+msgid "— No pool selected —"
+msgstr ""
+
+#: forms.py:699
+msgid "— Use the exhibitor pool —"
+msgstr ""
+
+#: forms.py:719
 msgid "Enable call"
 msgstr ""
 
-#: exhibition/forms.py:719
+#: forms.py:720
 msgid "Hide call page after the deadline"
 msgstr ""
 
-#: exhibition/forms.py:720
+#: forms.py:721
 msgid "Make this call private (accessible only via a secret link)"
 msgstr ""
 
-#: exhibition/forms.py:724
+#: forms.py:725
 msgid ""
 "Turn the call on. Keep it enabled for private calls too, otherwise the "
 "secret link stops working."
 msgstr ""
 
-#: exhibition/forms.py:727
+#: forms.py:728
 msgid ""
 "The call page is not linked anywhere public and can only be opened with the "
 "secret link shown below."
 msgstr ""
 
-#: exhibition/forms.py:868
+#: forms.py:869
 msgid "Your answer"
 msgstr ""
 
-#: exhibition/forms.py:1024 exhibition/models.py:563
-#: exhibition/templates/exhibitors/proposal_detail.html:88
+#: forms.py:1025 models.py:611 templates/exhibitors/proposal_detail.html:88
 msgid "Language"
 msgstr ""
 
-#: exhibition/forms.py:1025
+#: forms.py:1026
 msgid "The language you are filling in this form with."
 msgstr ""
 
-#: exhibition/forms.py:1086 exhibition/models.py:151 exhibition/models.py:523
-#: exhibition/models.py:602
+#: forms.py:1087 models.py:151 models.py:571 models.py:650
 msgid "Message to the organizers"
 msgstr ""
 
-#: exhibition/forms.py:1149
+#: forms.py:1150
 msgid ""
 "The organization name is locked after acceptance. Contact the organizers to "
 "change it."
 msgstr ""
 
-#: exhibition/forms.py:1425
+#: forms.py:1426
 msgid "Approve as exhibitor"
 msgstr ""
 
-#: exhibition/forms.py:1426
+#: forms.py:1427
 msgid "Approve as sponsor"
 msgstr ""
 
-#: exhibition/forms.py:1428 exhibition/models.py:352 exhibition/models.py:596
-#: exhibition/models.py:966 exhibition/views.py:505
+#: forms.py:1429 models.py:383 models.py:644 models.py:1014 views.py:544
 msgid "Booth name"
 msgstr ""
 
-#: exhibition/forms.py:1429 exhibition/forms.py:1459 exhibition/models.py:607
+#: forms.py:1430 forms.py:1460 models.py:655
 msgid "Internal review notes"
 msgstr ""
 
-#: exhibition/forms.py:1470
+#: forms.py:1471
 msgid "Field label"
 msgstr ""
 
-#: exhibition/forms.py:1475 exhibition/forms.py:1510
+#: forms.py:1476 forms.py:1551
 msgid "Help text"
 msgstr ""
 
-#: exhibition/forms.py:1476
+#: forms.py:1477
 msgid "Shown below the field on the exhibitor form."
 msgstr ""
 
-#: exhibition/forms.py:1483
+#: forms.py:1484
 #, python-format
 msgid "Leave empty to use the default: %(label)s"
 msgstr ""
 
-#: exhibition/forms.py:1492
-msgid "Options"
-msgstr ""
-
-#: exhibition/forms.py:1493
-msgid "For choice fields, enter one option per line."
-msgstr ""
-
-#: exhibition/forms.py:1508
-msgid "Field type"
-msgstr ""
-
-#: exhibition/forms.py:1509 exhibition/models.py:878
-msgid "Custom question"
-msgstr ""
-
-#: exhibition/forms.py:1511
-#: exhibition/templates/exhibitors/call_questions.html:31
-#: exhibition/templates/exhibitors/call_questions.html:63
-msgid "Required"
-msgstr ""
-
-#: exhibition/forms.py:1535
+#: forms.py:1523
 msgid "Please provide at least one option for this question type."
 msgstr ""
 
-#: exhibition/forms.py:1576 exhibition/forms.py:1665
+#: forms.py:1549
+msgid "Field type"
+msgstr ""
+
+#: forms.py:1550 models.py:926
+msgid "Custom question"
+msgstr ""
+
+#: forms.py:1552 templates/exhibitors/call_questions.html:31
+#: templates/exhibitors/call_questions.html:63
+msgid "Required"
+msgstr ""
+
+#: forms.py:1583 forms.py:1672
 msgid "Choose social platform"
 msgstr ""
 
-#: exhibition/forms.py:1578 exhibition/forms.py:1667
+#: forms.py:1585 forms.py:1674
 msgid "Social platform"
 msgstr ""
 
-#: exhibition/forms.py:1582 exhibition/forms.py:1671
+#: forms.py:1589 forms.py:1678
 msgid "Profile or path"
 msgstr ""
 
-#: exhibition/forms.py:1596 exhibition/forms.py:1685
+#: forms.py:1603 forms.py:1692
 msgid "Profile, handle, or full URL"
 msgstr ""
 
-#: exhibition/forms.py:1616 exhibition/forms.py:1705
+#: forms.py:1623 forms.py:1712
 msgid "Please enter a profile, handle, or URL or remove this row."
 msgstr ""
 
-#: exhibition/forms.py:1622 exhibition/forms.py:1711
+#: forms.py:1629 forms.py:1718
 msgid "Please choose a social platform."
 msgstr ""
 
-#: exhibition/forms.py:1626 exhibition/forms.py:1715
+#: forms.py:1633 forms.py:1722
 msgid "Please enter a profile, handle, or URL."
 msgstr ""
 
-#: exhibition/forms.py:1648 exhibition/forms.py:1737
+#: forms.py:1655 forms.py:1744
 msgid "Link label"
 msgstr ""
 
-#: exhibition/forms.py:1654 exhibition/forms.py:1743
+#: forms.py:1661 forms.py:1750
 msgid "https://example.com"
 msgstr ""
 
-#: exhibition/forms.py:1807
+#: forms.py:1848
 msgid ""
 "Leave empty to keep this in the outbox until sent manually. Time is "
 "interpreted in the event timezone."
 msgstr ""
 
-#: exhibition/forms.py:1814 exhibition/forms.py:1877
+#: forms.py:1861 forms.py:1940
 msgid "The scheduled time must be in the future."
 msgstr ""
 
-#: exhibition/forms.py:1822
+#: forms.py:1869
 msgid "Exhibitors and sponsors"
 msgstr ""
 
-#: exhibition/forms.py:1823
+#: forms.py:1870
 msgid "Exhibitors only"
 msgstr ""
 
-#: exhibition/forms.py:1824
+#: forms.py:1871
 msgid "Sponsors only"
 msgstr ""
 
-#: exhibition/forms.py:1828
+#: forms.py:1875
 msgid "Application state"
 msgstr ""
 
-#: exhibition/forms.py:1836
+#: forms.py:1883
 msgid "Partner type"
 msgstr ""
 
-#: exhibition/forms.py:1844
+#: forms.py:1891
 msgid "Any sponsor group"
 msgstr ""
 
-#: exhibition/forms.py:1846 exhibition/models.py:1035 exhibition/models.py:1089
-#: exhibition/templates/exhibitors/_email_outbox_body.html:6
-#: exhibition/templates/exhibitors/_email_sent_body.html:6
+#: forms.py:1893 forms.py:1953 models.py:1084 models.py:1146
+#: templates/exhibitors/_email_outbox_body.html:6
+#: templates/exhibitors/_email_sent_body.html:6
 msgid "Subject"
 msgstr ""
 
-#: exhibition/forms.py:1848
+#: forms.py:1895
 msgid "Send at"
 msgstr ""
 
-#: exhibition/forms.py:1851
+#: forms.py:1898
 msgid "Leave empty to send immediately or save to the outbox."
 msgstr ""
 
-#: exhibition/forms.py:1859 exhibition/models.py:1036 exhibition/models.py:1090
+#: forms.py:1906 forms.py:1960 models.py:1085 models.py:1147
 msgid "Body"
 msgstr ""
 
-#: exhibition/forms.py:1885 exhibition/views.py:2576
-msgid "Request received (confirmation)"
-msgstr ""
-
-#: exhibition/forms.py:1886 exhibition/views.py:2577
-msgid "Request accepted"
-msgstr ""
-
-#: exhibition/forms.py:1887 exhibition/views.py:2578
-msgid "Request rejected"
-msgstr ""
-
-#: exhibition/forms.py:1888 exhibition/views.py:2579
-msgid "Exhibitor lead scanning key"
-msgstr ""
-
-#: exhibition/forms.py:1897
-#, python-format
-msgid "%(role)s — subject"
-msgstr ""
-
-#: exhibition/forms.py:1904
-#, python-format
-msgid "%(role)s — body"
-msgstr ""
-
-#: exhibition/mail.py:57
+#: mail.py:59
 #, python-brace-format
 msgid "We received your request for {event_name}"
 msgstr ""
 
-#: exhibition/mail.py:59
+#: mail.py:61
 #, python-brace-format
 msgid ""
 "Hello,\n"
@@ -623,12 +559,12 @@ msgid ""
 "The {event_name} team"
 msgstr ""
 
-#: exhibition/mail.py:69
+#: mail.py:71
 #, python-brace-format
 msgid "Your request for {event_name} has been accepted"
 msgstr ""
 
-#: exhibition/mail.py:71
+#: mail.py:73
 #, python-brace-format
 msgid ""
 "Hello,\n"
@@ -640,12 +576,12 @@ msgid ""
 "The {event_name} team"
 msgstr ""
 
-#: exhibition/mail.py:80
+#: mail.py:82
 #, python-brace-format
 msgid "Update on your request for {event_name}"
 msgstr ""
 
-#: exhibition/mail.py:82
+#: mail.py:84
 #, python-brace-format
 msgid ""
 "Hello,\n"
@@ -659,12 +595,12 @@ msgid ""
 "The {event_name} team"
 msgstr ""
 
-#: exhibition/mail.py:91
+#: mail.py:93
 #, python-brace-format
 msgid "Lead Scanning Access for {event_name}"
 msgstr ""
 
-#: exhibition/mail.py:93
+#: mail.py:95
 #, python-brace-format
 msgid ""
 "Hello {exhibitor_name},\n"
@@ -690,983 +626,1082 @@ msgid ""
 "The {event_name} Team"
 msgstr ""
 
-#: exhibition/mail.py:174
+#: mail.py:110
+#, python-brace-format
+msgid "Your vouchers for {event_name} — {exhibitor_name}"
+msgstr ""
+
+#: mail.py:112
+#, python-brace-format
+msgid ""
+"Dear {exhibitor_name},\n"
+"\n"
+"Thank you for participating in {event_name}. Please share the voucher codes "
+"below with your audience — anyone who uses one gets credited to you as a "
+"lead.\n"
+"\n"
+"{voucher_list}\n"
+"\n"
+"They can redeem a code on the event ticket shop at checkout.\n"
+"\n"
+"If you have any questions, please don't hesitate to reach out.\n"
+"\n"
+"Best regards,\n"
+"The {event_name} Team"
+msgstr ""
+
+#: mail.py:190
 msgid "This value will be replaced based on dynamic parameters."
 msgstr ""
 
-#: exhibition/models.py:137 exhibition/models.py:515
+#: mail.py:312
+#, python-format
+msgid "…and %(count)d more voucher code in the attached CSV file."
+msgid_plural "…and %(count)d more voucher codes in the attached CSV file."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: models.py:137 models.py:563
 msgid "Contact email"
 msgstr ""
 
-#: exhibition/models.py:156
-#: exhibition/templates/exhibitors/proposal_detail.html:132
+#: models.py:156 templates/exhibitors/proposal_detail.html:132
 msgid "Social media"
 msgstr ""
 
-#: exhibition/models.py:161
-#: exhibition/templates/exhibitors/proposal_detail.html:140
+#: models.py:161 templates/exhibitors/proposal_detail.html:140
 msgid "Extra links"
 msgstr ""
 
-#: exhibition/models.py:216
+#: models.py:212
+msgid "Vouchers per exhibitor"
+msgstr ""
+
+#: models.py:226
+msgid ""
+"The voucher tag created under Tickets → Vouchers that exhibitors draw their "
+"codes from."
+msgstr ""
+
+#: models.py:233
+msgid "Leave empty to draw sponsor codes from the exhibitor pool as well."
+msgstr ""
+
+#: models.py:239
+msgid "Attach voucher list as CSV"
+msgstr ""
+
+#: models.py:240
+msgid ""
+"Adds a spreadsheet of the recipient's own voucher codes to the voucher email."
+msgstr ""
+
+#: models.py:247
 msgid "Call headline"
 msgstr ""
 
-#: exhibition/models.py:220
+#: models.py:251
 msgid "Call text"
 msgstr ""
 
-#: exhibition/models.py:225
+#: models.py:256
 msgid "Submission deadline"
 msgstr ""
 
-#: exhibition/models.py:298
+#: models.py:329
 msgid "Show this sponsor group on the front page."
 msgstr ""
 
-#: exhibition/models.py:314 exhibition/models.py:558
-#: exhibition/templates/exhibitors/dashboard.html:73
-#: exhibition/templates/exhibitors/exhibitor_info.html:69
-#: exhibition/templates/exhibitors/proposal_list.html:19
-#: exhibition/templates/exhibitors/public_proposal_list.html:11
-#: exhibition/views.py:505
+#: models.py:345 models.py:606 templates/exhibitors/dashboard.html:73
+#: templates/exhibitors/exhibitor_info.html:79
+#: templates/exhibitors/proposal_list.html:19
+#: templates/exhibitors/public_proposal_list.html:11 views.py:544
 msgid "Name"
 msgstr ""
 
-#: exhibition/models.py:315 exhibition/models.py:559
-#: exhibition/templates/exhibitors/proposal_detail.html:117
+#: models.py:346 models.py:607 templates/exhibitors/proposal_detail.html:117
 msgid "Description"
 msgstr ""
 
-#: exhibition/models.py:316 exhibition/models.py:419 exhibition/models.py:435
-#: exhibition/models.py:565 exhibition/models.py:815 exhibition/models.py:831
-#: exhibition/models.py:844
-#: exhibition/templates/exhibitors/proposal_detail.html:103
+#: models.py:347 models.py:467 models.py:483 models.py:613 models.py:863
+#: models.py:879 models.py:892 templates/exhibitors/proposal_detail.html:103
 msgid "URL"
 msgstr ""
 
-#: exhibition/models.py:317 exhibition/models.py:566
-#: exhibition/templates/exhibitors/proposal_detail.html:77
-#: exhibition/views.py:505
+#: models.py:348 models.py:614 templates/exhibitors/proposal_detail.html:77
+#: views.py:544
 msgid "Email"
 msgstr ""
 
-#: exhibition/models.py:318 exhibition/models.py:567
-#: exhibition/templates/exhibitors/proposal_detail.html:105
+#: models.py:349 models.py:615 templates/exhibitors/proposal_detail.html:105
 msgid "Contact URL"
 msgstr ""
 
-#: exhibition/models.py:319 exhibition/models.py:568
-#: exhibition/templates/exhibitors/proposal_detail.html:107
+#: models.py:350 models.py:616 templates/exhibitors/proposal_detail.html:107
 msgid "Video URL"
 msgstr ""
 
-#: exhibition/models.py:322 exhibition/models.py:571
-#: exhibition/templates/exhibitors/proposal_detail.html:109
+#: models.py:353 models.py:619 templates/exhibitors/proposal_detail.html:109
 msgid "Slides"
 msgstr ""
 
-#: exhibition/models.py:326 exhibition/models.py:575
+#: models.py:357 models.py:623
 msgid "Slides URL"
 msgstr ""
 
-#: exhibition/models.py:328 exhibition/models.py:577
+#: models.py:359 models.py:625
 msgid "Logo URL"
 msgstr ""
 
-#: exhibition/models.py:330 exhibition/models.py:579
+#: models.py:361 models.py:627
 msgid "Header image URL"
 msgstr ""
 
-#: exhibition/models.py:434 exhibition/models.py:830
+#: models.py:482 models.py:878
 msgid "Label"
 msgstr ""
 
-#: exhibition/models.py:445
+#: models.py:493
 msgid "draft"
 msgstr ""
 
-#: exhibition/models.py:446
+#: models.py:494
 msgid "submitted"
 msgstr ""
 
-#: exhibition/models.py:447
+#: models.py:495
 msgid "accepted"
 msgstr ""
 
-#: exhibition/models.py:448
+#: models.py:496
 msgid "rejected"
 msgstr ""
 
-#: exhibition/models.py:449
+#: models.py:497
 msgid "withdrawn"
 msgstr ""
 
-#: exhibition/models.py:514
+#: models.py:562
 msgid "Organization Description"
 msgstr ""
 
-#: exhibition/models.py:516
+#: models.py:564
 msgid "Organization Website"
 msgstr ""
 
-#: exhibition/models.py:517
+#: models.py:565
 msgid "Contact Page URL"
 msgstr ""
 
-#: exhibition/models.py:518
+#: models.py:566
 msgid "Promotional Video URL"
 msgstr ""
 
-#: exhibition/models.py:519
+#: models.py:567
 msgid "Promotional Slides"
 msgstr ""
 
-#: exhibition/models.py:521
+#: models.py:569
 msgid "Header Image"
 msgstr ""
 
-#: exhibition/models.py:524 exhibition/templates/exhibitors/add.html:29
-#: exhibition/templates/exhibitors/public_proposal_form.html:38
+#: models.py:572 templates/exhibitors/add.html:29
+#: templates/exhibitors/public_proposal_form.html:38
 msgid "Social Media"
 msgstr ""
 
-#: exhibition/models.py:525 exhibition/templates/exhibitors/add.html:92
-#: exhibition/templates/exhibitors/public_proposal_form.html:91
+#: models.py:573 templates/exhibitors/add.html:92
+#: templates/exhibitors/public_proposal_form.html:91
 msgid "Extra Links"
 msgstr ""
 
-#: exhibition/models.py:841
+#: models.py:889
 msgid "Number"
 msgstr ""
 
-#: exhibition/models.py:842
+#: models.py:890
 msgid "Text (one line)"
 msgstr ""
 
-#: exhibition/models.py:843
+#: models.py:891
 msgid "Multiline text"
 msgstr ""
 
-#: exhibition/models.py:845
+#: models.py:893
 msgid "Email address"
 msgstr ""
 
-#: exhibition/models.py:846
+#: models.py:894
 msgid "Confirm Checkbox"
 msgstr ""
 
-#: exhibition/models.py:847
+#: models.py:895
 msgid "Radio button (Choose one option)"
 msgstr ""
 
-#: exhibition/models.py:848
+#: models.py:896
 msgid "Dropdown (Choose one option)"
 msgstr ""
 
-#: exhibition/models.py:849
+#: models.py:897
 msgid "Checkbox (Choose one or several options)"
 msgstr ""
 
-#: exhibition/models.py:850
+#: models.py:898
 msgid "File upload"
 msgstr ""
 
-#: exhibition/models.py:851
+#: models.py:899
 msgid "Date"
 msgstr ""
 
-#: exhibition/models.py:852
+#: models.py:900
 msgid "Time"
 msgstr ""
 
-#: exhibition/models.py:853
+#: models.py:901
 msgid "Date and time"
 msgstr ""
 
-#: exhibition/models.py:854
+#: models.py:902
 msgid "Country code (ISO 3166-1 alpha-2)"
 msgstr ""
 
-#: exhibition/models.py:855
+#: models.py:903
 msgid "Phone number"
 msgstr ""
 
-#: exhibition/models.py:883
+#: models.py:931
 msgid "help text"
 msgstr ""
 
-#: exhibition/models.py:885 exhibition/templates/exhibitors/add.html:29
-#: exhibition/templates/exhibitors/add.html:92
-#: exhibition/templates/exhibitors/public_proposal_form.html:38
-#: exhibition/templates/exhibitors/public_proposal_form.html:91
+#: models.py:933 templates/exhibitors/add.html:29
+#: templates/exhibitors/add.html:92
+#: templates/exhibitors/public_proposal_form.html:38
+#: templates/exhibitors/public_proposal_form.html:91
 msgid "required"
 msgstr ""
 
-#: exhibition/models.py:886
+#: models.py:934
 msgid "active"
 msgstr ""
 
-#: exhibition/models.py:906
+#: models.py:954
 msgid "Response"
 msgstr ""
 
-#: exhibition/models.py:938
+#: models.py:986
 msgid "Yes"
 msgstr ""
 
-#: exhibition/models.py:940
+#: models.py:988
 msgid "No"
 msgstr ""
 
-#: exhibition/models.py:1034
-#: exhibition/templates/exhibitors/_email_outbox_body.html:5
-#: exhibition/templates/exhibitors/_email_sent_body.html:5
+#: models.py:1083 templates/exhibitors/_email_outbox_body.html:5
+#: templates/exhibitors/_email_sent_body.html:5
 msgid "Recipient"
 msgstr ""
 
-#: exhibition/models.py:1045
+#: models.py:1101
 msgid "Queued email"
 msgstr ""
 
-#: exhibition/models.py:1046
+#: models.py:1102
 msgid "Queued emails"
 msgstr ""
 
-#: exhibition/models.py:1088
+#: models.py:1145
 msgid "Template name"
 msgstr ""
 
-#: exhibition/models.py:1095
+#: models.py:1152
 msgid "Custom email template"
 msgstr ""
 
-#: exhibition/models.py:1096
+#: models.py:1153
 msgid "Custom email templates"
 msgstr ""
 
-#: exhibition/signals.py:75
+#: signals.py:81
 msgid "Screen and evaluate exhibitor and sponsor requests for the event."
 msgstr ""
 
-#: exhibition/signals.py:76
+#: signals.py:82
 msgid "Request Review Dashboard"
 msgstr ""
 
-#: exhibition/signals.py:80
+#: signals.py:86
 msgid ""
 "Manage exhibitors and sponsors, maintain booth details, and create partner "
 "profiles for the event."
 msgstr ""
 
-#: exhibition/signals.py:82
+#: signals.py:88
 msgid "Exhibitors & Sponsors Dashboard"
 msgstr ""
 
-#: exhibition/signals.py:88 exhibition/templates/exhibitors/base.html:5
-#: exhibition/templates/exhibitors/base.html:125
-#: exhibition/templates/exhibitors/exhibitor_info.html:4
-#: exhibition/templates/exhibitors/exhibitor_info.html:15
+#: signals.py:94 templates/exhibitors/base.html:6
+#: templates/exhibitors/base.html:136
+#: templates/exhibitors/exhibitor_info.html:4
+#: templates/exhibitors/exhibitor_info.html:15
 msgid "Exhibitors & Sponsors"
 msgstr ""
 
-#: exhibition/signals.py:90
+#: signals.py:96
 msgid "Go to"
 msgstr ""
 
-#: exhibition/signals.py:166 exhibition/templates/exhibitors/call_base.html:4
-#: exhibition/templates/exhibitors/call_base.html:7
-#: exhibition/templates/exhibitors/public_call.html:7
-#: exhibition/templates/exhibitors/settings.html:8
-#: exhibition/templates/exhibitors/settings.html:25
+#: signals.py:172 templates/exhibitors/call_base.html:4
+#: templates/exhibitors/call_base.html:7
+#: templates/exhibitors/public_call.html:7 templates/exhibitors/settings.html:8
+#: templates/exhibitors/settings.html:27
 msgid "Call for Exhibitors"
 msgstr ""
 
-#: exhibition/signals.py:207 exhibition/signals.py:231
+#: signals.py:213 signals.py:237
 msgid "Acme Corp"
 msgstr ""
 
-#: exhibition/signals.py:225
+#: signals.py:231
 msgid "Jane Doe"
 msgstr ""
 
-#: exhibition/signals.py:293 exhibition/templates/exhibitors/base.html:62
-#: exhibition/templates/exhibitors/proposal_list.html:5
-#: exhibition/templates/exhibitors/proposal_list.html:15
+#: signals.py:305 templates/exhibitors/base.html:73
+#: templates/exhibitors/proposal_list.html:5
+#: templates/exhibitors/proposal_list.html:15
 msgid "Exhibition requests"
 msgstr ""
 
-#: exhibition/signals.py:298
+#: signals.py:310
 msgid "Exhibition request approved."
 msgstr ""
 
-#: exhibition/signals.py:299
+#: signals.py:311
 msgid "Exhibition request rejected."
 msgstr ""
 
-#: exhibition/signals.py:300
+#: signals.py:312
 msgid "Exhibition request withdrawn."
 msgstr ""
 
-#: exhibition/signals.py:301
+#: signals.py:313
 msgid "Exhibition request reopened for review."
 msgstr ""
 
-#: exhibition/signals.py:302
+#: signals.py:314
 msgid "Exhibition request changed."
 msgstr ""
 
-#: exhibition/signals.py:303
+#: signals.py:315
 msgid "Organization profile created from an approved request."
 msgstr ""
 
-#: exhibition/signals.py:304
+#: signals.py:316
 msgid "Organization profile reactivated after re-approval."
 msgstr ""
 
-#: exhibition/signals.py:305
+#: signals.py:317
 msgid "Organization profile updated from the submitter's changes."
 msgstr ""
 
-#: exhibition/signals.py:306
+#: signals.py:318
 msgid "Organization profile created."
 msgstr ""
 
-#: exhibition/signals.py:307
+#: signals.py:319
 msgid "Organization profile changed."
 msgstr ""
 
-#: exhibition/signals.py:308
+#: signals.py:320
 msgid "Organization profile deleted."
 msgstr ""
 
-#: exhibition/signals.py:309
+#: signals.py:321
 msgid "Exhibition settings changed."
 msgstr ""
 
-#: exhibition/signals.py:310
+#: signals.py:322
 msgid "Call for exhibitors settings changed."
 msgstr ""
 
-#: exhibition/signals.py:311
+#: signals.py:323
 msgid "Private call link regenerated."
 msgstr ""
 
-#: exhibition/signals.py:312
+#: signals.py:324
 msgid "Sponsor group created."
 msgstr ""
 
-#: exhibition/signals.py:313
+#: signals.py:325
 msgid "Sponsor group changed."
 msgstr ""
 
-#: exhibition/signals.py:314 exhibition/views.py:457
+#: signals.py:326 views.py:496
 msgid "Sponsor group deleted."
 msgstr ""
 
-#: exhibition/signals.py:315
+#: signals.py:327
 msgid "Exhibitor form question created."
 msgstr ""
 
-#: exhibition/signals.py:316
+#: signals.py:328
 msgid "Exhibitor form question changed."
 msgstr ""
 
-#: exhibition/signals.py:317
+#: signals.py:329
 msgid "Exhibitor form question deleted."
 msgstr ""
 
-#: exhibition/signals.py:318
+#: signals.py:330
 msgid "Email sent."
 msgstr ""
 
-#: exhibition/signals.py:337
+#: signals.py:349
 #, python-brace-format
 msgid "Updated: {fields}."
 msgstr ""
 
-#: exhibition/signals.py:360
+#: signals.py:372
 #, python-brace-format
 msgid "State changed from {old} to {new}."
 msgstr ""
 
-#: exhibition/signals.py:382
+#: signals.py:394
 #, python-brace-format
 msgid "Exhibition request {val}"
 msgstr ""
 
-#: exhibition/signals.py:391
+#: signals.py:403
 #, python-brace-format
 msgid "Organization profile {val}"
 msgstr ""
 
-#: exhibition/signals.py:400
+#: signals.py:412
 #, python-brace-format
 msgid "Exhibitor form question {val}"
 msgstr ""
 
-#: exhibition/signals.py:409
+#: signals.py:421
 #, python-brace-format
 msgid "Sponsor group {val}"
 msgstr ""
 
-#: exhibition/social_links.py:36
+#: social_links.py:36
 msgid "Facebook"
 msgstr ""
 
-#: exhibition/social_links.py:43
+#: social_links.py:43
 msgid "Flickr"
 msgstr ""
 
-#: exhibition/social_links.py:50
+#: social_links.py:50
 msgid "GitHub"
 msgstr ""
 
-#: exhibition/social_links.py:57
+#: social_links.py:57
 msgid "GitLab"
 msgstr ""
 
-#: exhibition/social_links.py:64
+#: social_links.py:64
 msgid "Gitter"
 msgstr ""
 
-#: exhibition/social_links.py:71
+#: social_links.py:71
 msgid "Google Groups"
 msgstr ""
 
-#: exhibition/social_links.py:78
+#: social_links.py:78
 msgid "Instagram"
 msgstr ""
 
-#: exhibition/social_links.py:85
+#: social_links.py:85
 msgid "LinkedIn"
 msgstr ""
 
-#: exhibition/social_links.py:92
+#: social_links.py:92
 msgid "Mastodon"
 msgstr ""
 
-#: exhibition/social_links.py:99
+#: social_links.py:99
 msgid "Patreon"
 msgstr ""
 
-#: exhibition/social_links.py:106
+#: social_links.py:106
 msgid "Telegram"
 msgstr ""
 
-#: exhibition/social_links.py:113
+#: social_links.py:113
 msgid "Vimeo"
 msgstr ""
 
-#: exhibition/social_links.py:120
+#: social_links.py:120
 msgid "VK"
 msgstr ""
 
-#: exhibition/social_links.py:127
+#: social_links.py:127
 msgid "Weibo"
 msgstr ""
 
-#: exhibition/social_links.py:134
+#: social_links.py:134
 msgid "X"
 msgstr ""
 
-#: exhibition/social_links.py:141
+#: social_links.py:141
 msgid "Xing"
 msgstr ""
 
-#: exhibition/social_links.py:148
+#: social_links.py:148
 msgid "YouTube"
 msgstr ""
 
-#: exhibition/social_links.py:155
+#: social_links.py:155
 msgid "YouTube Privacy"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:7
+#: templates/exhibitors/_email_outbox_body.html:7
 msgid "Created"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:14
+#: templates/exhibitors/_email_outbox_body.html:14
 msgid "Send selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:17
+#: templates/exhibitors/_email_outbox_body.html:17
 msgid "Discard selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:20
+#: templates/exhibitors/_email_outbox_body.html:20
 msgid "Send all"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:23
+#: templates/exhibitors/_email_outbox_body.html:23
 msgid "Discard all"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:35
+#: templates/exhibitors/_email_outbox_body.html:35
 msgid "Scheduled"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:36
-#: exhibition/templates/exhibitors/proposal_list.html:65
+#: templates/exhibitors/_email_outbox_body.html:36
+#: templates/exhibitors/proposal_list.html:65
 msgid "Actions"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:67
-msgid "Send this email"
+#: templates/exhibitors/_email_outbox_body.html:68
+msgid "Send"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:73
-msgid "Edit this email"
+#: templates/exhibitors/_email_outbox_body.html:75
+#: templates/exhibitors/_partner_row.html:54
+#: templates/exhibitors/call_questions.html:73
+#: templates/exhibitors/call_questions.html:76
+#: templates/exhibitors/dashboard.html:120
+#: templates/exhibitors/email_compose.html:55
+#: templates/exhibitors/email_custom_template_form.html:30
+#: templates/exhibitors/email_templates.html:50
+#: templates/exhibitors/email_templates.html:97
+#: templates/exhibitors/public_proposal_list.html:32
+#: templates/exhibitors/settings.html:59
+msgid "Edit"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:79
-msgid "Discard this email"
+#: templates/exhibitors/_email_outbox_body.html:82
+#: templates/exhibitors/email_bulk_discard.html:30
+#: templates/exhibitors/email_delete.html:31
+msgid "Discard"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:91
-#: exhibition/templates/exhibitors/_email_sent_body.html:34
+#: templates/exhibitors/_email_outbox_body.html:95
+#: templates/exhibitors/_email_sent_body.html:35
 msgid "No emails match your search."
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:93
+#: templates/exhibitors/_email_outbox_body.html:97
 msgid "The outbox is empty."
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_sent_body.html:7
-#: exhibition/templates/exhibitors/base.html:105
+#: templates/exhibitors/_email_sent_body.html:7
+#: templates/exhibitors/_partner_row.html:45 templates/exhibitors/base.html:116
 msgid "Sent"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_sent_body.html:36
+#: templates/exhibitors/_email_sent_body.html:37
 msgid "No emails have been sent yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:12
-#: exhibition/templates/exhibitors/public_list.html:29
+#: templates/exhibitors/_filter_form.html:12
+#: templates/exhibitors/public_list.html:29
 msgid "Search"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:18
-#: exhibition/templates/exhibitors/_filter_form.html:20
+#: templates/exhibitors/_filter_form.html:18
+#: templates/exhibitors/_filter_form.html:21
 msgid "Clear filters"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:29
+#: templates/exhibitors/_filter_form.html:30
 msgid "Filters"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:50
+#: templates/exhibitors/_filter_form.html:51
 msgid "Apply filters"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:5
+#: templates/exhibitors/_image_preview_dialog.html:11
+msgid "Close preview"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:5
 #, python-format
 msgid "Select %(name)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:33
+#: templates/exhibitors/_partner_row.html:33
 msgid "Untitled"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:40
+#: templates/exhibitors/_partner_row.html:40
+msgid "Waiting in the outbox"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:41
+msgid "In outbox"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:44
+#, python-format
+msgid "Last sent %(sent)s"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:48
+msgid "Not sent"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:55
 msgid "Copied!"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:40
+#: templates/exhibitors/_partner_row.html:55
 msgid "Copy failed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:40
+#: templates/exhibitors/_partner_row.html:55
 msgid "Key"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:41
-#: exhibition/templates/exhibitors/add.html:231
-#: exhibition/templates/exhibitors/vouchers.html:5
+#: templates/exhibitors/_partner_row.html:56 templates/exhibitors/add.html:235
+#: templates/exhibitors/base.html:42
+#: templates/exhibitors/exhibitor_info.html:95
+#: templates/exhibitors/exhibitor_info.html:125
+#: templates/exhibitors/vouchers.html:5 views.py:2933
 msgid "Vouchers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:42
-#: exhibition/templates/exhibitors/devices.html:5
+#: templates/exhibitors/_partner_row.html:57
+#: templates/exhibitors/devices.html:5
 msgid "Lead-scanning devices"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:45
+#: templates/exhibitors/_partner_row.html:58
+#: templates/exhibitors/call_question_delete.html:19
+#: templates/exhibitors/call_questions.html:74
+#: templates/exhibitors/delete.html:19
+#: templates/exhibitors/email_custom_template_delete.html:19
+#: templates/exhibitors/settings.html:335
+msgid "Delete"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:60
 msgid "Move"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_sort_header.html:7
+#: templates/exhibitors/_sort_header.html:7
 msgid "Sort ascending"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_sort_header.html:10
+#: templates/exhibitors/_sort_header.html:10
 msgid "Sort descending"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:24
+#: templates/exhibitors/add.html:24
 msgid "Profile"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:29
-#: exhibition/templates/exhibitors/add.html:92
-#: exhibition/templates/exhibitors/call_questions.html:62
-#: exhibition/templates/exhibitors/settings.html:50
+#: templates/exhibitors/add.html:29 templates/exhibitors/add.html:92
+#: templates/exhibitors/call_questions.html:62
+#: templates/exhibitors/settings.html:54
 msgid "Optional"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:80
-#: exhibition/templates/exhibitors/public_proposal_form.html:79
+#: templates/exhibitors/add.html:80
+#: templates/exhibitors/public_proposal_form.html:79
 msgid "Add social media link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:137
-#: exhibition/templates/exhibitors/public_proposal_form.html:120
+#: templates/exhibitors/add.html:137
+#: templates/exhibitors/public_proposal_form.html:120
 msgid "Add extra link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:157
-#: exhibition/templates/exhibitors/add.html:160
-#: exhibition/templates/exhibitors/public_proposal_form.html:140
-#: exhibition/templates/exhibitors/public_proposal_form.html:143
+#: templates/exhibitors/add.html:157 templates/exhibitors/add.html:161
+#: templates/exhibitors/public_proposal_form.html:140
+#: templates/exhibitors/public_proposal_form.html:144
 msgid "Logo preview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:162
-#: exhibition/templates/exhibitors/add.html:180
-#: exhibition/templates/exhibitors/public_proposal_form.html:145
-#: exhibition/templates/exhibitors/public_proposal_form.html:163
+#: templates/exhibitors/add.html:164 templates/exhibitors/add.html:184
+#: templates/exhibitors/public_proposal_form.html:147
+#: templates/exhibitors/public_proposal_form.html:167
 msgid "We could not load this image preview."
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:175
-#: exhibition/templates/exhibitors/add.html:178
-#: exhibition/templates/exhibitors/public_proposal_form.html:158
-#: exhibition/templates/exhibitors/public_proposal_form.html:161
+#: templates/exhibitors/add.html:177 templates/exhibitors/add.html:181
+#: templates/exhibitors/public_proposal_form.html:160
+#: templates/exhibitors/public_proposal_form.html:164
 msgid "Header image preview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:196
+#: templates/exhibitors/add.html:200
 msgid "Organizer only"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:237
+#: templates/exhibitors/add.html:241
 msgid "Internal notes"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:244
-#: exhibition/templates/exhibitors/email_edit.html:38
-#: exhibition/templates/exhibitors/public_proposal_form.html:182
-#: exhibition/templates/exhibitors/public_proposal_form.html:186
+#: templates/exhibitors/add.html:248 templates/exhibitors/email_edit.html:38
+#: templates/exhibitors/public_proposal_form.html:186
+#: templates/exhibitors/public_proposal_form.html:190
 msgid "Save changes"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:246
-#: exhibition/templates/exhibitors/call_default_field_form.html:21
-#: exhibition/templates/exhibitors/call_question_form.html:30
-#: exhibition/templates/exhibitors/call_questions.html:96
-#: exhibition/templates/exhibitors/email_custom_template_form.html:51
-#: exhibition/templates/exhibitors/email_templates.html:123
-#: exhibition/templates/exhibitors/proposal_detail.html:188
-#: exhibition/templates/exhibitors/settings.html:85
-#: exhibition/templates/exhibitors/settings.html:170
-#: exhibition/templates/exhibitors/settings.html:269
+#: templates/exhibitors/add.html:250
+#: templates/exhibitors/call_default_field_form.html:21
+#: templates/exhibitors/call_question_form.html:114
+#: templates/exhibitors/call_questions.html:96
+#: templates/exhibitors/email_custom_template_form.html:51
+#: templates/exhibitors/email_templates.html:123
+#: templates/exhibitors/proposal_detail.html:188
+#: templates/exhibitors/settings.html:89 templates/exhibitors/settings.html:217
+#: templates/exhibitors/settings.html:250
+#: templates/exhibitors/settings.html:359
 msgid "Save"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:255
-#: exhibition/templates/exhibitors/call_default_field_form.html:23
-#: exhibition/templates/exhibitors/call_default_field_reset.html:24
-#: exhibition/templates/exhibitors/call_question_delete.html:21
-#: exhibition/templates/exhibitors/call_question_form.html:32
-#: exhibition/templates/exhibitors/delete.html:24
-#: exhibition/templates/exhibitors/email_bulk_discard.html:27
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:21
-#: exhibition/templates/exhibitors/email_custom_template_form.html:53
-#: exhibition/templates/exhibitors/email_delete.html:28
-#: exhibition/templates/exhibitors/proposal_list.html:174
-#: exhibition/templates/exhibitors/public_proposal_form.html:176
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:16
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:21
-#: exhibition/templates/exhibitors/settings.html:194
-#: exhibition/templates/exhibitors/settings.html:270
+#: templates/exhibitors/add.html:259
+#: templates/exhibitors/call_default_field_form.html:23
+#: templates/exhibitors/call_default_field_reset.html:24
+#: templates/exhibitors/call_question_delete.html:21
+#: templates/exhibitors/call_question_form.html:116
+#: templates/exhibitors/delete.html:24
+#: templates/exhibitors/email_bulk_discard.html:27
+#: templates/exhibitors/email_custom_template_delete.html:21
+#: templates/exhibitors/email_custom_template_form.html:53
+#: templates/exhibitors/email_delete.html:28
+#: templates/exhibitors/proposal_list.html:175
+#: templates/exhibitors/public_proposal_form.html:180
+#: templates/exhibitors/public_proposal_reinstate.html:16
+#: templates/exhibitors/public_proposal_withdraw.html:21
+#: templates/exhibitors/settings.html:278
+#: templates/exhibitors/settings.html:360
+#: templates/exhibitors/voucher_bulk_send.html:96
 msgid "Cancel"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:262
-#: exhibition/templates/exhibitors/proposal_detail.html:208
+#: templates/exhibitors/add.html:266
+#: templates/exhibitors/proposal_detail.html:208
 msgid "History"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:11
+#: templates/exhibitors/base.html:17
 msgid "Overview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:18
-#: exhibition/templates/exhibitors/call_questions.html:33
+#: templates/exhibitors/base.html:24
+#: templates/exhibitors/call_questions.html:33
 msgid "Settings"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:26
-#: exhibition/templates/exhibitors/base.html:70
-#: exhibition/templates/exhibitors/dashboard.html:21
-#: exhibition/templates/exhibitors/exhibitor_info.html:4
-#: exhibition/templates/exhibitors/exhibitor_info.html:15
+#: templates/exhibitors/base.html:32 templates/exhibitors/base.html:81
+#: templates/exhibitors/dashboard.html:21
+#: templates/exhibitors/exhibitor_info.html:4
+#: templates/exhibitors/exhibitor_info.html:15
 msgid "Exhibitors"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:31
-#: exhibition/templates/exhibitors/base.html:76
-#: exhibition/templates/exhibitors/dashboard.html:29
-#: exhibition/templates/exhibitors/exhibitor_info.html:4
-#: exhibition/templates/exhibitors/exhibitor_info.html:15
+#: templates/exhibitors/base.html:37 templates/exhibitors/base.html:87
+#: templates/exhibitors/dashboard.html:29
+#: templates/exhibitors/exhibitor_info.html:4
+#: templates/exhibitors/exhibitor_info.html:15
 msgid "Sponsors"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:39
-#: exhibition/templates/exhibitors/dashboard.html:117
+#: templates/exhibitors/base.html:50 templates/exhibitors/dashboard.html:117
 msgid "Call for exhibitors"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:47
+#: templates/exhibitors/base.html:58
 msgid "Content"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:52
-#: exhibition/templates/exhibitors/call_questions.html:5
-#: exhibition/templates/exhibitors/call_questions.html:16
+#: templates/exhibitors/base.html:63 templates/exhibitors/call_questions.html:5
+#: templates/exhibitors/call_questions.html:16
 msgid "Exhibitor form"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:85
+#: templates/exhibitors/base.html:96
 msgid "Message center"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:94
+#: templates/exhibitors/base.html:105
 msgid "Compose"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:99
+#: templates/exhibitors/base.html:110
 msgid "Outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:111
+#: templates/exhibitors/base.html:122
 msgid "Templates"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:130
+#: templates/exhibitors/base.html:141
 msgid "Home"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:134
+#: templates/exhibitors/base.html:145
 msgid "Tickets"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:138
+#: templates/exhibitors/base.html:149
 msgid "Talks"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:143
+#: templates/exhibitors/base.html:154
 msgid "Access videos related to this event"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:144
+#: templates/exhibitors/base.html:155
 msgid "Videos"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_form.html:5
-#: exhibition/templates/exhibitors/call_default_field_form.html:8
-#: exhibition/templates/exhibitors/call_question_form.html:11
-#: exhibition/templates/exhibitors/call_question_form.html:14
+#: templates/exhibitors/call_default_field_form.html:5
+#: templates/exhibitors/call_default_field_form.html:8
+#: templates/exhibitors/call_question_form.html:14
+#: templates/exhibitors/call_question_form.html:17
 msgid "Form field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:4
-#: exhibition/templates/exhibitors/call_default_field_reset.html:7
+#: templates/exhibitors/call_default_field_reset.html:4
+#: templates/exhibitors/call_default_field_reset.html:7
 msgid "Reset form field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:14
+#: templates/exhibitors/call_default_field_reset.html:14
 #, python-format
 msgid ""
 "Are you sure you want to reset \"%(label)s\" back to the default "
 "\"%(default_label)s\"?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:19
+#: templates/exhibitors/call_default_field_reset.html:19
 msgid ""
 "This clears the custom label and help text. Default fields are part of the "
 "form and cannot be deleted; turn the field off with the Active toggle to "
 "hide it."
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:22
-#: exhibition/templates/exhibitors/public_list.html:32
+#: templates/exhibitors/call_default_field_reset.html:22
 msgid "Reset"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_question_delete.html:4
-#: exhibition/templates/exhibitors/call_question_delete.html:7
+#: templates/exhibitors/call_question_delete.html:4
+#: templates/exhibitors/call_question_delete.html:7
 msgid "Delete form field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_question_delete.html:14
+#: templates/exhibitors/call_question_delete.html:14
 #, python-format
 msgid "Are you sure you want to delete the question \"%(question)s\"?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_question_delete.html:19
-#: exhibition/templates/exhibitors/call_questions.html:74
-#: exhibition/templates/exhibitors/delete.html:19
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:19
-msgid "Delete"
+#: templates/exhibitors/call_question_form.html:31
+msgid "Answer options"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:23
+#: templates/exhibitors/call_question_form.html:34
+msgid "Only applicable if you choose a choice field type above."
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:48
+#, python-format
+msgid "Answer option %(id)s"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:56
+#: templates/exhibitors/call_question_form.html:58
+#: templates/exhibitors/call_question_form.html:87
+#: templates/exhibitors/call_question_form.html:89
+msgid "Move option up"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:60
+#: templates/exhibitors/call_question_form.html:62
+#: templates/exhibitors/call_question_form.html:91
+#: templates/exhibitors/call_question_form.html:93
+msgid "Move option down"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:64
+#: templates/exhibitors/call_question_form.html:66
+#: templates/exhibitors/call_question_form.html:95
+#: templates/exhibitors/call_question_form.html:97
+msgid "Delete option"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:81
+msgid "New answer option"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:106
+msgid "Add a new option"
+msgstr ""
+
+#: templates/exhibitors/call_questions.html:23
 msgid "Form fields"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:24
+#: templates/exhibitors/call_questions.html:24
 msgid ""
 "Choose which fields are shown on the exhibitor form and drag any row to "
 "reorder it."
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:29
-#: exhibition/templates/exhibitors/proposal_detail.html:38
+#: templates/exhibitors/call_questions.html:29
+#: templates/exhibitors/proposal_detail.html:38
 msgid "Field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:32
+#: templates/exhibitors/call_questions.html:32
 msgid "Answers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:42
+#: templates/exhibitors/call_questions.html:42
 msgid "Custom"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:48
+#: templates/exhibitors/call_questions.html:48
 #, python-format
 msgid "Toggle active state for %(field)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:61
+#: templates/exhibitors/call_questions.html:61
 #, python-format
 msgid "Required status for %(field)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:73
-#: exhibition/templates/exhibitors/call_questions.html:76
-#: exhibition/templates/exhibitors/dashboard.html:120
-#: exhibition/templates/exhibitors/email_compose.html:55
-#: exhibition/templates/exhibitors/email_custom_template_form.html:30
-#: exhibition/templates/exhibitors/email_templates.html:50
-#: exhibition/templates/exhibitors/email_templates.html:97
-#: exhibition/templates/exhibitors/public_proposal_list.html:32
-#: exhibition/templates/exhibitors/settings.html:55
-msgid "Edit"
-msgstr ""
-
-#: exhibition/templates/exhibitors/call_questions.html:77
+#: templates/exhibitors/call_questions.html:77
 msgid "Reset to default"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:79
+#: templates/exhibitors/call_questions.html:79
 msgid "Move field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:90
+#: templates/exhibitors/call_questions.html:90
 msgid "New custom field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:5
-#: exhibition/templates/exhibitors/dashboard.html:9
+#: templates/exhibitors/dashboard.html:5 templates/exhibitors/dashboard.html:9
 msgid "Exhibition overview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:39
+#: templates/exhibitors/dashboard.html:39
 msgid "Requests awaiting review"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:48
+#: templates/exhibitors/dashboard.html:48
 msgid "Emails in outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:61
+#: templates/exhibitors/dashboard.html:61
 msgid "Recent requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:64
+#: templates/exhibitors/dashboard.html:64
 msgid "View all"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:76
+#: templates/exhibitors/dashboard.html:76
 msgid "Submitted"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:91
-#: exhibition/templates/exhibitors/proposal_detail.html:97
-#: exhibition/templates/exhibitors/proposal_list.html:97
+#: templates/exhibitors/dashboard.html:91
+#: templates/exhibitors/proposal_detail.html:97
+#: templates/exhibitors/proposal_list.html:97
 msgid "Sponsor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:93
-#: exhibition/templates/exhibitors/proposal_detail.html:99
-#: exhibition/templates/exhibitors/proposal_list.html:99
+#: templates/exhibitors/dashboard.html:93
+#: templates/exhibitors/proposal_detail.html:99
+#: templates/exhibitors/proposal_list.html:99
 msgid "Exhibitor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:105
+#: templates/exhibitors/dashboard.html:105
 msgid "No requests have been submitted yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:128
+#: templates/exhibitors/dashboard.html:128
 msgid "The call is not published, so nobody can submit a request."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:131
+#: templates/exhibitors/dashboard.html:131
 msgid "Open"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:134
+#: templates/exhibitors/dashboard.html:134
 #, python-format
 msgid "Closes on %(deadline)s."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:139
+#: templates/exhibitors/dashboard.html:139
 msgid "No deadline set."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:142
+#: templates/exhibitors/dashboard.html:142
 msgid "Closed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:144
+#: templates/exhibitors/dashboard.html:144
 #, python-format
 msgid "The deadline passed on %(deadline)s."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:151
+#: templates/exhibitors/dashboard.html:151
 msgid "Private — reachable only with the secret link."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:157
-#: exhibition/templates/exhibitors/settings.html:90
-#: exhibition/templates/exhibitors/settings.html:94
+#: templates/exhibitors/dashboard.html:157
+#: templates/exhibitors/settings.html:94 templates/exhibitors/settings.html:98
 msgid "View call page"
 msgstr ""
 
-#: exhibition/templates/exhibitors/delete.html:11
+#: templates/exhibitors/delete.html:11
 #, python-format
 msgid ""
 "Are you sure you want to delete “%(name)s”? This action cannot be undone."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:8
+#: templates/exhibitors/devices.html:8
 #, python-format
 msgid "Lead-scanning devices for %(name)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:13
+#: templates/exhibitors/devices.html:13
 #, python-brace-format
 msgid ""
 "Provision check-in app devices for this partner. Each device gets its own "
@@ -1674,66 +1709,64 @@ msgid ""
 "through the {device_tokens} placeholder."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:21
+#: templates/exhibitors/devices.html:21
 msgid ""
 "Provisioning devices requires organizer-level permissions. Ask an organizer "
 "admin to create the devices for this partner."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:29
+#: templates/exhibitors/devices.html:29
 msgid "Provisioned devices"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:35
+#: templates/exhibitors/devices.html:35
 msgid "Device"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:36
+#: templates/exhibitors/devices.html:36
 msgid "Setup token"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:37
+#: templates/exhibitors/devices.html:37
 msgid "Status"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:47
+#: templates/exhibitors/devices.html:47
 msgid "Connected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:49
+#: templates/exhibitors/devices.html:49
 msgid "Awaiting setup"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:60
+#: templates/exhibitors/devices.html:60
 msgid ""
 "Generate new setup tokens? Any device that is already scanning will be "
 "disconnected and must be set up again."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:65
+#: templates/exhibitors/devices.html:65
 msgid "Generate new setup tokens"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:70
+#: templates/exhibitors/devices.html:70
 msgid "No devices have been provisioned for this partner yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:80
-#: exhibition/templates/exhibitors/devices.html:85
+#: templates/exhibitors/devices.html:80 templates/exhibitors/devices.html:85
 msgid "Add devices"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:87
-#: exhibition/templates/exhibitors/vouchers.html:88
+#: templates/exhibitors/devices.html:87 templates/exhibitors/vouchers.html:133
 msgid "Back"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_bulk_discard.html:4
-#: exhibition/templates/exhibitors/email_bulk_discard.html:7
+#: templates/exhibitors/email_bulk_discard.html:4
+#: templates/exhibitors/email_bulk_discard.html:7
 msgid "Discard emails"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_bulk_discard.html:19
+#: templates/exhibitors/email_bulk_discard.html:19
 #, python-format
 msgid ""
 "Are you sure you want to discard %(counter)s queued email? This cannot be "
@@ -1744,80 +1777,80 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/templates/exhibitors/email_bulk_discard.html:30
-#: exhibition/templates/exhibitors/email_delete.html:31
-msgid "Discard"
-msgstr ""
-
-#: exhibition/templates/exhibitors/email_compose.html:7
-#: exhibition/templates/exhibitors/email_compose.html:16
+#: templates/exhibitors/email_compose.html:7
+#: templates/exhibitors/email_compose.html:16
 msgid "Compose email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:21
+#: templates/exhibitors/email_compose.html:21
 msgid ""
 "Send an update to a group of applicants. One email is queued per recipient, "
 "with placeholders resolved individually."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:26
+#: templates/exhibitors/email_compose.html:26
 msgid "Load from template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:28
+#: templates/exhibitors/email_compose.html:28
 msgid "Select a saved template…"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:33
+#: templates/exhibitors/email_compose.html:33
 msgid "Load"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:41
-#: exhibition/templates/exhibitors/email_edit.html:23
+#: templates/exhibitors/email_compose.html:41
+#: templates/exhibitors/email_edit.html:23
 msgid "Recipients"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:47
+#: templates/exhibitors/email_compose.html:47
 msgid "Message"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:58
-#: exhibition/templates/exhibitors/email_custom_template_form.html:33
-#: exhibition/templates/exhibitors/email_templates.html:53
-#: exhibition/templates/exhibitors/email_templates.html:100
-#: exhibition/templates/exhibitors/settings.html:58
+#: templates/exhibitors/email_compose.html:51
+msgctxt "form"
+msgid "required"
+msgstr ""
+
+#: templates/exhibitors/email_compose.html:58
+#: templates/exhibitors/email_custom_template_form.html:33
+#: templates/exhibitors/email_templates.html:53
+#: templates/exhibitors/email_templates.html:100
+#: templates/exhibitors/settings.html:62
 msgid "Preview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:80
+#: templates/exhibitors/email_compose.html:80
 msgid "Save to outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:83
+#: templates/exhibitors/email_compose.html:83
 msgid "Send / Schedule"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:4
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:7
+#: templates/exhibitors/email_custom_template_delete.html:4
+#: templates/exhibitors/email_custom_template_delete.html:7
 msgid "Delete custom template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:14
+#: templates/exhibitors/email_custom_template_delete.html:14
 #, python-format
 msgid "Are you sure you want to delete the custom template \"%(name)s\"?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_custom_template_form.html:7
-#: exhibition/templates/exhibitors/email_custom_template_form.html:15
+#: templates/exhibitors/email_custom_template_form.html:7
+#: templates/exhibitors/email_custom_template_form.html:15
 msgid "Custom template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_delete.html:4
-#: exhibition/templates/exhibitors/email_delete.html:7
+#: templates/exhibitors/email_delete.html:4
+#: templates/exhibitors/email_delete.html:7
 msgid "Discard email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_delete.html:15
+#: templates/exhibitors/email_delete.html:15
 #, python-format
 msgid ""
 "Are you sure you want to discard the email “%(subject)s” to %(counter)s "
@@ -1828,908 +1861,1198 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/templates/exhibitors/email_delete.html:21
+#: templates/exhibitors/email_delete.html:21
 #, python-format
 msgid ""
 "Are you sure you want to discard the email “%(subject)s” to %(to)s? This "
 "cannot be undone."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:5
+#: templates/exhibitors/email_edit.html:5
 msgid "Edit email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:8
+#: templates/exhibitors/email_edit.html:8
 msgid "Preview / edit email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:14
+#: templates/exhibitors/email_edit.html:14
 msgid "Back to outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:41
+#: templates/exhibitors/email_edit.html:41
 msgid "Save & send"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_outbox.html:12
-#: exhibition/templates/exhibitors/email_outbox.html:15
+#: templates/exhibitors/email_outbox.html:12
+#: templates/exhibitors/email_outbox.html:15
 msgid "Email outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_outbox.html:20
+#: templates/exhibitors/email_outbox.html:20
 msgid ""
 "Emails waiting to be sent. Review, edit, or discard them before sending."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_sent.html:12
-#: exhibition/templates/exhibitors/email_sent.html:15
+#: templates/exhibitors/email_sent.html:12
+#: templates/exhibitors/email_sent.html:15
 msgid "Sent emails"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:7
-#: exhibition/templates/exhibitors/email_templates.html:16
+#: templates/exhibitors/email_templates.html:7
+#: templates/exhibitors/email_templates.html:16
 msgid "Email templates"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:22
+#: templates/exhibitors/email_templates.html:22
 msgid "New template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:27
+#: templates/exhibitors/email_templates.html:27
 msgid ""
 "These templates are used for the confirmation email sent when an applicant "
 "submits a request, and for the accept/reject emails you send from the outbox."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:81
+#: templates/exhibitors/email_templates.html:81
 msgid "Discard this template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:31
+#: templates/exhibitors/exhibitor_info.html:31
 msgid "No organizations match your filters."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:33
+#: templates/exhibitors/exhibitor_info.html:33
 msgid "You don't have any sponsors yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:35
+#: templates/exhibitors/exhibitor_info.html:35
 msgid "You don't have any exhibitors yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:37
+#: templates/exhibitors/exhibitor_info.html:37
 msgid "You don't have any exhibitors or sponsors yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:43
-#: exhibition/templates/exhibitors/exhibitor_info.html:52
-#: exhibition/views.py:1837
+#: templates/exhibitors/exhibitor_info.html:43
+#: templates/exhibitors/exhibitor_info.html:57 views.py:1979
 msgid "Add a Sponsor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:43
-#: exhibition/templates/exhibitors/exhibitor_info.html:52
-#: exhibition/views.py:1838
+#: templates/exhibitors/exhibitor_info.html:43
+#: templates/exhibitors/exhibitor_info.html:57 views.py:1980
 msgid "Add an Exhibitor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:43
-#: exhibition/templates/exhibitors/exhibitor_info.html:52
-#: exhibition/views.py:1839
+#: templates/exhibitors/exhibitor_info.html:43
+#: templates/exhibitors/exhibitor_info.html:57 views.py:1981
 msgid "Add an Exhibitor or Sponsor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:48
-#: exhibition/templates/exhibitors/proposal_list.html:169
+#: templates/exhibitors/exhibitor_info.html:48
+#: templates/exhibitors/proposal_list.html:170
 msgid "selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:54
+#: templates/exhibitors/exhibitor_info.html:59
 msgid "Download access keys as CSV"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:56
+#: templates/exhibitors/exhibitor_info.html:61
 msgid "Download sponsor keys"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:56
+#: templates/exhibitors/exhibitor_info.html:61
 msgid "Download exhibitor keys"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:56
+#: templates/exhibitors/exhibitor_info.html:61
 msgid "Download access keys"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:65
+#: templates/exhibitors/exhibitor_info.html:64
+msgid "Queue a voucher email for everyone in this list"
+msgstr ""
+
+#: templates/exhibitors/exhibitor_info.html:65
+msgid "Send vouchers to all"
+msgstr ""
+
+#: templates/exhibitors/exhibitor_info.html:75
 msgid ""
 "Drag-and-drop ordering is available only on the unfiltered, single-page list."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:70
+#: templates/exhibitors/exhibitor_info.html:80
 msgid "Booth"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:78
-#: exhibition/templates/exhibitors/exhibitor_info.html:106
+#: templates/exhibitors/exhibitor_info.html:88
+#: templates/exhibitors/exhibitor_info.html:117
 msgid "Select all partners"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:84
-#: exhibition/templates/exhibitors/exhibitor_info.html:112
+#: templates/exhibitors/exhibitor_info.html:94
+#: templates/exhibitors/exhibitor_info.html:123
 msgid "Group"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:12
-#: exhibition/templates/exhibitors/proposal_detail.html:15
+#: templates/exhibitors/proposal_detail.html:12
+#: templates/exhibitors/proposal_detail.html:15
 msgid "Review exhibition request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:21
+#: templates/exhibitors/proposal_detail.html:21
 msgid "Back to exhibition requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:29
+#: templates/exhibitors/proposal_detail.html:29
 #, python-format
 msgid "Changes made by the applicant after acceptance (%(when)s)"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:39
+#: templates/exhibitors/proposal_detail.html:39
 msgid "Before acceptance"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:40
+#: templates/exhibitors/proposal_detail.html:40
 msgid "After edit"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:55
+#: templates/exhibitors/proposal_detail.html:55
 msgid "The applicant edited the profile, but the tracked fields are unchanged."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:57
+#: templates/exhibitors/proposal_detail.html:57
 msgid ""
 "This profile was edited before change tracking was available, so the "
 "original values are not recorded."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:69
-#: exhibition/templates/exhibitors/proposal_list.html:20
+#: templates/exhibitors/proposal_detail.html:69
+#: templates/exhibitors/proposal_list.html:20
 msgid "Submitter"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:80
+#: templates/exhibitors/proposal_detail.html:80
 msgid "Hidden"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:121
+#: templates/exhibitors/proposal_detail.html:121
 msgid "Message to organizers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:129
+#: templates/exhibitors/proposal_detail.html:129
 msgid "Links"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:152
+#: templates/exhibitors/proposal_detail.html:152
 msgid "Download"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:154
+#: templates/exhibitors/proposal_detail.html:154
 msgid "Custom answers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:176
+#: templates/exhibitors/proposal_detail.html:176
 msgid "Review"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:192
-#: exhibition/templates/exhibitors/proposal_list.html:117
-#: exhibition/templates/exhibitors/proposal_list.html:164
+#: templates/exhibitors/proposal_detail.html:192
+#: templates/exhibitors/proposal_list.html:118
+#: templates/exhibitors/proposal_list.html:165
 msgid "Approve"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:195
-#: exhibition/templates/exhibitors/proposal_list.html:122
-#: exhibition/templates/exhibitors/proposal_list.html:165
+#: templates/exhibitors/proposal_detail.html:195
+#: templates/exhibitors/proposal_list.html:123
+#: templates/exhibitors/proposal_list.html:166
 msgid "Reject"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:200
+#: templates/exhibitors/proposal_detail.html:200
 msgid "Open profile"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:22
+#: templates/exhibitors/proposal_list.html:22
 msgid "Updated"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:33
+#: templates/exhibitors/proposal_list.html:33
 msgid "Select at least one request."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:34
+#: templates/exhibitors/proposal_list.html:34
 msgid "None of the selected requests can be approved."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:35
+#: templates/exhibitors/proposal_list.html:35
 msgid "None of the selected requests can be rejected."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:36
+#: templates/exhibitors/proposal_list.html:36
 #, python-brace-format
 msgid "{count} selected requests cannot be approved and will be skipped."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:37
+#: templates/exhibitors/proposal_list.html:37
 #, python-brace-format
 msgid "{count} selected requests cannot be rejected and will be skipped."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:41
+#: templates/exhibitors/proposal_list.html:41
 msgid "Approve selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:44
+#: templates/exhibitors/proposal_list.html:44
 msgid "Reject selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:55
+#: templates/exhibitors/proposal_list.html:55
 msgid "Select all matching requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:75
+#: templates/exhibitors/proposal_list.html:75
 msgid "Select request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:106
+#: templates/exhibitors/proposal_list.html:106
 msgid "Edited after acceptance, see detail view for changes."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:127
-#: exhibition/templates/exhibitors/proposal_list.html:166
-#: exhibition/templates/exhibitors/public_proposal_list.html:39
+#: templates/exhibitors/proposal_list.html:128
+#: templates/exhibitors/proposal_list.html:167
+#: templates/exhibitors/public_proposal_list.html:39
 msgid "Withdraw"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:132
-#: exhibition/templates/exhibitors/proposal_list.html:167
+#: templates/exhibitors/proposal_list.html:133
+#: templates/exhibitors/proposal_list.html:168
 msgid "Reopen for review"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:137
-#: exhibition/templates/exhibitors/public_proposal_list.html:34
+#: templates/exhibitors/proposal_list.html:138
+#: templates/exhibitors/public_proposal_list.html:34
 msgid "View"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:149
+#: templates/exhibitors/proposal_list.html:150
 msgid "No exhibition requests match your filters."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:151
+#: templates/exhibitors/proposal_list.html:152
 msgid "No exhibition requests have been submitted yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:159
+#: templates/exhibitors/proposal_list.html:160
 msgid "Approve the selected requests and create their partner profiles?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:160
+#: templates/exhibitors/proposal_list.html:161
 msgid "Reject the selected requests?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:161
+#: templates/exhibitors/proposal_list.html:162
 msgid "Reject this request?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:162
+#: templates/exhibitors/proposal_list.html:163
 msgid "Withdraw this request?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:163
+#: templates/exhibitors/proposal_list.html:164
 msgid "Reopen this request for review?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:168
+#: templates/exhibitors/proposal_list.html:169
 msgid "The action could not be completed. Please try again."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:170
+#: templates/exhibitors/proposal_list.html:171
 msgid ""
 "Approve every request matching the current filters, including those on other "
 "pages?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:171
+#: templates/exhibitors/proposal_list.html:172
 msgid ""
 "Reject every request matching the current filters, including those on other "
 "pages?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:172
+#: templates/exhibitors/proposal_list.html:173
 msgid "Please confirm"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:173
+#: templates/exhibitors/proposal_list.html:174
 msgid "Confirm"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:14
+#: templates/exhibitors/public_call.html:14
 msgid "Submit a request to become an exhibitor for this event."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:20
+#: templates/exhibitors/public_call.html:20
 #, python-format
 msgid "You can submit requests until %(deadline)s (%(timezone)s)."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:24
+#: templates/exhibitors/public_call.html:24
 #, python-format
 msgid "This call closed on %(deadline)s (%(timezone)s)."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:34
+#: templates/exhibitors/public_call.html:34
 msgid "View your requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:40
-#: exhibition/templates/exhibitors/public_proposal_form.html:18
-#: exhibition/templates/exhibitors/public_proposal_list.html:65
+#: templates/exhibitors/public_call.html:40
+#: templates/exhibitors/public_proposal_form.html:18
+#: templates/exhibitors/public_proposal_list.html:65
 msgid "Submit a request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:42
+#: templates/exhibitors/public_call.html:42
 msgid "Requests are closed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:21
-#: exhibition/templates/exhibitors/public_detail.html:94
+#: templates/exhibitors/public_detail.html:21
+#: templates/exhibitors/public_detail.html:93
 msgid "Previous"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:24
-#: exhibition/templates/exhibitors/public_detail.html:98
+#: templates/exhibitors/public_detail.html:24
+#: templates/exhibitors/public_detail.html:97
 msgid "Next"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:47
+#: templates/exhibitors/public_detail.html:47
 msgid "Get In Touch"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:87
-#: exhibition/templates/exhibitors/public_detail.html:103
+#: templates/exhibitors/public_detail.html:87
+#: templates/exhibitors/public_detail.html:102
 msgid "Open slides PDF"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:88
-#, python-brace-format
-msgid "Slide {current} of {total}"
-msgstr ""
-
-#: exhibition/templates/exhibitors/public_detail.html:112
+#: templates/exhibitors/public_detail.html:111
 msgid "Send email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:126
+#: templates/exhibitors/public_detail.html:125
 msgid "Visit website"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_list.html:54
+#: templates/exhibitors/public_list.html:32
+msgid "Clear"
+msgstr ""
+
+#: templates/exhibitors/public_list.html:54
 msgid "No exhibitors match your search."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_list.html:56
+#: templates/exhibitors/public_list.html:56
 msgid "No exhibitors are currently available."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:16
+#: templates/exhibitors/public_proposal_form.html:16
 msgid "Edit request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:23
-#: exhibition/views.py:883
+#: templates/exhibitors/public_proposal_form.html:23 views.py:958
 msgid "This request can no longer be edited."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:186
+#: templates/exhibitors/public_proposal_form.html:190
 msgid "Submit request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:189
+#: templates/exhibitors/public_proposal_form.html:193
 msgid "or save as draft for now"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:199
+#: templates/exhibitors/public_proposal_form.html:203
 msgid "Back to your requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:5
+#: templates/exhibitors/public_proposal_list.html:5
 msgid "Your exhibition requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:13
+#: templates/exhibitors/public_proposal_list.html:13
 msgid "Last modified"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:23
+#: templates/exhibitors/public_proposal_list.html:23
 msgid "Withdrawn"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:44
+#: templates/exhibitors/public_proposal_list.html:44
 msgid "Reinstate"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:56
+#: templates/exhibitors/public_proposal_list.html:56
 msgid "Create a new request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:61
+#: templates/exhibitors/public_proposal_list.html:61
 msgid "You have not submitted an exhibition request yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:5
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:21
+#: templates/exhibitors/public_proposal_reinstate.html:5
+#: templates/exhibitors/public_proposal_reinstate.html:21
 msgid "Reinstate request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:7
+#: templates/exhibitors/public_proposal_reinstate.html:7
 #, python-format
 msgid ""
 "Do you want to reinstate your withdrawn request “%(name)s”? It will be "
 "pending review again."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:5
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:26
+#: templates/exhibitors/public_proposal_withdraw.html:5
+#: templates/exhibitors/public_proposal_withdraw.html:26
 msgid "Withdraw request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:7
+#: templates/exhibitors/public_proposal_withdraw.html:7
 #, python-format
 msgid "Are you sure you want to withdraw your request “%(name)s”?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:13
+#: templates/exhibitors/public_proposal_withdraw.html:13
 msgid ""
 "This request has already been approved. Withdrawing it will hide the "
 "exhibitor or sponsor profile created from it from public listings."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:10
-#: exhibition/templates/exhibitors/settings.html:27
+#: templates/exhibitors/settings.html:10 templates/exhibitors/settings.html:29
 msgid "Sponsor Settings"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:12
-#: exhibition/templates/exhibitors/settings.html:29
+#: templates/exhibitors/settings.html:12 templates/exhibitors/settings.html:31
+msgid "Voucher Settings"
+msgstr ""
+
+#: templates/exhibitors/settings.html:14 templates/exhibitors/settings.html:33
 msgid "Exhibitor Settings"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:42
+#: templates/exhibitors/settings.html:46
 msgid "Publish your call"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:43
+#: templates/exhibitors/settings.html:47
 msgid "Publish a login-required application form for exhibitors."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:72
+#: templates/exhibitors/settings.html:76
 msgid ""
 "This panel renders unsaved draft text using the same styling as the live "
 "public call page."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:104
+#: templates/exhibitors/settings.html:108
 msgid "Secret call link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:107
+#: templates/exhibitors/settings.html:111
 msgid ""
 "This call is private: it is not linked anywhere public. Share the link below "
 "with the organizations you want to invite. Anyone who has it can open the "
 "call and apply."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:113
+#: templates/exhibitors/settings.html:117
 msgid "Copied"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:113
+#: templates/exhibitors/settings.html:117
 msgid "Copy to clipboard"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:114
+#: templates/exhibitors/settings.html:118
 msgid "Copy"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:119
+#: templates/exhibitors/settings.html:123
 msgid ""
 "Regenerate the secret link? The current link will stop working immediately."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:125
+#: templates/exhibitors/settings.html:129
 msgid "Regenerate link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:127
+#: templates/exhibitors/settings.html:131
 msgid "Regenerating immediately invalidates the current link."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:138
+#: templates/exhibitors/settings.html:143
+msgid "Voucher pools"
+msgstr ""
+
+#: templates/exhibitors/settings.html:147
+msgid ""
+"Create the voucher codes under Tickets → Vouchers and give them a tag, then "
+"pick that tag here. Exhibitors and sponsors are handed codes from the pool "
+"you choose. Reload this page to pick up a tag you just created."
+msgstr ""
+
+#: templates/exhibitors/settings.html:157
+msgid "Create vouchers pool"
+msgstr ""
+
+#: templates/exhibitors/settings.html:159
+msgid "(opens in a new tab)"
+msgstr ""
+
+#: templates/exhibitors/settings.html:168
+#: templates/exhibitors/settings.html:182
+#, python-format
+msgid "%(counter)s voucher in this pool is not assigned to anyone yet."
+msgid_plural ""
+"%(counter)s vouchers in this pool are not assigned to anyone yet."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: templates/exhibitors/settings.html:194
+msgid "How many each one gets"
+msgstr ""
+
+#: templates/exhibitors/settings.html:196
+msgid ""
+"Applies to any exhibitor or sponsor that does not belong to a sponsor group. "
+"Sponsor groups set their own number on the Sponsors page, and an individual "
+"exhibitor or sponsor can be given a different number on their own voucher "
+"page."
+msgstr ""
+
+#: templates/exhibitors/settings.html:206
+msgid "Voucher email"
+msgstr ""
+
+#: templates/exhibitors/settings.html:208
+msgid "Applies to the voucher email sent to exhibitors and sponsors alike."
+msgstr ""
+
+#: templates/exhibitors/settings.html:228
 msgid "Data access"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:139
+#: templates/exhibitors/settings.html:229
 msgid ""
 "In this section, you can control which attendee data is shared with "
 "exhibitors when an exhibitor voucher is used or when the exhibitor uses the "
 "lead scanning app."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:142
+#: templates/exhibitors/settings.html:232
 msgid "Exhibitor vouchers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:158
-msgid "Exhibitor login"
-msgstr ""
-
-#: exhibition/templates/exhibitors/settings.html:160
-msgid ""
-"The access-code email sent to exhibitors is now edited together with the "
-"plugin's other email templates."
-msgstr ""
-
-#: exhibition/templates/exhibitors/settings.html:162
-msgid "Edit email templates"
-msgstr ""
-
-#: exhibition/templates/exhibitors/settings.html:177
+#: templates/exhibitors/settings.html:257
 msgid "Group List"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:180
+#: templates/exhibitors/settings.html:260
 msgid "Add a Group"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:193
+#: templates/exhibitors/settings.html:272
+#: templates/exhibitors/settings.html:354
+msgid "Voucher defaults for this group"
+msgstr ""
+
+#: templates/exhibitors/settings.html:277
 msgid "Add"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:204
+#: templates/exhibitors/settings.html:288
 msgid "Group Name"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:206
+#: templates/exhibitors/settings.html:290
 msgid "Partners"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:207
+#: templates/exhibitors/settings.html:291
 msgid "Front Page"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:220
-#: exhibition/templates/exhibitors/settings.html:226
+#: templates/exhibitors/settings.html:304
+#: templates/exhibitors/settings.html:310
 msgid "Show this sponsor group in the Supported By section on the front page."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:251
+#: templates/exhibitors/settings.html:326
+msgid "Edit sponsor group"
+msgstr ""
+
+#: templates/exhibitors/settings.html:337
 msgid "Reorder sponsor group"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:281
+#: templates/exhibitors/settings.html:371
 msgid "You do not have any sponsor groups yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:8
+#: templates/exhibitors/voucher_bulk_send.html:4
+#: templates/exhibitors/voucher_bulk_send.html:7
+msgid "Send vouchers"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:18
+#, python-format
+msgid "A voucher email will be placed in the outbox for %(counter)s sponsor."
+msgid_plural ""
+"A voucher email will be placed in the outbox for %(counter)s sponsors."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:24
+#, python-format
+msgid "A voucher email will be placed in the outbox for %(counter)s exhibitor."
+msgid_plural ""
+"A voucher email will be placed in the outbox for %(counter)s exhibitors."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:37
+#, python-format
+msgid "&mdash; %(counter)s voucher will be created"
+msgid_plural "&mdash; %(counter)s vouchers will be created"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:45
+#, python-format
+msgid "&mdash; %(counter)s existing voucher"
+msgid_plural "&mdash; %(counter)s existing vouchers"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:58
+msgid "None of the sponsors in this list can be emailed yet."
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:60
+msgid "None of the exhibitors in this list can be emailed yet."
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:66
+msgid "Skipped: no email address"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:75
+msgid "Skipped: voucher count is set to 0"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:84
+msgid "Skipped: no vouchers available from their pool"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:86
+msgid ""
+"Check that a voucher pool is selected under Settings → Vouchers and that it "
+"still has unassigned codes."
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:99
+msgid "Queue emails"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:8
 #, python-format
 msgid "Vouchers for %(name)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:13
+#: templates/exhibitors/vouchers.html:13
 msgid ""
-"Issue ticket vouchers for this partner to hand out. Whoever redeems one on "
-"the ticket shop becomes a lead this partner can retrieve, as long as voucher "
+"Hand this exhibitor or sponsor codes from the voucher pool. Whoever redeems "
+"one on the ticket shop becomes a lead they can retrieve, as long as voucher "
 "data access is enabled for them."
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:20
-msgid "Issued vouchers"
+#: templates/exhibitors/vouchers.html:20
+msgid "Assigned vouchers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:24
+#: templates/exhibitors/vouchers.html:24
 msgid "Download codes (CSV)"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:31
+#: templates/exhibitors/vouchers.html:31
 msgid "Code"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:32 exhibition/views.py:1994
+#: templates/exhibitors/vouchers.html:32 utils.py:495
 msgid "Product"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:34 exhibition/views.py:1998
+#: templates/exhibitors/vouchers.html:33 utils.py:496
+msgid "Price effect"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:34 utils.py:499
 msgid "Redeemed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:56
+#: templates/exhibitors/vouchers.html:35 utils.py:498
+msgid "Valid until"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:56
 msgid "Already redeemed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:67
-msgid "No vouchers have been issued for this partner yet."
+#: templates/exhibitors/vouchers.html:62
+msgid "Return to pool"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:76
-msgid "Issue new vouchers"
+#: templates/exhibitors/vouchers.html:74
+msgid "No vouchers have been assigned to this partner yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:86
-msgid "Create vouchers"
+#: templates/exhibitors/vouchers.html:82
+msgid "Take more from the pool"
 msgstr ""
 
-#: exhibition/templates/sponsors/presale_supported_by.html:4
+#: templates/exhibitors/vouchers.html:84
+msgid ""
+"Codes come from the voucher pool chosen under Settings. The email always "
+"carries this partner's complete list of codes, so you can assign some now "
+"and send them together with more later. It is placed in the outbox for you "
+"to review before it goes out."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:92
+#, python-format
+msgid "%(counter)s voucher is left unassigned in the pool."
+msgid_plural "%(counter)s vouchers are left unassigned in the pool."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: templates/exhibitors/vouchers.html:100 views.py:2230
+msgid "No voucher pool is selected yet. Choose one under Settings → Vouchers."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:106
+msgid "A voucher email for this partner is waiting in the outbox."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:108
+msgid "Go to outbox"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:114
+#, python-format
+msgid "Vouchers were last emailed to this partner on %(sent)s."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:120
+msgid ""
+"This partner has no email address on file, so vouchers cannot be emailed."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:127
+msgid "Assign and prepare email"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:130
+msgid "Assign without emailing"
+msgstr ""
+
+#: templates/sponsors/presale_supported_by.html:4
 msgid "Supported By"
 msgstr ""
 
-#: exhibition/views.py:324
+#: utils.py:493
+msgid "Voucher code"
+msgstr ""
+
+#: utils.py:494
+msgid "Redeem link"
+msgstr ""
+
+#: utils.py:497
+msgid "Value"
+msgstr ""
+
+#: utils.py:500
+msgid "Maximum usages"
+msgstr ""
+
+#: views.py:342
 msgid "Company name"
 msgstr ""
 
-#: exhibition/views.py:325
+#: views.py:343
 msgid "Job title"
 msgstr ""
 
-#: exhibition/views.py:326
+#: views.py:344
 msgid "Address"
 msgstr ""
 
-#: exhibition/views.py:333
+#: views.py:351
 msgid "Attendee Name"
 msgstr ""
 
-#: exhibition/views.py:338
+#: views.py:356
 msgid "Attendee Email"
 msgstr ""
 
-#: exhibition/views.py:377
+#: views.py:395 views.py:412
 msgid "Settings have been saved."
 msgstr ""
 
-#: exhibition/views.py:393
+#: views.py:428
 msgid "Call settings have been saved."
 msgstr ""
 
-#: exhibition/views.py:401
+#: views.py:436
 msgid ""
 "A new secret call link has been generated. The old link no longer works."
 msgstr ""
 
-#: exhibition/views.py:416
+#: views.py:451
 msgid "Sponsor group added."
 msgstr ""
 
-#: exhibition/views.py:437
+#: views.py:454 views.py:477 views.py:853 views.py:1169 views.py:1796
+#: views.py:1918 views.py:2564 views.py:3025
+msgid "We could not save your changes. See below for details."
+msgstr ""
+
+#: views.py:474
 msgid "Sponsor group updated."
 msgstr ""
 
-#: exhibition/views.py:452
+#: views.py:491
 msgid "This sponsor group cannot be deleted while it is assigned to partners."
 msgstr ""
 
-#: exhibition/views.py:460
+#: views.py:499
 msgid "Unknown action."
 msgstr ""
 
-#: exhibition/views.py:505
+#: views.py:544
 msgid "Access key"
 msgstr ""
 
-#: exhibition/views.py:745 exhibition/views.py:1060
+#: views.py:819 views.py:1135
 msgid "Add at least one social media link."
 msgstr ""
 
-#: exhibition/views.py:754 exhibition/views.py:1069
+#: views.py:828 views.py:1144
 msgid "Add at least one extra link."
 msgstr ""
 
-#: exhibition/views.py:809
+#: views.py:884
 msgid "The call for exhibitors is closed."
 msgstr ""
 
-#: exhibition/views.py:837
+#: views.py:912
 msgid "Your request has been saved."
 msgstr ""
 
-#: exhibition/views.py:920 exhibition/views.py:1776
+#: views.py:995 views.py:1914
 msgid "Your changes have been saved."
 msgstr ""
 
-#: exhibition/views.py:953
+#: views.py:1028
 msgid "This proposal can no longer be withdrawn."
 msgstr ""
 
-#: exhibition/views.py:961
+#: views.py:1036
 msgid "Your request has been withdrawn."
 msgstr ""
 
-#: exhibition/views.py:963
+#: views.py:1038
 msgid "This request can no longer be withdrawn."
 msgstr ""
 
-#: exhibition/views.py:989 exhibition/views.py:999
+#: views.py:1064 views.py:1074
 msgid "This request can no longer be reinstated."
 msgstr ""
 
-#: exhibition/views.py:997
+#: views.py:1072
 msgid "Your request has been reinstated and is pending review again."
 msgstr ""
 
-#: exhibition/views.py:1121
+#: views.py:1197
 msgid "Invalid request body."
 msgstr ""
 
-#: exhibition/views.py:1124 exhibition/views.py:1129
+#: views.py:1200 views.py:1205
 msgid "Invalid sponsor group IDs."
 msgstr ""
 
-#: exhibition/views.py:1133
+#: views.py:1209
 msgid "Sponsor group IDs must be unique."
 msgstr ""
 
-#: exhibition/views.py:1141
+#: views.py:1217
 msgid "Reorder request must include each sponsor group exactly once."
 msgstr ""
 
-#: exhibition/views.py:1346
+#: views.py:1422
 msgid "This request can no longer be changed to that state."
 msgstr ""
 
-#: exhibition/views.py:1350
+#: views.py:1426
 msgid "Review details saved."
 msgstr ""
 
-#: exhibition/views.py:1359
+#: views.py:1435
 msgid ""
 "Request approved and partner profile created. An acceptance email was placed "
 "in the outbox."
 msgstr ""
 
-#: exhibition/views.py:1369
+#: views.py:1445
 msgid "Request rejected. A rejection email was placed in the outbox."
 msgstr ""
 
-#: exhibition/views.py:1372
+#: views.py:1448
 msgid "Request withdrawn."
 msgstr ""
 
-#: exhibition/views.py:1375
+#: views.py:1451
 msgid "Request reopened for review."
 msgstr ""
 
-#: exhibition/views.py:1407
+#: views.py:1483
 msgid "No valid action was selected."
 msgstr ""
 
-#: exhibition/views.py:1454
+#: views.py:1530
 #, python-format
 msgid "%(count)d request was approved."
 msgid_plural "%(count)d requests were approved."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1455
+#: views.py:1531
 #, python-format
 msgid "%(count)d request was rejected."
 msgid_plural "%(count)d requests were rejected."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1456
+#: views.py:1532
 #, python-format
 msgid "%(count)d request was withdrawn."
 msgid_plural "%(count)d requests were withdrawn."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1457
+#: views.py:1533
 #, python-format
 msgid "%(count)d request was reopened."
 msgid_plural "%(count)d requests were reopened."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1461
+#: views.py:1537
 msgid "No proposals were updated."
 msgstr ""
 
-#: exhibition/views.py:1464
+#: views.py:1540
 #, python-format
 msgid "%(skipped)d was skipped because it was already processed."
 msgid_plural "%(skipped)d were skipped because they were already processed."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1605
+#: views.py:1681
 msgid "Exhibitor form settings have been saved."
 msgstr ""
 
-#: exhibition/views.py:1730
+#: views.py:1868
 msgid "The requested form field does not exist."
 msgstr ""
 
-#: exhibition/views.py:1791
+#: views.py:1933
 msgid "The field has been reset to its default."
 msgstr ""
 
-#: exhibition/views.py:1829 exhibition/views.py:1900
+#: views.py:1971 views.py:2042
 msgid "An access-credentials email was placed in the outbox."
 msgstr ""
 
-#: exhibition/views.py:1907
+#: views.py:2049
 msgid "Edit Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1908
+#: views.py:2050
 msgid "Edit Exhibitor"
 msgstr ""
 
-#: exhibition/views.py:1909
+#: views.py:2051
 msgid "Edit Exhibitor & Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1910
+#: views.py:2052
 msgid "Edit Exhibitor or Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1940
+#: views.py:2082
 msgid "Delete Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1941
+#: views.py:2083
 msgid "Delete Exhibitor"
 msgstr ""
 
-#: exhibition/views.py:1942
+#: views.py:2084
 msgid "Delete Exhibitor & Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1943
+#: views.py:2085
 msgid "Delete Exhibitor or Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1992
-msgid "Voucher code"
+#: views.py:2164
+msgid "This voucher has already been redeemed and cannot be returned."
 msgstr ""
 
-#: exhibition/views.py:1993
-msgid "Redeem link"
+#: views.py:2170
+msgid ""
+"This code was already included in a voucher email to this partner, so it "
+"cannot be returned to the pool. Delete it under Tickets → Vouchers instead."
 msgstr ""
 
-#: exhibition/views.py:1999
-msgid "Maximum usages"
+#: views.py:2176
+msgid "Voucher returned to the pool."
 msgstr ""
 
-#: exhibition/views.py:2035
-msgid "This voucher has already been redeemed and cannot be removed."
+#: views.py:2207
+msgid "Enter how many vouchers to take from the pool."
 msgstr ""
 
-#: exhibition/views.py:2040
-msgid "Voucher removed."
-msgstr ""
-
-#: exhibition/views.py:2060
+#: views.py:2215
 #, python-format
-msgid "%(count)d voucher created."
-msgid_plural "%(count)d vouchers created."
+msgid "%(count)d voucher taken from the pool."
+msgid_plural "%(count)d vouchers taken from the pool."
 msgstr[0] ""
 msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
 
-#: exhibition/views.py:2112
+#: views.py:2232
+#, python-format
+msgid ""
+"The pool only has %(remaining)d voucher(s) left, so %(count)d cannot be "
+"taken."
+msgstr ""
+
+#: views.py:2244
+msgid "No email address is on file, so vouchers cannot be emailed."
+msgstr ""
+
+#: views.py:2253
+msgid "This partner holds no vouchers yet, so there is nothing to email."
+msgstr ""
+
+#: views.py:2259
+#, python-format
+msgid "An email with %(count)d voucher code was placed in the outbox."
+msgid_plural "An email with %(count)d voucher codes was placed in the outbox."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: views.py:2347
+msgid "There is nobody to send vouchers to in this list."
+msgstr ""
+
+#: views.py:2354
+#, python-format
+msgid "%(count)d voucher email was placed in the outbox."
+msgid_plural "%(count)d voucher emails were placed in the outbox."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: views.py:2371
+#, python-format
+msgid ""
+"%(count)d was skipped because no unassigned codes were available from their "
+"pool."
+msgid_plural ""
+"%(count)d were skipped because no unassigned codes were available from their "
+"pool."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: views.py:2386
+#, python-format
+msgid "%(count)d sponsor was skipped because it has no email address."
+msgid_plural ""
+"%(count)d sponsors were skipped because they have no email address."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: views.py:2392
+#, python-format
+msgid "%(count)d exhibitor was skipped because it has no email address."
+msgid_plural ""
+"%(count)d exhibitors were skipped because they have no email address."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: views.py:2401
+#, python-format
+msgid "%(count)d sponsor was skipped because their voucher count is set to 0."
+msgid_plural ""
+"%(count)d sponsors were skipped because their voucher count is set to 0."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: views.py:2407
+#, python-format
+msgid ""
+"%(count)d exhibitor was skipped because their voucher count is set to 0."
+msgid_plural ""
+"%(count)d exhibitors were skipped because their voucher count is set to 0."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: views.py:2461
 #, python-format
 msgid "%(count)d device added."
 msgid_plural "%(count)d devices added."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2123
+#: views.py:2472
 #, python-format
 msgid ""
 "New setup tokens generated. %(count)d device that was already scanning is "
@@ -2740,79 +3063,95 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2132
+#: views.py:2481
 msgid "New setup tokens generated."
 msgstr ""
 
-#: exhibition/views.py:2194
+#: views.py:2543
 msgid "No applicants matched the selected filters."
 msgstr ""
 
-#: exhibition/views.py:2202
+#: views.py:2551
 #, python-format
 msgid "%(count)d emails have been scheduled."
 msgstr ""
 
-#: exhibition/views.py:2206
+#: views.py:2555
 #, python-format
 msgid "%(count)d emails have been sent."
 msgstr ""
 
-#: exhibition/views.py:2210
+#: views.py:2559
 #, python-format
 msgid "%(count)d emails have been placed in the outbox."
 msgstr ""
 
-#: exhibition/views.py:2385
+#: views.py:2738
 msgid "The emails have been saved and sent."
 msgstr ""
 
-#: exhibition/views.py:2389
+#: views.py:2742
 msgid "The emails have been saved."
 msgstr ""
 
-#: exhibition/views.py:2395
+#: views.py:2748
 msgid "The email has been saved and sent."
 msgstr ""
 
-#: exhibition/views.py:2399
+#: views.py:2752
 msgid "The email has been saved."
 msgstr ""
 
-#: exhibition/views.py:2423 exhibition/views.py:2497
+#: views.py:2776 views.py:2850
 #, python-format
 msgid "%(count)d email has been sent."
 msgid_plural "%(count)d emails have been sent."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2459
+#: views.py:2812
 msgid "The email has been discarded."
 msgstr ""
 
-#: exhibition/views.py:2501 exhibition/views.py:2514 exhibition/views.py:2519
+#: views.py:2854 views.py:2867 views.py:2872
 msgid "No emails were selected."
 msgstr ""
 
-#: exhibition/views.py:2510
+#: views.py:2863
 #, python-format
 msgid "%(count)d email has been discarded."
 msgid_plural "%(count)d emails have been discarded."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2594
+#: views.py:2929
+msgid "Request received (confirmation)"
+msgstr ""
+
+#: views.py:2930
+msgid "Request accepted"
+msgstr ""
+
+#: views.py:2931
+msgid "Request rejected"
+msgstr ""
+
+#: views.py:2932
+msgid "Exhibitor lead scanning key"
+msgstr ""
+
+#: views.py:2948
 msgid "Email templates have been saved."
 msgstr ""
 
-#: exhibition/views.py:2617 exhibition/views.py:2621
+#: views.py:2971 views.py:2975
 msgid "Unknown template."
 msgstr ""
 
-#: exhibition/views.py:2667
+#: views.py:3021
 msgid "Custom template has been created."
 msgstr ""
 
-#: exhibition/views.py:2683
+#: views.py:3041
 msgid "Custom template has been deleted."
 msgstr ""

--- a/exhibition/locale/ur/LC_MESSAGES/django.po
+++ b/exhibition/locale/ur/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 10:29+0000\n"
+"POT-Creation-Date: 2026-09-11 11:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,595 +18,531 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: exhibition/apps.py:14 exhibition/apps.py:17 exhibition/signals.py:157
-#: exhibition/templates/exhibitors/public_list.html:6
-#: exhibition/templates/exhibitors/public_list.html:14
-#: exhibition/templates/exhibitors/public_list.html:16
+#: apps.py:14 apps.py:17 signals.py:163 templates/exhibitors/public_list.html:6
+#: templates/exhibitors/public_list.html:14
+#: templates/exhibitors/public_list.html:16
 msgid "Exhibition"
 msgstr ""
 
-#: exhibition/apps.py:19
+#: apps.py:19
 msgid "This plugin enables to add and control exhibitors in eventyay"
 msgstr ""
 
-#: exhibition/filters.py:9
+#: filters.py:9
 msgid "Any"
 msgstr ""
 
-#: exhibition/filters.py:10
+#: filters.py:10
 msgid "Enabled"
 msgstr ""
 
-#: exhibition/filters.py:11 exhibition/templates/exhibitors/dashboard.html:127
+#: filters.py:11 templates/exhibitors/dashboard.html:127
 msgid "Disabled"
 msgstr ""
 
-#: exhibition/filters.py:15
+#: filters.py:15
 msgid "All types"
 msgstr ""
 
-#: exhibition/filters.py:16
+#: filters.py:16
 msgid "Exhibitor only"
 msgstr ""
 
-#: exhibition/filters.py:17
+#: filters.py:17
 msgid "Sponsor only"
 msgstr ""
 
-#: exhibition/filters.py:18 exhibition/templates/exhibitors/dashboard.html:89
-#: exhibition/templates/exhibitors/proposal_detail.html:95
-#: exhibition/templates/exhibitors/proposal_list.html:95
+#: filters.py:18 templates/exhibitors/dashboard.html:89
+#: templates/exhibitors/proposal_detail.html:95
+#: templates/exhibitors/proposal_list.html:95
 msgid "Exhibitor and sponsor"
 msgstr ""
 
-#: exhibition/filters.py:80 exhibition/filters.py:81
+#: filters.py:80 filters.py:81
 msgid "Search requests…"
 msgstr ""
 
-#: exhibition/filters.py:81
+#: filters.py:81
 msgid "Search requests"
 msgstr ""
 
-#: exhibition/filters.py:85 exhibition/templates/exhibitors/dashboard.html:75
-#: exhibition/templates/exhibitors/proposal_detail.html:85
-#: exhibition/templates/exhibitors/proposal_list.html:21
-#: exhibition/templates/exhibitors/public_proposal_list.html:12
+#: filters.py:85 templates/exhibitors/dashboard.html:75
+#: templates/exhibitors/proposal_detail.html:85
+#: templates/exhibitors/proposal_list.html:21
+#: templates/exhibitors/public_proposal_list.html:12
 msgid "State"
 msgstr ""
 
-#: exhibition/filters.py:86
+#: filters.py:86
 msgid "All states"
 msgstr ""
 
-#: exhibition/filters.py:90 exhibition/templates/exhibitors/dashboard.html:74
-#: exhibition/templates/exhibitors/proposal_detail.html:91
-#: exhibition/templates/exhibitors/proposal_list.html:62
+#: filters.py:90 templates/exhibitors/dashboard.html:74
+#: templates/exhibitors/proposal_detail.html:91
+#: templates/exhibitors/proposal_list.html:62
 msgid "Type"
 msgstr ""
 
-#: exhibition/filters.py:99 exhibition/filters.py:102
+#: filters.py:99 filters.py:102
 msgid "Search by name…"
 msgstr ""
 
-#: exhibition/filters.py:103
+#: filters.py:103
 msgid "Search requests by name"
 msgstr ""
 
-#: exhibition/filters.py:132 exhibition/filters.py:133
+#: filters.py:132 filters.py:133
 msgid "Search organizations…"
 msgstr ""
 
-#: exhibition/filters.py:133
+#: filters.py:133
 msgid "Search organizations"
 msgstr ""
 
-#: exhibition/filters.py:137
+#: filters.py:137
 msgid "Visibility"
 msgstr ""
 
-#: exhibition/filters.py:139
+#: filters.py:139
 msgid "All organizations"
 msgstr ""
 
-#: exhibition/filters.py:140 exhibition/forms.py:1512
-#: exhibition/templates/exhibitors/call_questions.html:30
+#: filters.py:140 forms.py:1553 templates/exhibitors/call_questions.html:30
 msgid "Active"
 msgstr ""
 
-#: exhibition/filters.py:141
+#: filters.py:141
 msgid "Inactive"
 msgstr ""
 
-#: exhibition/filters.py:146 exhibition/filters.py:207 exhibition/forms.py:207
-#: exhibition/forms.py:1410 exhibition/forms.py:1841
+#: filters.py:146 filters.py:207 forms.py:212 forms.py:1411 forms.py:1888
 msgid "Sponsor group"
 msgstr ""
 
-#: exhibition/filters.py:149 exhibition/filters.py:210
+#: filters.py:149 filters.py:210
 msgid "All groups"
 msgstr ""
 
-#: exhibition/filters.py:152 exhibition/templates/exhibitors/add.html:222
+#: filters.py:152 templates/exhibitors/add.html:226
 msgid "Lead scanning"
 msgstr ""
 
-#: exhibition/filters.py:157
+#: filters.py:157
 msgid "Lead access"
 msgstr ""
 
-#: exhibition/filters.py:162
+#: filters.py:162
 msgid "Voucher access"
 msgstr ""
 
-#: exhibition/filters.py:202 exhibition/filters.py:203
+#: filters.py:202 filters.py:203
 msgid "Search exhibitors…"
 msgstr ""
 
-#: exhibition/filters.py:203
+#: filters.py:203
 msgid "Search exhibitors"
 msgstr ""
 
-#: exhibition/filters.py:240 exhibition/filters.py:241
+#: filters.py:240 filters.py:241
 msgid "Search emails…"
 msgstr ""
 
-#: exhibition/filters.py:241
+#: filters.py:241
 msgid "Search emails"
 msgstr ""
 
-#: exhibition/forms.py:67
+#: forms.py:72
 #, python-format
 msgid "Times are in the event timezone: %(tz)s."
 msgstr ""
 
-#: exhibition/forms.py:128 exhibition/forms.py:139 exhibition/forms.py:933
-#: exhibition/forms.py:944
+#: forms.py:133 forms.py:144 forms.py:934 forms.py:945
 msgid "— No selection —"
 msgstr ""
 
-#: exhibition/forms.py:211
+#: forms.py:216
 msgid "Can view voucher redemptions"
 msgstr ""
 
-#: exhibition/forms.py:213 exhibition/forms.py:397
+#: forms.py:218 forms.py:402
 msgid ""
 "Lets this exhibitor or sponsor retrieve the attendees who redeemed vouchers "
 "issued to them. Separate from lead scanning, which covers attendees scanned "
 "at the booth."
 msgstr ""
 
-#: exhibition/forms.py:219
+#: forms.py:224
 msgid "Can view and export collected leads"
 msgstr ""
 
-#: exhibition/forms.py:221
+#: forms.py:226
 msgid ""
 "Lets this exhibitor retrieve the full list of leads they have already "
 "scanned. Turn this off to let them keep scanning without seeing the "
 "collected attendee data."
 msgstr ""
 
-#: exhibition/forms.py:226
+#: forms.py:231
 msgid "Lead scanning behavior"
 msgstr ""
 
-#: exhibition/forms.py:231
+#: forms.py:236
 msgid ""
 "Every attendee is one lead, even when scanned from multiple devices. Notes "
 "and ratings are shared between devices."
 msgstr ""
 
-#: exhibition/forms.py:238
+#: forms.py:243
 msgid ""
 "Every attendee is a new lead when scanned from a new device. Notes and "
 "ratings are specific to the device."
 msgstr ""
 
-#: exhibition/forms.py:251
+#: forms.py:256
 msgid "Comment"
 msgstr ""
 
-#: exhibition/forms.py:253
+#: forms.py:258
 msgid ""
 "The text entered in this field will not be visible to the user and is "
 "available for your convenience."
 msgstr ""
 
-#: exhibition/forms.py:258 exhibition/forms.py:1427 exhibition/views.py:505
+#: forms.py:263 forms.py:1428 views.py:544
 msgid "Booth ID"
 msgstr ""
 
-#: exhibition/forms.py:291 exhibition/forms.py:1027 exhibition/forms.py:1076
-#: exhibition/models.py:130
+#: forms.py:296 forms.py:1028 forms.py:1077 models.py:130
 msgid "Organization name"
 msgstr ""
 
-#: exhibition/forms.py:292 exhibition/forms.py:1030 exhibition/forms.py:1077
-#: exhibition/models.py:136
+#: forms.py:297 forms.py:1031 forms.py:1078 models.py:136
 msgid "Organization description"
 msgstr ""
 
-#: exhibition/forms.py:293 exhibition/forms.py:1078
+#: forms.py:298 forms.py:1079
 msgid "E-mail"
 msgstr ""
 
-#: exhibition/forms.py:294 exhibition/forms.py:1079 exhibition/models.py:139
+#: forms.py:299 forms.py:1080 models.py:139
 msgid "Contact page URL"
 msgstr ""
 
-#: exhibition/forms.py:295 exhibition/forms.py:1080 exhibition/models.py:140
+#: forms.py:300 forms.py:1081 models.py:140
 msgid "Promotional video URL"
 msgstr ""
 
-#: exhibition/forms.py:296 exhibition/forms.py:1081 exhibition/models.py:141
+#: forms.py:301 forms.py:1082 models.py:141
 msgid "Promotional slides"
 msgstr ""
 
-#: exhibition/forms.py:297 exhibition/forms.py:1082 exhibition/models.py:142
-#: exhibition/models.py:520
-#: exhibition/templates/exhibitors/proposal_detail.html:111
+#: forms.py:302 forms.py:1083 models.py:142 models.py:568
+#: templates/exhibitors/proposal_detail.html:111
 msgid "Logo"
 msgstr ""
 
-#: exhibition/forms.py:298 exhibition/forms.py:1083 exhibition/models.py:145
-#: exhibition/templates/exhibitors/proposal_detail.html:113
+#: forms.py:303 forms.py:1084 models.py:145
+#: templates/exhibitors/proposal_detail.html:113
 msgid "Header image"
 msgstr ""
 
-#: exhibition/forms.py:299 exhibition/forms.py:1084 exhibition/models.py:138
+#: forms.py:304 forms.py:1085 models.py:138
 msgid "Organization website"
 msgstr ""
 
-#: exhibition/forms.py:300
+#: forms.py:305
 msgid "Mark this partner as an exhibitor"
 msgstr ""
 
-#: exhibition/forms.py:301
+#: forms.py:306
 msgid "Mark this partner as an event sponsor"
 msgstr ""
 
-#: exhibition/forms.py:302 exhibition/forms.py:1036 exhibition/forms.py:1085
-#: exhibition/models.py:148 exhibition/models.py:522
+#: forms.py:307 forms.py:1037 forms.py:1086 models.py:148 models.py:570
 msgid "Preferred booth name"
 msgstr ""
 
-#: exhibition/forms.py:303
+#: forms.py:308
 msgid "Can scan attendee badges"
 msgstr ""
 
-#: exhibition/forms.py:307
+#: forms.py:312
 msgid ""
 "Lets this exhibitor sign in to the lead scanning app and scan attendees at "
 "their booth. Turn this off to block scanning entirely."
 msgstr ""
 
-#: exhibition/forms.py:348 exhibition/forms.py:1441
+#: forms.py:353 forms.py:1442
 msgid "No sponsor group"
 msgstr ""
 
-#: exhibition/forms.py:385
+#: forms.py:390
 msgid ""
 "Lets this exhibitor retrieve the attendees who redeemed vouchers issued to "
 "them. Separate from lead scanning, which covers attendees scanned at the "
 "booth."
 msgstr ""
 
-#: exhibition/forms.py:389
+#: forms.py:394
 msgid ""
 "Lets this sponsor retrieve the attendees who redeemed vouchers issued to "
 "them. Separate from lead scanning, which covers attendees scanned at the "
 "booth."
 msgstr ""
 
-#: exhibition/forms.py:393
+#: forms.py:398
 msgid ""
 "Lets this exhibitor and sponsor retrieve the attendees who redeemed vouchers "
 "issued to them. Separate from lead scanning, which covers attendees scanned "
 "at the booth."
 msgstr ""
 
-#: exhibition/forms.py:466 exhibition/forms.py:553 exhibition/forms.py:1361
-#: exhibition/forms.py:1375
+#: forms.py:471 forms.py:558 forms.py:1362 forms.py:1376 forms.py:1855
+#: forms.py:1924 forms.py:1930 forms.py:1932 forms.py:1934
 msgid "This field is required."
 msgstr ""
 
-#: exhibition/forms.py:511 exhibition/forms.py:516
+#: forms.py:516 forms.py:521
 msgid "Slides upload must be a PDF file."
 msgstr ""
 
-#: exhibition/forms.py:540
+#: forms.py:545
 msgid "A partner must be marked as an exhibitor, a sponsor, or both."
 msgstr ""
 
-#: exhibition/forms.py:615
+#: forms.py:620
 msgid "Devices to add"
 msgstr ""
 
-#: exhibition/forms.py:617
+#: forms.py:622
 msgid ""
 "How many new devices to provision now, in addition to any already listed "
 "above. Each device gets its own single-use setup token and QR code."
 msgstr ""
 
-#: exhibition/forms.py:627
-msgid "Select a product…"
+#: forms.py:635
+msgid "Vouchers to take from the pool"
 msgstr ""
 
-#: exhibition/forms.py:628
-msgid "Ticket product"
+#: forms.py:636
+msgid ""
+"Set to 0 to email the codes this partner already has without taking any more."
 msgstr ""
 
-#: exhibition/forms.py:629
-msgid "The product a redeemed voucher applies to."
-msgstr ""
-
-#: exhibition/forms.py:635
-msgid "Number of vouchers"
-msgstr ""
-
-#: exhibition/forms.py:640
-msgid "Maximum usages per voucher"
-msgstr ""
-
-#: exhibition/forms.py:645 exhibition/templates/exhibitors/vouchers.html:33
-#: exhibition/views.py:1995
-msgid "Price effect"
-msgstr ""
-
-#: exhibition/forms.py:651 exhibition/views.py:1996
-msgid "Value"
-msgstr ""
-
-#: exhibition/forms.py:652
-msgid "Amount or percentage, depending on the selected price effect."
-msgstr ""
-
-#: exhibition/forms.py:657 exhibition/templates/exhibitors/vouchers.html:35
-#: exhibition/views.py:1997
-msgid "Valid until"
-msgstr ""
-
-#: exhibition/forms.py:673
-msgid "Enter a value for the selected price effect."
-msgstr ""
-
-#: exhibition/forms.py:678 exhibition/models.py:295
-#: exhibition/templates/exhibitors/settings.html:205
+#: forms.py:647 models.py:326 templates/exhibitors/settings.html:289
 msgid "Level"
 msgstr ""
 
-#: exhibition/forms.py:685 exhibition/models.py:294
+#: forms.py:654 models.py:325
 msgid "Group name"
 msgstr ""
 
-#: exhibition/forms.py:718
+#: forms.py:677 models.py:225
+msgid "Exhibitor voucher pool"
+msgstr ""
+
+#: forms.py:678 models.py:232
+msgid "Sponsor voucher pool"
+msgstr ""
+
+#: forms.py:698
+msgid "— No pool selected —"
+msgstr ""
+
+#: forms.py:699
+msgid "— Use the exhibitor pool —"
+msgstr ""
+
+#: forms.py:719
 msgid "Enable call"
 msgstr ""
 
-#: exhibition/forms.py:719
+#: forms.py:720
 msgid "Hide call page after the deadline"
 msgstr ""
 
-#: exhibition/forms.py:720
+#: forms.py:721
 msgid "Make this call private (accessible only via a secret link)"
 msgstr ""
 
-#: exhibition/forms.py:724
+#: forms.py:725
 msgid ""
 "Turn the call on. Keep it enabled for private calls too, otherwise the "
 "secret link stops working."
 msgstr ""
 
-#: exhibition/forms.py:727
+#: forms.py:728
 msgid ""
 "The call page is not linked anywhere public and can only be opened with the "
 "secret link shown below."
 msgstr ""
 
-#: exhibition/forms.py:868
+#: forms.py:869
 msgid "Your answer"
 msgstr ""
 
-#: exhibition/forms.py:1024 exhibition/models.py:563
-#: exhibition/templates/exhibitors/proposal_detail.html:88
+#: forms.py:1025 models.py:611 templates/exhibitors/proposal_detail.html:88
 msgid "Language"
 msgstr ""
 
-#: exhibition/forms.py:1025
+#: forms.py:1026
 msgid "The language you are filling in this form with."
 msgstr ""
 
-#: exhibition/forms.py:1086 exhibition/models.py:151 exhibition/models.py:523
-#: exhibition/models.py:602
+#: forms.py:1087 models.py:151 models.py:571 models.py:650
 msgid "Message to the organizers"
 msgstr ""
 
-#: exhibition/forms.py:1149
+#: forms.py:1150
 msgid ""
 "The organization name is locked after acceptance. Contact the organizers to "
 "change it."
 msgstr ""
 
-#: exhibition/forms.py:1425
+#: forms.py:1426
 msgid "Approve as exhibitor"
 msgstr ""
 
-#: exhibition/forms.py:1426
+#: forms.py:1427
 msgid "Approve as sponsor"
 msgstr ""
 
-#: exhibition/forms.py:1428 exhibition/models.py:352 exhibition/models.py:596
-#: exhibition/models.py:966 exhibition/views.py:505
+#: forms.py:1429 models.py:383 models.py:644 models.py:1014 views.py:544
 msgid "Booth name"
 msgstr ""
 
-#: exhibition/forms.py:1429 exhibition/forms.py:1459 exhibition/models.py:607
+#: forms.py:1430 forms.py:1460 models.py:655
 msgid "Internal review notes"
 msgstr ""
 
-#: exhibition/forms.py:1470
+#: forms.py:1471
 msgid "Field label"
 msgstr ""
 
-#: exhibition/forms.py:1475 exhibition/forms.py:1510
+#: forms.py:1476 forms.py:1551
 msgid "Help text"
 msgstr ""
 
-#: exhibition/forms.py:1476
+#: forms.py:1477
 msgid "Shown below the field on the exhibitor form."
 msgstr ""
 
-#: exhibition/forms.py:1483
+#: forms.py:1484
 #, python-format
 msgid "Leave empty to use the default: %(label)s"
 msgstr ""
 
-#: exhibition/forms.py:1492
-msgid "Options"
-msgstr ""
-
-#: exhibition/forms.py:1493
-msgid "For choice fields, enter one option per line."
-msgstr ""
-
-#: exhibition/forms.py:1508
-msgid "Field type"
-msgstr ""
-
-#: exhibition/forms.py:1509 exhibition/models.py:878
-msgid "Custom question"
-msgstr ""
-
-#: exhibition/forms.py:1511
-#: exhibition/templates/exhibitors/call_questions.html:31
-#: exhibition/templates/exhibitors/call_questions.html:63
-msgid "Required"
-msgstr ""
-
-#: exhibition/forms.py:1535
+#: forms.py:1523
 msgid "Please provide at least one option for this question type."
 msgstr ""
 
-#: exhibition/forms.py:1576 exhibition/forms.py:1665
+#: forms.py:1549
+msgid "Field type"
+msgstr ""
+
+#: forms.py:1550 models.py:926
+msgid "Custom question"
+msgstr ""
+
+#: forms.py:1552 templates/exhibitors/call_questions.html:31
+#: templates/exhibitors/call_questions.html:63
+msgid "Required"
+msgstr ""
+
+#: forms.py:1583 forms.py:1672
 msgid "Choose social platform"
 msgstr ""
 
-#: exhibition/forms.py:1578 exhibition/forms.py:1667
+#: forms.py:1585 forms.py:1674
 msgid "Social platform"
 msgstr ""
 
-#: exhibition/forms.py:1582 exhibition/forms.py:1671
+#: forms.py:1589 forms.py:1678
 msgid "Profile or path"
 msgstr ""
 
-#: exhibition/forms.py:1596 exhibition/forms.py:1685
+#: forms.py:1603 forms.py:1692
 msgid "Profile, handle, or full URL"
 msgstr ""
 
-#: exhibition/forms.py:1616 exhibition/forms.py:1705
+#: forms.py:1623 forms.py:1712
 msgid "Please enter a profile, handle, or URL or remove this row."
 msgstr ""
 
-#: exhibition/forms.py:1622 exhibition/forms.py:1711
+#: forms.py:1629 forms.py:1718
 msgid "Please choose a social platform."
 msgstr ""
 
-#: exhibition/forms.py:1626 exhibition/forms.py:1715
+#: forms.py:1633 forms.py:1722
 msgid "Please enter a profile, handle, or URL."
 msgstr ""
 
-#: exhibition/forms.py:1648 exhibition/forms.py:1737
+#: forms.py:1655 forms.py:1744
 msgid "Link label"
 msgstr ""
 
-#: exhibition/forms.py:1654 exhibition/forms.py:1743
+#: forms.py:1661 forms.py:1750
 msgid "https://example.com"
 msgstr ""
 
-#: exhibition/forms.py:1807
+#: forms.py:1848
 msgid ""
 "Leave empty to keep this in the outbox until sent manually. Time is "
 "interpreted in the event timezone."
 msgstr ""
 
-#: exhibition/forms.py:1814 exhibition/forms.py:1877
+#: forms.py:1861 forms.py:1940
 msgid "The scheduled time must be in the future."
 msgstr ""
 
-#: exhibition/forms.py:1822
+#: forms.py:1869
 msgid "Exhibitors and sponsors"
 msgstr ""
 
-#: exhibition/forms.py:1823
+#: forms.py:1870
 msgid "Exhibitors only"
 msgstr ""
 
-#: exhibition/forms.py:1824
+#: forms.py:1871
 msgid "Sponsors only"
 msgstr ""
 
-#: exhibition/forms.py:1828
+#: forms.py:1875
 msgid "Application state"
 msgstr ""
 
-#: exhibition/forms.py:1836
+#: forms.py:1883
 msgid "Partner type"
 msgstr ""
 
-#: exhibition/forms.py:1844
+#: forms.py:1891
 msgid "Any sponsor group"
 msgstr ""
 
-#: exhibition/forms.py:1846 exhibition/models.py:1035 exhibition/models.py:1089
-#: exhibition/templates/exhibitors/_email_outbox_body.html:6
-#: exhibition/templates/exhibitors/_email_sent_body.html:6
+#: forms.py:1893 forms.py:1953 models.py:1084 models.py:1146
+#: templates/exhibitors/_email_outbox_body.html:6
+#: templates/exhibitors/_email_sent_body.html:6
 msgid "Subject"
 msgstr ""
 
-#: exhibition/forms.py:1848
+#: forms.py:1895
 msgid "Send at"
 msgstr ""
 
-#: exhibition/forms.py:1851
+#: forms.py:1898
 msgid "Leave empty to send immediately or save to the outbox."
 msgstr ""
 
-#: exhibition/forms.py:1859 exhibition/models.py:1036 exhibition/models.py:1090
+#: forms.py:1906 forms.py:1960 models.py:1085 models.py:1147
 msgid "Body"
 msgstr ""
 
-#: exhibition/forms.py:1885 exhibition/views.py:2576
-msgid "Request received (confirmation)"
-msgstr ""
-
-#: exhibition/forms.py:1886 exhibition/views.py:2577
-msgid "Request accepted"
-msgstr ""
-
-#: exhibition/forms.py:1887 exhibition/views.py:2578
-msgid "Request rejected"
-msgstr ""
-
-#: exhibition/forms.py:1888 exhibition/views.py:2579
-msgid "Exhibitor lead scanning key"
-msgstr ""
-
-#: exhibition/forms.py:1897
-#, python-format
-msgid "%(role)s — subject"
-msgstr ""
-
-#: exhibition/forms.py:1904
-#, python-format
-msgid "%(role)s — body"
-msgstr ""
-
-#: exhibition/mail.py:57
+#: mail.py:59
 #, python-brace-format
 msgid "We received your request for {event_name}"
 msgstr ""
 
-#: exhibition/mail.py:59
+#: mail.py:61
 #, python-brace-format
 msgid ""
 "Hello,\n"
@@ -621,12 +557,12 @@ msgid ""
 "The {event_name} team"
 msgstr ""
 
-#: exhibition/mail.py:69
+#: mail.py:71
 #, python-brace-format
 msgid "Your request for {event_name} has been accepted"
 msgstr ""
 
-#: exhibition/mail.py:71
+#: mail.py:73
 #, python-brace-format
 msgid ""
 "Hello,\n"
@@ -638,12 +574,12 @@ msgid ""
 "The {event_name} team"
 msgstr ""
 
-#: exhibition/mail.py:80
+#: mail.py:82
 #, python-brace-format
 msgid "Update on your request for {event_name}"
 msgstr ""
 
-#: exhibition/mail.py:82
+#: mail.py:84
 #, python-brace-format
 msgid ""
 "Hello,\n"
@@ -657,12 +593,12 @@ msgid ""
 "The {event_name} team"
 msgstr ""
 
-#: exhibition/mail.py:91
+#: mail.py:93
 #, python-brace-format
 msgid "Lead Scanning Access for {event_name}"
 msgstr ""
 
-#: exhibition/mail.py:93
+#: mail.py:95
 #, python-brace-format
 msgid ""
 "Hello {exhibitor_name},\n"
@@ -688,983 +624,1080 @@ msgid ""
 "The {event_name} Team"
 msgstr ""
 
-#: exhibition/mail.py:174
+#: mail.py:110
+#, python-brace-format
+msgid "Your vouchers for {event_name} — {exhibitor_name}"
+msgstr ""
+
+#: mail.py:112
+#, python-brace-format
+msgid ""
+"Dear {exhibitor_name},\n"
+"\n"
+"Thank you for participating in {event_name}. Please share the voucher codes "
+"below with your audience — anyone who uses one gets credited to you as a "
+"lead.\n"
+"\n"
+"{voucher_list}\n"
+"\n"
+"They can redeem a code on the event ticket shop at checkout.\n"
+"\n"
+"If you have any questions, please don't hesitate to reach out.\n"
+"\n"
+"Best regards,\n"
+"The {event_name} Team"
+msgstr ""
+
+#: mail.py:190
 msgid "This value will be replaced based on dynamic parameters."
 msgstr ""
 
-#: exhibition/models.py:137 exhibition/models.py:515
+#: mail.py:312
+#, python-format
+msgid "…and %(count)d more voucher code in the attached CSV file."
+msgid_plural "…and %(count)d more voucher codes in the attached CSV file."
+msgstr[0] ""
+msgstr[1] ""
+
+#: models.py:137 models.py:563
 msgid "Contact email"
 msgstr ""
 
-#: exhibition/models.py:156
-#: exhibition/templates/exhibitors/proposal_detail.html:132
+#: models.py:156 templates/exhibitors/proposal_detail.html:132
 msgid "Social media"
 msgstr ""
 
-#: exhibition/models.py:161
-#: exhibition/templates/exhibitors/proposal_detail.html:140
+#: models.py:161 templates/exhibitors/proposal_detail.html:140
 msgid "Extra links"
 msgstr ""
 
-#: exhibition/models.py:216
+#: models.py:212
+msgid "Vouchers per exhibitor"
+msgstr ""
+
+#: models.py:226
+msgid ""
+"The voucher tag created under Tickets → Vouchers that exhibitors draw their "
+"codes from."
+msgstr ""
+
+#: models.py:233
+msgid "Leave empty to draw sponsor codes from the exhibitor pool as well."
+msgstr ""
+
+#: models.py:239
+msgid "Attach voucher list as CSV"
+msgstr ""
+
+#: models.py:240
+msgid ""
+"Adds a spreadsheet of the recipient's own voucher codes to the voucher email."
+msgstr ""
+
+#: models.py:247
 msgid "Call headline"
 msgstr ""
 
-#: exhibition/models.py:220
+#: models.py:251
 msgid "Call text"
 msgstr ""
 
-#: exhibition/models.py:225
+#: models.py:256
 msgid "Submission deadline"
 msgstr ""
 
-#: exhibition/models.py:298
+#: models.py:329
 msgid "Show this sponsor group on the front page."
 msgstr ""
 
-#: exhibition/models.py:314 exhibition/models.py:558
-#: exhibition/templates/exhibitors/dashboard.html:73
-#: exhibition/templates/exhibitors/exhibitor_info.html:69
-#: exhibition/templates/exhibitors/proposal_list.html:19
-#: exhibition/templates/exhibitors/public_proposal_list.html:11
-#: exhibition/views.py:505
+#: models.py:345 models.py:606 templates/exhibitors/dashboard.html:73
+#: templates/exhibitors/exhibitor_info.html:79
+#: templates/exhibitors/proposal_list.html:19
+#: templates/exhibitors/public_proposal_list.html:11 views.py:544
 msgid "Name"
 msgstr ""
 
-#: exhibition/models.py:315 exhibition/models.py:559
-#: exhibition/templates/exhibitors/proposal_detail.html:117
+#: models.py:346 models.py:607 templates/exhibitors/proposal_detail.html:117
 msgid "Description"
 msgstr ""
 
-#: exhibition/models.py:316 exhibition/models.py:419 exhibition/models.py:435
-#: exhibition/models.py:565 exhibition/models.py:815 exhibition/models.py:831
-#: exhibition/models.py:844
-#: exhibition/templates/exhibitors/proposal_detail.html:103
+#: models.py:347 models.py:467 models.py:483 models.py:613 models.py:863
+#: models.py:879 models.py:892 templates/exhibitors/proposal_detail.html:103
 msgid "URL"
 msgstr ""
 
-#: exhibition/models.py:317 exhibition/models.py:566
-#: exhibition/templates/exhibitors/proposal_detail.html:77
-#: exhibition/views.py:505
+#: models.py:348 models.py:614 templates/exhibitors/proposal_detail.html:77
+#: views.py:544
 msgid "Email"
 msgstr ""
 
-#: exhibition/models.py:318 exhibition/models.py:567
-#: exhibition/templates/exhibitors/proposal_detail.html:105
+#: models.py:349 models.py:615 templates/exhibitors/proposal_detail.html:105
 msgid "Contact URL"
 msgstr ""
 
-#: exhibition/models.py:319 exhibition/models.py:568
-#: exhibition/templates/exhibitors/proposal_detail.html:107
+#: models.py:350 models.py:616 templates/exhibitors/proposal_detail.html:107
 msgid "Video URL"
 msgstr ""
 
-#: exhibition/models.py:322 exhibition/models.py:571
-#: exhibition/templates/exhibitors/proposal_detail.html:109
+#: models.py:353 models.py:619 templates/exhibitors/proposal_detail.html:109
 msgid "Slides"
 msgstr ""
 
-#: exhibition/models.py:326 exhibition/models.py:575
+#: models.py:357 models.py:623
 msgid "Slides URL"
 msgstr ""
 
-#: exhibition/models.py:328 exhibition/models.py:577
+#: models.py:359 models.py:625
 msgid "Logo URL"
 msgstr ""
 
-#: exhibition/models.py:330 exhibition/models.py:579
+#: models.py:361 models.py:627
 msgid "Header image URL"
 msgstr ""
 
-#: exhibition/models.py:434 exhibition/models.py:830
+#: models.py:482 models.py:878
 msgid "Label"
 msgstr ""
 
-#: exhibition/models.py:445
+#: models.py:493
 msgid "draft"
 msgstr ""
 
-#: exhibition/models.py:446
+#: models.py:494
 msgid "submitted"
 msgstr ""
 
-#: exhibition/models.py:447
+#: models.py:495
 msgid "accepted"
 msgstr ""
 
-#: exhibition/models.py:448
+#: models.py:496
 msgid "rejected"
 msgstr ""
 
-#: exhibition/models.py:449
+#: models.py:497
 msgid "withdrawn"
 msgstr ""
 
-#: exhibition/models.py:514
+#: models.py:562
 msgid "Organization Description"
 msgstr ""
 
-#: exhibition/models.py:516
+#: models.py:564
 msgid "Organization Website"
 msgstr ""
 
-#: exhibition/models.py:517
+#: models.py:565
 msgid "Contact Page URL"
 msgstr ""
 
-#: exhibition/models.py:518
+#: models.py:566
 msgid "Promotional Video URL"
 msgstr ""
 
-#: exhibition/models.py:519
+#: models.py:567
 msgid "Promotional Slides"
 msgstr ""
 
-#: exhibition/models.py:521
+#: models.py:569
 msgid "Header Image"
 msgstr ""
 
-#: exhibition/models.py:524 exhibition/templates/exhibitors/add.html:29
-#: exhibition/templates/exhibitors/public_proposal_form.html:38
+#: models.py:572 templates/exhibitors/add.html:29
+#: templates/exhibitors/public_proposal_form.html:38
 msgid "Social Media"
 msgstr ""
 
-#: exhibition/models.py:525 exhibition/templates/exhibitors/add.html:92
-#: exhibition/templates/exhibitors/public_proposal_form.html:91
+#: models.py:573 templates/exhibitors/add.html:92
+#: templates/exhibitors/public_proposal_form.html:91
 msgid "Extra Links"
 msgstr ""
 
-#: exhibition/models.py:841
+#: models.py:889
 msgid "Number"
 msgstr ""
 
-#: exhibition/models.py:842
+#: models.py:890
 msgid "Text (one line)"
 msgstr ""
 
-#: exhibition/models.py:843
+#: models.py:891
 msgid "Multiline text"
 msgstr ""
 
-#: exhibition/models.py:845
+#: models.py:893
 msgid "Email address"
 msgstr ""
 
-#: exhibition/models.py:846
+#: models.py:894
 msgid "Confirm Checkbox"
 msgstr ""
 
-#: exhibition/models.py:847
+#: models.py:895
 msgid "Radio button (Choose one option)"
 msgstr ""
 
-#: exhibition/models.py:848
+#: models.py:896
 msgid "Dropdown (Choose one option)"
 msgstr ""
 
-#: exhibition/models.py:849
+#: models.py:897
 msgid "Checkbox (Choose one or several options)"
 msgstr ""
 
-#: exhibition/models.py:850
+#: models.py:898
 msgid "File upload"
 msgstr ""
 
-#: exhibition/models.py:851
+#: models.py:899
 msgid "Date"
 msgstr ""
 
-#: exhibition/models.py:852
+#: models.py:900
 msgid "Time"
 msgstr ""
 
-#: exhibition/models.py:853
+#: models.py:901
 msgid "Date and time"
 msgstr ""
 
-#: exhibition/models.py:854
+#: models.py:902
 msgid "Country code (ISO 3166-1 alpha-2)"
 msgstr ""
 
-#: exhibition/models.py:855
+#: models.py:903
 msgid "Phone number"
 msgstr ""
 
-#: exhibition/models.py:883
+#: models.py:931
 msgid "help text"
 msgstr ""
 
-#: exhibition/models.py:885 exhibition/templates/exhibitors/add.html:29
-#: exhibition/templates/exhibitors/add.html:92
-#: exhibition/templates/exhibitors/public_proposal_form.html:38
-#: exhibition/templates/exhibitors/public_proposal_form.html:91
+#: models.py:933 templates/exhibitors/add.html:29
+#: templates/exhibitors/add.html:92
+#: templates/exhibitors/public_proposal_form.html:38
+#: templates/exhibitors/public_proposal_form.html:91
 msgid "required"
 msgstr ""
 
-#: exhibition/models.py:886
+#: models.py:934
 msgid "active"
 msgstr ""
 
-#: exhibition/models.py:906
+#: models.py:954
 msgid "Response"
 msgstr ""
 
-#: exhibition/models.py:938
+#: models.py:986
 msgid "Yes"
 msgstr ""
 
-#: exhibition/models.py:940
+#: models.py:988
 msgid "No"
 msgstr ""
 
-#: exhibition/models.py:1034
-#: exhibition/templates/exhibitors/_email_outbox_body.html:5
-#: exhibition/templates/exhibitors/_email_sent_body.html:5
+#: models.py:1083 templates/exhibitors/_email_outbox_body.html:5
+#: templates/exhibitors/_email_sent_body.html:5
 msgid "Recipient"
 msgstr ""
 
-#: exhibition/models.py:1045
+#: models.py:1101
 msgid "Queued email"
 msgstr ""
 
-#: exhibition/models.py:1046
+#: models.py:1102
 msgid "Queued emails"
 msgstr ""
 
-#: exhibition/models.py:1088
+#: models.py:1145
 msgid "Template name"
 msgstr ""
 
-#: exhibition/models.py:1095
+#: models.py:1152
 msgid "Custom email template"
 msgstr ""
 
-#: exhibition/models.py:1096
+#: models.py:1153
 msgid "Custom email templates"
 msgstr ""
 
-#: exhibition/signals.py:75
+#: signals.py:81
 msgid "Screen and evaluate exhibitor and sponsor requests for the event."
 msgstr ""
 
-#: exhibition/signals.py:76
+#: signals.py:82
 msgid "Request Review Dashboard"
 msgstr ""
 
-#: exhibition/signals.py:80
+#: signals.py:86
 msgid ""
 "Manage exhibitors and sponsors, maintain booth details, and create partner "
 "profiles for the event."
 msgstr ""
 
-#: exhibition/signals.py:82
+#: signals.py:88
 msgid "Exhibitors & Sponsors Dashboard"
 msgstr ""
 
-#: exhibition/signals.py:88 exhibition/templates/exhibitors/base.html:5
-#: exhibition/templates/exhibitors/base.html:125
-#: exhibition/templates/exhibitors/exhibitor_info.html:4
-#: exhibition/templates/exhibitors/exhibitor_info.html:15
+#: signals.py:94 templates/exhibitors/base.html:6
+#: templates/exhibitors/base.html:136
+#: templates/exhibitors/exhibitor_info.html:4
+#: templates/exhibitors/exhibitor_info.html:15
 msgid "Exhibitors & Sponsors"
 msgstr ""
 
-#: exhibition/signals.py:90
+#: signals.py:96
 msgid "Go to"
 msgstr ""
 
-#: exhibition/signals.py:166 exhibition/templates/exhibitors/call_base.html:4
-#: exhibition/templates/exhibitors/call_base.html:7
-#: exhibition/templates/exhibitors/public_call.html:7
-#: exhibition/templates/exhibitors/settings.html:8
-#: exhibition/templates/exhibitors/settings.html:25
+#: signals.py:172 templates/exhibitors/call_base.html:4
+#: templates/exhibitors/call_base.html:7
+#: templates/exhibitors/public_call.html:7 templates/exhibitors/settings.html:8
+#: templates/exhibitors/settings.html:27
 msgid "Call for Exhibitors"
 msgstr ""
 
-#: exhibition/signals.py:207 exhibition/signals.py:231
+#: signals.py:213 signals.py:237
 msgid "Acme Corp"
 msgstr ""
 
-#: exhibition/signals.py:225
+#: signals.py:231
 msgid "Jane Doe"
 msgstr ""
 
-#: exhibition/signals.py:293 exhibition/templates/exhibitors/base.html:62
-#: exhibition/templates/exhibitors/proposal_list.html:5
-#: exhibition/templates/exhibitors/proposal_list.html:15
+#: signals.py:305 templates/exhibitors/base.html:73
+#: templates/exhibitors/proposal_list.html:5
+#: templates/exhibitors/proposal_list.html:15
 msgid "Exhibition requests"
 msgstr ""
 
-#: exhibition/signals.py:298
+#: signals.py:310
 msgid "Exhibition request approved."
 msgstr ""
 
-#: exhibition/signals.py:299
+#: signals.py:311
 msgid "Exhibition request rejected."
 msgstr ""
 
-#: exhibition/signals.py:300
+#: signals.py:312
 msgid "Exhibition request withdrawn."
 msgstr ""
 
-#: exhibition/signals.py:301
+#: signals.py:313
 msgid "Exhibition request reopened for review."
 msgstr ""
 
-#: exhibition/signals.py:302
+#: signals.py:314
 msgid "Exhibition request changed."
 msgstr ""
 
-#: exhibition/signals.py:303
+#: signals.py:315
 msgid "Organization profile created from an approved request."
 msgstr ""
 
-#: exhibition/signals.py:304
+#: signals.py:316
 msgid "Organization profile reactivated after re-approval."
 msgstr ""
 
-#: exhibition/signals.py:305
+#: signals.py:317
 msgid "Organization profile updated from the submitter's changes."
 msgstr ""
 
-#: exhibition/signals.py:306
+#: signals.py:318
 msgid "Organization profile created."
 msgstr ""
 
-#: exhibition/signals.py:307
+#: signals.py:319
 msgid "Organization profile changed."
 msgstr ""
 
-#: exhibition/signals.py:308
+#: signals.py:320
 msgid "Organization profile deleted."
 msgstr ""
 
-#: exhibition/signals.py:309
+#: signals.py:321
 msgid "Exhibition settings changed."
 msgstr ""
 
-#: exhibition/signals.py:310
+#: signals.py:322
 msgid "Call for exhibitors settings changed."
 msgstr ""
 
-#: exhibition/signals.py:311
+#: signals.py:323
 msgid "Private call link regenerated."
 msgstr ""
 
-#: exhibition/signals.py:312
+#: signals.py:324
 msgid "Sponsor group created."
 msgstr ""
 
-#: exhibition/signals.py:313
+#: signals.py:325
 msgid "Sponsor group changed."
 msgstr ""
 
-#: exhibition/signals.py:314 exhibition/views.py:457
+#: signals.py:326 views.py:496
 msgid "Sponsor group deleted."
 msgstr ""
 
-#: exhibition/signals.py:315
+#: signals.py:327
 msgid "Exhibitor form question created."
 msgstr ""
 
-#: exhibition/signals.py:316
+#: signals.py:328
 msgid "Exhibitor form question changed."
 msgstr ""
 
-#: exhibition/signals.py:317
+#: signals.py:329
 msgid "Exhibitor form question deleted."
 msgstr ""
 
-#: exhibition/signals.py:318
+#: signals.py:330
 msgid "Email sent."
 msgstr ""
 
-#: exhibition/signals.py:337
+#: signals.py:349
 #, python-brace-format
 msgid "Updated: {fields}."
 msgstr ""
 
-#: exhibition/signals.py:360
+#: signals.py:372
 #, python-brace-format
 msgid "State changed from {old} to {new}."
 msgstr ""
 
-#: exhibition/signals.py:382
+#: signals.py:394
 #, python-brace-format
 msgid "Exhibition request {val}"
 msgstr ""
 
-#: exhibition/signals.py:391
+#: signals.py:403
 #, python-brace-format
 msgid "Organization profile {val}"
 msgstr ""
 
-#: exhibition/signals.py:400
+#: signals.py:412
 #, python-brace-format
 msgid "Exhibitor form question {val}"
 msgstr ""
 
-#: exhibition/signals.py:409
+#: signals.py:421
 #, python-brace-format
 msgid "Sponsor group {val}"
 msgstr ""
 
-#: exhibition/social_links.py:36
+#: social_links.py:36
 msgid "Facebook"
 msgstr ""
 
-#: exhibition/social_links.py:43
+#: social_links.py:43
 msgid "Flickr"
 msgstr ""
 
-#: exhibition/social_links.py:50
+#: social_links.py:50
 msgid "GitHub"
 msgstr ""
 
-#: exhibition/social_links.py:57
+#: social_links.py:57
 msgid "GitLab"
 msgstr ""
 
-#: exhibition/social_links.py:64
+#: social_links.py:64
 msgid "Gitter"
 msgstr ""
 
-#: exhibition/social_links.py:71
+#: social_links.py:71
 msgid "Google Groups"
 msgstr ""
 
-#: exhibition/social_links.py:78
+#: social_links.py:78
 msgid "Instagram"
 msgstr ""
 
-#: exhibition/social_links.py:85
+#: social_links.py:85
 msgid "LinkedIn"
 msgstr ""
 
-#: exhibition/social_links.py:92
+#: social_links.py:92
 msgid "Mastodon"
 msgstr ""
 
-#: exhibition/social_links.py:99
+#: social_links.py:99
 msgid "Patreon"
 msgstr ""
 
-#: exhibition/social_links.py:106
+#: social_links.py:106
 msgid "Telegram"
 msgstr ""
 
-#: exhibition/social_links.py:113
+#: social_links.py:113
 msgid "Vimeo"
 msgstr ""
 
-#: exhibition/social_links.py:120
+#: social_links.py:120
 msgid "VK"
 msgstr ""
 
-#: exhibition/social_links.py:127
+#: social_links.py:127
 msgid "Weibo"
 msgstr ""
 
-#: exhibition/social_links.py:134
+#: social_links.py:134
 msgid "X"
 msgstr ""
 
-#: exhibition/social_links.py:141
+#: social_links.py:141
 msgid "Xing"
 msgstr ""
 
-#: exhibition/social_links.py:148
+#: social_links.py:148
 msgid "YouTube"
 msgstr ""
 
-#: exhibition/social_links.py:155
+#: social_links.py:155
 msgid "YouTube Privacy"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:7
+#: templates/exhibitors/_email_outbox_body.html:7
 msgid "Created"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:14
+#: templates/exhibitors/_email_outbox_body.html:14
 msgid "Send selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:17
+#: templates/exhibitors/_email_outbox_body.html:17
 msgid "Discard selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:20
+#: templates/exhibitors/_email_outbox_body.html:20
 msgid "Send all"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:23
+#: templates/exhibitors/_email_outbox_body.html:23
 msgid "Discard all"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:35
+#: templates/exhibitors/_email_outbox_body.html:35
 msgid "Scheduled"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:36
-#: exhibition/templates/exhibitors/proposal_list.html:65
+#: templates/exhibitors/_email_outbox_body.html:36
+#: templates/exhibitors/proposal_list.html:65
 msgid "Actions"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:67
-msgid "Send this email"
+#: templates/exhibitors/_email_outbox_body.html:68
+msgid "Send"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:73
-msgid "Edit this email"
+#: templates/exhibitors/_email_outbox_body.html:75
+#: templates/exhibitors/_partner_row.html:54
+#: templates/exhibitors/call_questions.html:73
+#: templates/exhibitors/call_questions.html:76
+#: templates/exhibitors/dashboard.html:120
+#: templates/exhibitors/email_compose.html:55
+#: templates/exhibitors/email_custom_template_form.html:30
+#: templates/exhibitors/email_templates.html:50
+#: templates/exhibitors/email_templates.html:97
+#: templates/exhibitors/public_proposal_list.html:32
+#: templates/exhibitors/settings.html:59
+msgid "Edit"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:79
-msgid "Discard this email"
+#: templates/exhibitors/_email_outbox_body.html:82
+#: templates/exhibitors/email_bulk_discard.html:30
+#: templates/exhibitors/email_delete.html:31
+msgid "Discard"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:91
-#: exhibition/templates/exhibitors/_email_sent_body.html:34
+#: templates/exhibitors/_email_outbox_body.html:95
+#: templates/exhibitors/_email_sent_body.html:35
 msgid "No emails match your search."
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:93
+#: templates/exhibitors/_email_outbox_body.html:97
 msgid "The outbox is empty."
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_sent_body.html:7
-#: exhibition/templates/exhibitors/base.html:105
+#: templates/exhibitors/_email_sent_body.html:7
+#: templates/exhibitors/_partner_row.html:45 templates/exhibitors/base.html:116
 msgid "Sent"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_sent_body.html:36
+#: templates/exhibitors/_email_sent_body.html:37
 msgid "No emails have been sent yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:12
-#: exhibition/templates/exhibitors/public_list.html:29
+#: templates/exhibitors/_filter_form.html:12
+#: templates/exhibitors/public_list.html:29
 msgid "Search"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:18
-#: exhibition/templates/exhibitors/_filter_form.html:20
+#: templates/exhibitors/_filter_form.html:18
+#: templates/exhibitors/_filter_form.html:21
 msgid "Clear filters"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:29
+#: templates/exhibitors/_filter_form.html:30
 msgid "Filters"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:50
+#: templates/exhibitors/_filter_form.html:51
 msgid "Apply filters"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:5
+#: templates/exhibitors/_image_preview_dialog.html:11
+msgid "Close preview"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:5
 #, python-format
 msgid "Select %(name)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:33
+#: templates/exhibitors/_partner_row.html:33
 msgid "Untitled"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:40
+#: templates/exhibitors/_partner_row.html:40
+msgid "Waiting in the outbox"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:41
+msgid "In outbox"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:44
+#, python-format
+msgid "Last sent %(sent)s"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:48
+msgid "Not sent"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:55
 msgid "Copied!"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:40
+#: templates/exhibitors/_partner_row.html:55
 msgid "Copy failed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:40
+#: templates/exhibitors/_partner_row.html:55
 msgid "Key"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:41
-#: exhibition/templates/exhibitors/add.html:231
-#: exhibition/templates/exhibitors/vouchers.html:5
+#: templates/exhibitors/_partner_row.html:56 templates/exhibitors/add.html:235
+#: templates/exhibitors/base.html:42
+#: templates/exhibitors/exhibitor_info.html:95
+#: templates/exhibitors/exhibitor_info.html:125
+#: templates/exhibitors/vouchers.html:5 views.py:2933
 msgid "Vouchers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:42
-#: exhibition/templates/exhibitors/devices.html:5
+#: templates/exhibitors/_partner_row.html:57
+#: templates/exhibitors/devices.html:5
 msgid "Lead-scanning devices"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:45
+#: templates/exhibitors/_partner_row.html:58
+#: templates/exhibitors/call_question_delete.html:19
+#: templates/exhibitors/call_questions.html:74
+#: templates/exhibitors/delete.html:19
+#: templates/exhibitors/email_custom_template_delete.html:19
+#: templates/exhibitors/settings.html:335
+msgid "Delete"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:60
 msgid "Move"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_sort_header.html:7
+#: templates/exhibitors/_sort_header.html:7
 msgid "Sort ascending"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_sort_header.html:10
+#: templates/exhibitors/_sort_header.html:10
 msgid "Sort descending"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:24
+#: templates/exhibitors/add.html:24
 msgid "Profile"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:29
-#: exhibition/templates/exhibitors/add.html:92
-#: exhibition/templates/exhibitors/call_questions.html:62
-#: exhibition/templates/exhibitors/settings.html:50
+#: templates/exhibitors/add.html:29 templates/exhibitors/add.html:92
+#: templates/exhibitors/call_questions.html:62
+#: templates/exhibitors/settings.html:54
 msgid "Optional"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:80
-#: exhibition/templates/exhibitors/public_proposal_form.html:79
+#: templates/exhibitors/add.html:80
+#: templates/exhibitors/public_proposal_form.html:79
 msgid "Add social media link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:137
-#: exhibition/templates/exhibitors/public_proposal_form.html:120
+#: templates/exhibitors/add.html:137
+#: templates/exhibitors/public_proposal_form.html:120
 msgid "Add extra link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:157
-#: exhibition/templates/exhibitors/add.html:160
-#: exhibition/templates/exhibitors/public_proposal_form.html:140
-#: exhibition/templates/exhibitors/public_proposal_form.html:143
+#: templates/exhibitors/add.html:157 templates/exhibitors/add.html:161
+#: templates/exhibitors/public_proposal_form.html:140
+#: templates/exhibitors/public_proposal_form.html:144
 msgid "Logo preview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:162
-#: exhibition/templates/exhibitors/add.html:180
-#: exhibition/templates/exhibitors/public_proposal_form.html:145
-#: exhibition/templates/exhibitors/public_proposal_form.html:163
+#: templates/exhibitors/add.html:164 templates/exhibitors/add.html:184
+#: templates/exhibitors/public_proposal_form.html:147
+#: templates/exhibitors/public_proposal_form.html:167
 msgid "We could not load this image preview."
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:175
-#: exhibition/templates/exhibitors/add.html:178
-#: exhibition/templates/exhibitors/public_proposal_form.html:158
-#: exhibition/templates/exhibitors/public_proposal_form.html:161
+#: templates/exhibitors/add.html:177 templates/exhibitors/add.html:181
+#: templates/exhibitors/public_proposal_form.html:160
+#: templates/exhibitors/public_proposal_form.html:164
 msgid "Header image preview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:196
+#: templates/exhibitors/add.html:200
 msgid "Organizer only"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:237
+#: templates/exhibitors/add.html:241
 msgid "Internal notes"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:244
-#: exhibition/templates/exhibitors/email_edit.html:38
-#: exhibition/templates/exhibitors/public_proposal_form.html:182
-#: exhibition/templates/exhibitors/public_proposal_form.html:186
+#: templates/exhibitors/add.html:248 templates/exhibitors/email_edit.html:38
+#: templates/exhibitors/public_proposal_form.html:186
+#: templates/exhibitors/public_proposal_form.html:190
 msgid "Save changes"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:246
-#: exhibition/templates/exhibitors/call_default_field_form.html:21
-#: exhibition/templates/exhibitors/call_question_form.html:30
-#: exhibition/templates/exhibitors/call_questions.html:96
-#: exhibition/templates/exhibitors/email_custom_template_form.html:51
-#: exhibition/templates/exhibitors/email_templates.html:123
-#: exhibition/templates/exhibitors/proposal_detail.html:188
-#: exhibition/templates/exhibitors/settings.html:85
-#: exhibition/templates/exhibitors/settings.html:170
-#: exhibition/templates/exhibitors/settings.html:269
+#: templates/exhibitors/add.html:250
+#: templates/exhibitors/call_default_field_form.html:21
+#: templates/exhibitors/call_question_form.html:114
+#: templates/exhibitors/call_questions.html:96
+#: templates/exhibitors/email_custom_template_form.html:51
+#: templates/exhibitors/email_templates.html:123
+#: templates/exhibitors/proposal_detail.html:188
+#: templates/exhibitors/settings.html:89 templates/exhibitors/settings.html:217
+#: templates/exhibitors/settings.html:250
+#: templates/exhibitors/settings.html:359
 msgid "Save"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:255
-#: exhibition/templates/exhibitors/call_default_field_form.html:23
-#: exhibition/templates/exhibitors/call_default_field_reset.html:24
-#: exhibition/templates/exhibitors/call_question_delete.html:21
-#: exhibition/templates/exhibitors/call_question_form.html:32
-#: exhibition/templates/exhibitors/delete.html:24
-#: exhibition/templates/exhibitors/email_bulk_discard.html:27
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:21
-#: exhibition/templates/exhibitors/email_custom_template_form.html:53
-#: exhibition/templates/exhibitors/email_delete.html:28
-#: exhibition/templates/exhibitors/proposal_list.html:174
-#: exhibition/templates/exhibitors/public_proposal_form.html:176
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:16
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:21
-#: exhibition/templates/exhibitors/settings.html:194
-#: exhibition/templates/exhibitors/settings.html:270
+#: templates/exhibitors/add.html:259
+#: templates/exhibitors/call_default_field_form.html:23
+#: templates/exhibitors/call_default_field_reset.html:24
+#: templates/exhibitors/call_question_delete.html:21
+#: templates/exhibitors/call_question_form.html:116
+#: templates/exhibitors/delete.html:24
+#: templates/exhibitors/email_bulk_discard.html:27
+#: templates/exhibitors/email_custom_template_delete.html:21
+#: templates/exhibitors/email_custom_template_form.html:53
+#: templates/exhibitors/email_delete.html:28
+#: templates/exhibitors/proposal_list.html:175
+#: templates/exhibitors/public_proposal_form.html:180
+#: templates/exhibitors/public_proposal_reinstate.html:16
+#: templates/exhibitors/public_proposal_withdraw.html:21
+#: templates/exhibitors/settings.html:278
+#: templates/exhibitors/settings.html:360
+#: templates/exhibitors/voucher_bulk_send.html:96
 msgid "Cancel"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:262
-#: exhibition/templates/exhibitors/proposal_detail.html:208
+#: templates/exhibitors/add.html:266
+#: templates/exhibitors/proposal_detail.html:208
 msgid "History"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:11
+#: templates/exhibitors/base.html:17
 msgid "Overview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:18
-#: exhibition/templates/exhibitors/call_questions.html:33
+#: templates/exhibitors/base.html:24
+#: templates/exhibitors/call_questions.html:33
 msgid "Settings"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:26
-#: exhibition/templates/exhibitors/base.html:70
-#: exhibition/templates/exhibitors/dashboard.html:21
-#: exhibition/templates/exhibitors/exhibitor_info.html:4
-#: exhibition/templates/exhibitors/exhibitor_info.html:15
+#: templates/exhibitors/base.html:32 templates/exhibitors/base.html:81
+#: templates/exhibitors/dashboard.html:21
+#: templates/exhibitors/exhibitor_info.html:4
+#: templates/exhibitors/exhibitor_info.html:15
 msgid "Exhibitors"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:31
-#: exhibition/templates/exhibitors/base.html:76
-#: exhibition/templates/exhibitors/dashboard.html:29
-#: exhibition/templates/exhibitors/exhibitor_info.html:4
-#: exhibition/templates/exhibitors/exhibitor_info.html:15
+#: templates/exhibitors/base.html:37 templates/exhibitors/base.html:87
+#: templates/exhibitors/dashboard.html:29
+#: templates/exhibitors/exhibitor_info.html:4
+#: templates/exhibitors/exhibitor_info.html:15
 msgid "Sponsors"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:39
-#: exhibition/templates/exhibitors/dashboard.html:117
+#: templates/exhibitors/base.html:50 templates/exhibitors/dashboard.html:117
 msgid "Call for exhibitors"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:47
+#: templates/exhibitors/base.html:58
 msgid "Content"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:52
-#: exhibition/templates/exhibitors/call_questions.html:5
-#: exhibition/templates/exhibitors/call_questions.html:16
+#: templates/exhibitors/base.html:63 templates/exhibitors/call_questions.html:5
+#: templates/exhibitors/call_questions.html:16
 msgid "Exhibitor form"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:85
+#: templates/exhibitors/base.html:96
 msgid "Message center"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:94
+#: templates/exhibitors/base.html:105
 msgid "Compose"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:99
+#: templates/exhibitors/base.html:110
 msgid "Outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:111
+#: templates/exhibitors/base.html:122
 msgid "Templates"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:130
+#: templates/exhibitors/base.html:141
 msgid "Home"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:134
+#: templates/exhibitors/base.html:145
 msgid "Tickets"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:138
+#: templates/exhibitors/base.html:149
 msgid "Talks"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:143
+#: templates/exhibitors/base.html:154
 msgid "Access videos related to this event"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:144
+#: templates/exhibitors/base.html:155
 msgid "Videos"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_form.html:5
-#: exhibition/templates/exhibitors/call_default_field_form.html:8
-#: exhibition/templates/exhibitors/call_question_form.html:11
-#: exhibition/templates/exhibitors/call_question_form.html:14
+#: templates/exhibitors/call_default_field_form.html:5
+#: templates/exhibitors/call_default_field_form.html:8
+#: templates/exhibitors/call_question_form.html:14
+#: templates/exhibitors/call_question_form.html:17
 msgid "Form field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:4
-#: exhibition/templates/exhibitors/call_default_field_reset.html:7
+#: templates/exhibitors/call_default_field_reset.html:4
+#: templates/exhibitors/call_default_field_reset.html:7
 msgid "Reset form field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:14
+#: templates/exhibitors/call_default_field_reset.html:14
 #, python-format
 msgid ""
 "Are you sure you want to reset \"%(label)s\" back to the default "
 "\"%(default_label)s\"?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:19
+#: templates/exhibitors/call_default_field_reset.html:19
 msgid ""
 "This clears the custom label and help text. Default fields are part of the "
 "form and cannot be deleted; turn the field off with the Active toggle to "
 "hide it."
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:22
-#: exhibition/templates/exhibitors/public_list.html:32
+#: templates/exhibitors/call_default_field_reset.html:22
 msgid "Reset"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_question_delete.html:4
-#: exhibition/templates/exhibitors/call_question_delete.html:7
+#: templates/exhibitors/call_question_delete.html:4
+#: templates/exhibitors/call_question_delete.html:7
 msgid "Delete form field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_question_delete.html:14
+#: templates/exhibitors/call_question_delete.html:14
 #, python-format
 msgid "Are you sure you want to delete the question \"%(question)s\"?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_question_delete.html:19
-#: exhibition/templates/exhibitors/call_questions.html:74
-#: exhibition/templates/exhibitors/delete.html:19
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:19
-msgid "Delete"
+#: templates/exhibitors/call_question_form.html:31
+msgid "Answer options"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:23
+#: templates/exhibitors/call_question_form.html:34
+msgid "Only applicable if you choose a choice field type above."
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:48
+#, python-format
+msgid "Answer option %(id)s"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:56
+#: templates/exhibitors/call_question_form.html:58
+#: templates/exhibitors/call_question_form.html:87
+#: templates/exhibitors/call_question_form.html:89
+msgid "Move option up"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:60
+#: templates/exhibitors/call_question_form.html:62
+#: templates/exhibitors/call_question_form.html:91
+#: templates/exhibitors/call_question_form.html:93
+msgid "Move option down"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:64
+#: templates/exhibitors/call_question_form.html:66
+#: templates/exhibitors/call_question_form.html:95
+#: templates/exhibitors/call_question_form.html:97
+msgid "Delete option"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:81
+msgid "New answer option"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:106
+msgid "Add a new option"
+msgstr ""
+
+#: templates/exhibitors/call_questions.html:23
 msgid "Form fields"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:24
+#: templates/exhibitors/call_questions.html:24
 msgid ""
 "Choose which fields are shown on the exhibitor form and drag any row to "
 "reorder it."
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:29
-#: exhibition/templates/exhibitors/proposal_detail.html:38
+#: templates/exhibitors/call_questions.html:29
+#: templates/exhibitors/proposal_detail.html:38
 msgid "Field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:32
+#: templates/exhibitors/call_questions.html:32
 msgid "Answers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:42
+#: templates/exhibitors/call_questions.html:42
 msgid "Custom"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:48
+#: templates/exhibitors/call_questions.html:48
 #, python-format
 msgid "Toggle active state for %(field)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:61
+#: templates/exhibitors/call_questions.html:61
 #, python-format
 msgid "Required status for %(field)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:73
-#: exhibition/templates/exhibitors/call_questions.html:76
-#: exhibition/templates/exhibitors/dashboard.html:120
-#: exhibition/templates/exhibitors/email_compose.html:55
-#: exhibition/templates/exhibitors/email_custom_template_form.html:30
-#: exhibition/templates/exhibitors/email_templates.html:50
-#: exhibition/templates/exhibitors/email_templates.html:97
-#: exhibition/templates/exhibitors/public_proposal_list.html:32
-#: exhibition/templates/exhibitors/settings.html:55
-msgid "Edit"
-msgstr ""
-
-#: exhibition/templates/exhibitors/call_questions.html:77
+#: templates/exhibitors/call_questions.html:77
 msgid "Reset to default"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:79
+#: templates/exhibitors/call_questions.html:79
 msgid "Move field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:90
+#: templates/exhibitors/call_questions.html:90
 msgid "New custom field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:5
-#: exhibition/templates/exhibitors/dashboard.html:9
+#: templates/exhibitors/dashboard.html:5 templates/exhibitors/dashboard.html:9
 msgid "Exhibition overview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:39
+#: templates/exhibitors/dashboard.html:39
 msgid "Requests awaiting review"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:48
+#: templates/exhibitors/dashboard.html:48
 msgid "Emails in outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:61
+#: templates/exhibitors/dashboard.html:61
 msgid "Recent requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:64
+#: templates/exhibitors/dashboard.html:64
 msgid "View all"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:76
+#: templates/exhibitors/dashboard.html:76
 msgid "Submitted"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:91
-#: exhibition/templates/exhibitors/proposal_detail.html:97
-#: exhibition/templates/exhibitors/proposal_list.html:97
+#: templates/exhibitors/dashboard.html:91
+#: templates/exhibitors/proposal_detail.html:97
+#: templates/exhibitors/proposal_list.html:97
 msgid "Sponsor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:93
-#: exhibition/templates/exhibitors/proposal_detail.html:99
-#: exhibition/templates/exhibitors/proposal_list.html:99
+#: templates/exhibitors/dashboard.html:93
+#: templates/exhibitors/proposal_detail.html:99
+#: templates/exhibitors/proposal_list.html:99
 msgid "Exhibitor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:105
+#: templates/exhibitors/dashboard.html:105
 msgid "No requests have been submitted yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:128
+#: templates/exhibitors/dashboard.html:128
 msgid "The call is not published, so nobody can submit a request."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:131
+#: templates/exhibitors/dashboard.html:131
 msgid "Open"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:134
+#: templates/exhibitors/dashboard.html:134
 #, python-format
 msgid "Closes on %(deadline)s."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:139
+#: templates/exhibitors/dashboard.html:139
 msgid "No deadline set."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:142
+#: templates/exhibitors/dashboard.html:142
 msgid "Closed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:144
+#: templates/exhibitors/dashboard.html:144
 #, python-format
 msgid "The deadline passed on %(deadline)s."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:151
+#: templates/exhibitors/dashboard.html:151
 msgid "Private — reachable only with the secret link."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:157
-#: exhibition/templates/exhibitors/settings.html:90
-#: exhibition/templates/exhibitors/settings.html:94
+#: templates/exhibitors/dashboard.html:157
+#: templates/exhibitors/settings.html:94 templates/exhibitors/settings.html:98
 msgid "View call page"
 msgstr ""
 
-#: exhibition/templates/exhibitors/delete.html:11
+#: templates/exhibitors/delete.html:11
 #, python-format
 msgid ""
 "Are you sure you want to delete “%(name)s”? This action cannot be undone."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:8
+#: templates/exhibitors/devices.html:8
 #, python-format
 msgid "Lead-scanning devices for %(name)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:13
+#: templates/exhibitors/devices.html:13
 #, python-brace-format
 msgid ""
 "Provision check-in app devices for this partner. Each device gets its own "
@@ -1672,66 +1705,64 @@ msgid ""
 "through the {device_tokens} placeholder."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:21
+#: templates/exhibitors/devices.html:21
 msgid ""
 "Provisioning devices requires organizer-level permissions. Ask an organizer "
 "admin to create the devices for this partner."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:29
+#: templates/exhibitors/devices.html:29
 msgid "Provisioned devices"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:35
+#: templates/exhibitors/devices.html:35
 msgid "Device"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:36
+#: templates/exhibitors/devices.html:36
 msgid "Setup token"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:37
+#: templates/exhibitors/devices.html:37
 msgid "Status"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:47
+#: templates/exhibitors/devices.html:47
 msgid "Connected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:49
+#: templates/exhibitors/devices.html:49
 msgid "Awaiting setup"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:60
+#: templates/exhibitors/devices.html:60
 msgid ""
 "Generate new setup tokens? Any device that is already scanning will be "
 "disconnected and must be set up again."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:65
+#: templates/exhibitors/devices.html:65
 msgid "Generate new setup tokens"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:70
+#: templates/exhibitors/devices.html:70
 msgid "No devices have been provisioned for this partner yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:80
-#: exhibition/templates/exhibitors/devices.html:85
+#: templates/exhibitors/devices.html:80 templates/exhibitors/devices.html:85
 msgid "Add devices"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:87
-#: exhibition/templates/exhibitors/vouchers.html:88
+#: templates/exhibitors/devices.html:87 templates/exhibitors/vouchers.html:133
 msgid "Back"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_bulk_discard.html:4
-#: exhibition/templates/exhibitors/email_bulk_discard.html:7
+#: templates/exhibitors/email_bulk_discard.html:4
+#: templates/exhibitors/email_bulk_discard.html:7
 msgid "Discard emails"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_bulk_discard.html:19
+#: templates/exhibitors/email_bulk_discard.html:19
 #, python-format
 msgid ""
 "Are you sure you want to discard %(counter)s queued email? This cannot be "
@@ -1742,80 +1773,80 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/templates/exhibitors/email_bulk_discard.html:30
-#: exhibition/templates/exhibitors/email_delete.html:31
-msgid "Discard"
-msgstr ""
-
-#: exhibition/templates/exhibitors/email_compose.html:7
-#: exhibition/templates/exhibitors/email_compose.html:16
+#: templates/exhibitors/email_compose.html:7
+#: templates/exhibitors/email_compose.html:16
 msgid "Compose email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:21
+#: templates/exhibitors/email_compose.html:21
 msgid ""
 "Send an update to a group of applicants. One email is queued per recipient, "
 "with placeholders resolved individually."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:26
+#: templates/exhibitors/email_compose.html:26
 msgid "Load from template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:28
+#: templates/exhibitors/email_compose.html:28
 msgid "Select a saved template…"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:33
+#: templates/exhibitors/email_compose.html:33
 msgid "Load"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:41
-#: exhibition/templates/exhibitors/email_edit.html:23
+#: templates/exhibitors/email_compose.html:41
+#: templates/exhibitors/email_edit.html:23
 msgid "Recipients"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:47
+#: templates/exhibitors/email_compose.html:47
 msgid "Message"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:58
-#: exhibition/templates/exhibitors/email_custom_template_form.html:33
-#: exhibition/templates/exhibitors/email_templates.html:53
-#: exhibition/templates/exhibitors/email_templates.html:100
-#: exhibition/templates/exhibitors/settings.html:58
+#: templates/exhibitors/email_compose.html:51
+msgctxt "form"
+msgid "required"
+msgstr ""
+
+#: templates/exhibitors/email_compose.html:58
+#: templates/exhibitors/email_custom_template_form.html:33
+#: templates/exhibitors/email_templates.html:53
+#: templates/exhibitors/email_templates.html:100
+#: templates/exhibitors/settings.html:62
 msgid "Preview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:80
+#: templates/exhibitors/email_compose.html:80
 msgid "Save to outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:83
+#: templates/exhibitors/email_compose.html:83
 msgid "Send / Schedule"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:4
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:7
+#: templates/exhibitors/email_custom_template_delete.html:4
+#: templates/exhibitors/email_custom_template_delete.html:7
 msgid "Delete custom template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:14
+#: templates/exhibitors/email_custom_template_delete.html:14
 #, python-format
 msgid "Are you sure you want to delete the custom template \"%(name)s\"?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_custom_template_form.html:7
-#: exhibition/templates/exhibitors/email_custom_template_form.html:15
+#: templates/exhibitors/email_custom_template_form.html:7
+#: templates/exhibitors/email_custom_template_form.html:15
 msgid "Custom template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_delete.html:4
-#: exhibition/templates/exhibitors/email_delete.html:7
+#: templates/exhibitors/email_delete.html:4
+#: templates/exhibitors/email_delete.html:7
 msgid "Discard email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_delete.html:15
+#: templates/exhibitors/email_delete.html:15
 #, python-format
 msgid ""
 "Are you sure you want to discard the email “%(subject)s” to %(counter)s "
@@ -1826,908 +1857,1170 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/templates/exhibitors/email_delete.html:21
+#: templates/exhibitors/email_delete.html:21
 #, python-format
 msgid ""
 "Are you sure you want to discard the email “%(subject)s” to %(to)s? This "
 "cannot be undone."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:5
+#: templates/exhibitors/email_edit.html:5
 msgid "Edit email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:8
+#: templates/exhibitors/email_edit.html:8
 msgid "Preview / edit email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:14
+#: templates/exhibitors/email_edit.html:14
 msgid "Back to outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:41
+#: templates/exhibitors/email_edit.html:41
 msgid "Save & send"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_outbox.html:12
-#: exhibition/templates/exhibitors/email_outbox.html:15
+#: templates/exhibitors/email_outbox.html:12
+#: templates/exhibitors/email_outbox.html:15
 msgid "Email outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_outbox.html:20
+#: templates/exhibitors/email_outbox.html:20
 msgid ""
 "Emails waiting to be sent. Review, edit, or discard them before sending."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_sent.html:12
-#: exhibition/templates/exhibitors/email_sent.html:15
+#: templates/exhibitors/email_sent.html:12
+#: templates/exhibitors/email_sent.html:15
 msgid "Sent emails"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:7
-#: exhibition/templates/exhibitors/email_templates.html:16
+#: templates/exhibitors/email_templates.html:7
+#: templates/exhibitors/email_templates.html:16
 msgid "Email templates"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:22
+#: templates/exhibitors/email_templates.html:22
 msgid "New template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:27
+#: templates/exhibitors/email_templates.html:27
 msgid ""
 "These templates are used for the confirmation email sent when an applicant "
 "submits a request, and for the accept/reject emails you send from the outbox."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:81
+#: templates/exhibitors/email_templates.html:81
 msgid "Discard this template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:31
+#: templates/exhibitors/exhibitor_info.html:31
 msgid "No organizations match your filters."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:33
+#: templates/exhibitors/exhibitor_info.html:33
 msgid "You don't have any sponsors yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:35
+#: templates/exhibitors/exhibitor_info.html:35
 msgid "You don't have any exhibitors yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:37
+#: templates/exhibitors/exhibitor_info.html:37
 msgid "You don't have any exhibitors or sponsors yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:43
-#: exhibition/templates/exhibitors/exhibitor_info.html:52
-#: exhibition/views.py:1837
+#: templates/exhibitors/exhibitor_info.html:43
+#: templates/exhibitors/exhibitor_info.html:57 views.py:1979
 msgid "Add a Sponsor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:43
-#: exhibition/templates/exhibitors/exhibitor_info.html:52
-#: exhibition/views.py:1838
+#: templates/exhibitors/exhibitor_info.html:43
+#: templates/exhibitors/exhibitor_info.html:57 views.py:1980
 msgid "Add an Exhibitor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:43
-#: exhibition/templates/exhibitors/exhibitor_info.html:52
-#: exhibition/views.py:1839
+#: templates/exhibitors/exhibitor_info.html:43
+#: templates/exhibitors/exhibitor_info.html:57 views.py:1981
 msgid "Add an Exhibitor or Sponsor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:48
-#: exhibition/templates/exhibitors/proposal_list.html:169
+#: templates/exhibitors/exhibitor_info.html:48
+#: templates/exhibitors/proposal_list.html:170
 msgid "selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:54
+#: templates/exhibitors/exhibitor_info.html:59
 msgid "Download access keys as CSV"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:56
+#: templates/exhibitors/exhibitor_info.html:61
 msgid "Download sponsor keys"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:56
+#: templates/exhibitors/exhibitor_info.html:61
 msgid "Download exhibitor keys"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:56
+#: templates/exhibitors/exhibitor_info.html:61
 msgid "Download access keys"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:65
+#: templates/exhibitors/exhibitor_info.html:64
+msgid "Queue a voucher email for everyone in this list"
+msgstr ""
+
+#: templates/exhibitors/exhibitor_info.html:65
+msgid "Send vouchers to all"
+msgstr ""
+
+#: templates/exhibitors/exhibitor_info.html:75
 msgid ""
 "Drag-and-drop ordering is available only on the unfiltered, single-page list."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:70
+#: templates/exhibitors/exhibitor_info.html:80
 msgid "Booth"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:78
-#: exhibition/templates/exhibitors/exhibitor_info.html:106
+#: templates/exhibitors/exhibitor_info.html:88
+#: templates/exhibitors/exhibitor_info.html:117
 msgid "Select all partners"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:84
-#: exhibition/templates/exhibitors/exhibitor_info.html:112
+#: templates/exhibitors/exhibitor_info.html:94
+#: templates/exhibitors/exhibitor_info.html:123
 msgid "Group"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:12
-#: exhibition/templates/exhibitors/proposal_detail.html:15
+#: templates/exhibitors/proposal_detail.html:12
+#: templates/exhibitors/proposal_detail.html:15
 msgid "Review exhibition request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:21
+#: templates/exhibitors/proposal_detail.html:21
 msgid "Back to exhibition requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:29
+#: templates/exhibitors/proposal_detail.html:29
 #, python-format
 msgid "Changes made by the applicant after acceptance (%(when)s)"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:39
+#: templates/exhibitors/proposal_detail.html:39
 msgid "Before acceptance"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:40
+#: templates/exhibitors/proposal_detail.html:40
 msgid "After edit"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:55
+#: templates/exhibitors/proposal_detail.html:55
 msgid "The applicant edited the profile, but the tracked fields are unchanged."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:57
+#: templates/exhibitors/proposal_detail.html:57
 msgid ""
 "This profile was edited before change tracking was available, so the "
 "original values are not recorded."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:69
-#: exhibition/templates/exhibitors/proposal_list.html:20
+#: templates/exhibitors/proposal_detail.html:69
+#: templates/exhibitors/proposal_list.html:20
 msgid "Submitter"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:80
+#: templates/exhibitors/proposal_detail.html:80
 msgid "Hidden"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:121
+#: templates/exhibitors/proposal_detail.html:121
 msgid "Message to organizers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:129
+#: templates/exhibitors/proposal_detail.html:129
 msgid "Links"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:152
+#: templates/exhibitors/proposal_detail.html:152
 msgid "Download"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:154
+#: templates/exhibitors/proposal_detail.html:154
 msgid "Custom answers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:176
+#: templates/exhibitors/proposal_detail.html:176
 msgid "Review"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:192
-#: exhibition/templates/exhibitors/proposal_list.html:117
-#: exhibition/templates/exhibitors/proposal_list.html:164
+#: templates/exhibitors/proposal_detail.html:192
+#: templates/exhibitors/proposal_list.html:118
+#: templates/exhibitors/proposal_list.html:165
 msgid "Approve"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:195
-#: exhibition/templates/exhibitors/proposal_list.html:122
-#: exhibition/templates/exhibitors/proposal_list.html:165
+#: templates/exhibitors/proposal_detail.html:195
+#: templates/exhibitors/proposal_list.html:123
+#: templates/exhibitors/proposal_list.html:166
 msgid "Reject"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:200
+#: templates/exhibitors/proposal_detail.html:200
 msgid "Open profile"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:22
+#: templates/exhibitors/proposal_list.html:22
 msgid "Updated"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:33
+#: templates/exhibitors/proposal_list.html:33
 msgid "Select at least one request."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:34
+#: templates/exhibitors/proposal_list.html:34
 msgid "None of the selected requests can be approved."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:35
+#: templates/exhibitors/proposal_list.html:35
 msgid "None of the selected requests can be rejected."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:36
+#: templates/exhibitors/proposal_list.html:36
 #, python-brace-format
 msgid "{count} selected requests cannot be approved and will be skipped."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:37
+#: templates/exhibitors/proposal_list.html:37
 #, python-brace-format
 msgid "{count} selected requests cannot be rejected and will be skipped."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:41
+#: templates/exhibitors/proposal_list.html:41
 msgid "Approve selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:44
+#: templates/exhibitors/proposal_list.html:44
 msgid "Reject selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:55
+#: templates/exhibitors/proposal_list.html:55
 msgid "Select all matching requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:75
+#: templates/exhibitors/proposal_list.html:75
 msgid "Select request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:106
+#: templates/exhibitors/proposal_list.html:106
 msgid "Edited after acceptance, see detail view for changes."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:127
-#: exhibition/templates/exhibitors/proposal_list.html:166
-#: exhibition/templates/exhibitors/public_proposal_list.html:39
+#: templates/exhibitors/proposal_list.html:128
+#: templates/exhibitors/proposal_list.html:167
+#: templates/exhibitors/public_proposal_list.html:39
 msgid "Withdraw"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:132
-#: exhibition/templates/exhibitors/proposal_list.html:167
+#: templates/exhibitors/proposal_list.html:133
+#: templates/exhibitors/proposal_list.html:168
 msgid "Reopen for review"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:137
-#: exhibition/templates/exhibitors/public_proposal_list.html:34
+#: templates/exhibitors/proposal_list.html:138
+#: templates/exhibitors/public_proposal_list.html:34
 msgid "View"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:149
+#: templates/exhibitors/proposal_list.html:150
 msgid "No exhibition requests match your filters."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:151
+#: templates/exhibitors/proposal_list.html:152
 msgid "No exhibition requests have been submitted yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:159
+#: templates/exhibitors/proposal_list.html:160
 msgid "Approve the selected requests and create their partner profiles?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:160
+#: templates/exhibitors/proposal_list.html:161
 msgid "Reject the selected requests?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:161
+#: templates/exhibitors/proposal_list.html:162
 msgid "Reject this request?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:162
+#: templates/exhibitors/proposal_list.html:163
 msgid "Withdraw this request?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:163
+#: templates/exhibitors/proposal_list.html:164
 msgid "Reopen this request for review?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:168
+#: templates/exhibitors/proposal_list.html:169
 msgid "The action could not be completed. Please try again."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:170
+#: templates/exhibitors/proposal_list.html:171
 msgid ""
 "Approve every request matching the current filters, including those on other "
 "pages?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:171
+#: templates/exhibitors/proposal_list.html:172
 msgid ""
 "Reject every request matching the current filters, including those on other "
 "pages?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:172
+#: templates/exhibitors/proposal_list.html:173
 msgid "Please confirm"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:173
+#: templates/exhibitors/proposal_list.html:174
 msgid "Confirm"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:14
+#: templates/exhibitors/public_call.html:14
 msgid "Submit a request to become an exhibitor for this event."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:20
+#: templates/exhibitors/public_call.html:20
 #, python-format
 msgid "You can submit requests until %(deadline)s (%(timezone)s)."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:24
+#: templates/exhibitors/public_call.html:24
 #, python-format
 msgid "This call closed on %(deadline)s (%(timezone)s)."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:34
+#: templates/exhibitors/public_call.html:34
 msgid "View your requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:40
-#: exhibition/templates/exhibitors/public_proposal_form.html:18
-#: exhibition/templates/exhibitors/public_proposal_list.html:65
+#: templates/exhibitors/public_call.html:40
+#: templates/exhibitors/public_proposal_form.html:18
+#: templates/exhibitors/public_proposal_list.html:65
 msgid "Submit a request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:42
+#: templates/exhibitors/public_call.html:42
 msgid "Requests are closed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:21
-#: exhibition/templates/exhibitors/public_detail.html:94
+#: templates/exhibitors/public_detail.html:21
+#: templates/exhibitors/public_detail.html:93
 msgid "Previous"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:24
-#: exhibition/templates/exhibitors/public_detail.html:98
+#: templates/exhibitors/public_detail.html:24
+#: templates/exhibitors/public_detail.html:97
 msgid "Next"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:47
+#: templates/exhibitors/public_detail.html:47
 msgid "Get In Touch"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:87
-#: exhibition/templates/exhibitors/public_detail.html:103
+#: templates/exhibitors/public_detail.html:87
+#: templates/exhibitors/public_detail.html:102
 msgid "Open slides PDF"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:88
-#, python-brace-format
-msgid "Slide {current} of {total}"
-msgstr ""
-
-#: exhibition/templates/exhibitors/public_detail.html:112
+#: templates/exhibitors/public_detail.html:111
 msgid "Send email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:126
+#: templates/exhibitors/public_detail.html:125
 msgid "Visit website"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_list.html:54
+#: templates/exhibitors/public_list.html:32
+msgid "Clear"
+msgstr ""
+
+#: templates/exhibitors/public_list.html:54
 msgid "No exhibitors match your search."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_list.html:56
+#: templates/exhibitors/public_list.html:56
 msgid "No exhibitors are currently available."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:16
+#: templates/exhibitors/public_proposal_form.html:16
 msgid "Edit request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:23
-#: exhibition/views.py:883
+#: templates/exhibitors/public_proposal_form.html:23 views.py:958
 msgid "This request can no longer be edited."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:186
+#: templates/exhibitors/public_proposal_form.html:190
 msgid "Submit request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:189
+#: templates/exhibitors/public_proposal_form.html:193
 msgid "or save as draft for now"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:199
+#: templates/exhibitors/public_proposal_form.html:203
 msgid "Back to your requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:5
+#: templates/exhibitors/public_proposal_list.html:5
 msgid "Your exhibition requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:13
+#: templates/exhibitors/public_proposal_list.html:13
 msgid "Last modified"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:23
+#: templates/exhibitors/public_proposal_list.html:23
 msgid "Withdrawn"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:44
+#: templates/exhibitors/public_proposal_list.html:44
 msgid "Reinstate"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:56
+#: templates/exhibitors/public_proposal_list.html:56
 msgid "Create a new request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:61
+#: templates/exhibitors/public_proposal_list.html:61
 msgid "You have not submitted an exhibition request yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:5
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:21
+#: templates/exhibitors/public_proposal_reinstate.html:5
+#: templates/exhibitors/public_proposal_reinstate.html:21
 msgid "Reinstate request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:7
+#: templates/exhibitors/public_proposal_reinstate.html:7
 #, python-format
 msgid ""
 "Do you want to reinstate your withdrawn request “%(name)s”? It will be "
 "pending review again."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:5
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:26
+#: templates/exhibitors/public_proposal_withdraw.html:5
+#: templates/exhibitors/public_proposal_withdraw.html:26
 msgid "Withdraw request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:7
+#: templates/exhibitors/public_proposal_withdraw.html:7
 #, python-format
 msgid "Are you sure you want to withdraw your request “%(name)s”?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:13
+#: templates/exhibitors/public_proposal_withdraw.html:13
 msgid ""
 "This request has already been approved. Withdrawing it will hide the "
 "exhibitor or sponsor profile created from it from public listings."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:10
-#: exhibition/templates/exhibitors/settings.html:27
+#: templates/exhibitors/settings.html:10 templates/exhibitors/settings.html:29
 msgid "Sponsor Settings"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:12
-#: exhibition/templates/exhibitors/settings.html:29
+#: templates/exhibitors/settings.html:12 templates/exhibitors/settings.html:31
+msgid "Voucher Settings"
+msgstr ""
+
+#: templates/exhibitors/settings.html:14 templates/exhibitors/settings.html:33
 msgid "Exhibitor Settings"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:42
+#: templates/exhibitors/settings.html:46
 msgid "Publish your call"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:43
+#: templates/exhibitors/settings.html:47
 msgid "Publish a login-required application form for exhibitors."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:72
+#: templates/exhibitors/settings.html:76
 msgid ""
 "This panel renders unsaved draft text using the same styling as the live "
 "public call page."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:104
+#: templates/exhibitors/settings.html:108
 msgid "Secret call link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:107
+#: templates/exhibitors/settings.html:111
 msgid ""
 "This call is private: it is not linked anywhere public. Share the link below "
 "with the organizations you want to invite. Anyone who has it can open the "
 "call and apply."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:113
+#: templates/exhibitors/settings.html:117
 msgid "Copied"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:113
+#: templates/exhibitors/settings.html:117
 msgid "Copy to clipboard"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:114
+#: templates/exhibitors/settings.html:118
 msgid "Copy"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:119
+#: templates/exhibitors/settings.html:123
 msgid ""
 "Regenerate the secret link? The current link will stop working immediately."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:125
+#: templates/exhibitors/settings.html:129
 msgid "Regenerate link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:127
+#: templates/exhibitors/settings.html:131
 msgid "Regenerating immediately invalidates the current link."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:138
+#: templates/exhibitors/settings.html:143
+msgid "Voucher pools"
+msgstr ""
+
+#: templates/exhibitors/settings.html:147
+msgid ""
+"Create the voucher codes under Tickets → Vouchers and give them a tag, then "
+"pick that tag here. Exhibitors and sponsors are handed codes from the pool "
+"you choose. Reload this page to pick up a tag you just created."
+msgstr ""
+
+#: templates/exhibitors/settings.html:157
+msgid "Create vouchers pool"
+msgstr ""
+
+#: templates/exhibitors/settings.html:159
+msgid "(opens in a new tab)"
+msgstr ""
+
+#: templates/exhibitors/settings.html:168
+#: templates/exhibitors/settings.html:182
+#, python-format
+msgid "%(counter)s voucher in this pool is not assigned to anyone yet."
+msgid_plural ""
+"%(counter)s vouchers in this pool are not assigned to anyone yet."
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/exhibitors/settings.html:194
+msgid "How many each one gets"
+msgstr ""
+
+#: templates/exhibitors/settings.html:196
+msgid ""
+"Applies to any exhibitor or sponsor that does not belong to a sponsor group. "
+"Sponsor groups set their own number on the Sponsors page, and an individual "
+"exhibitor or sponsor can be given a different number on their own voucher "
+"page."
+msgstr ""
+
+#: templates/exhibitors/settings.html:206
+msgid "Voucher email"
+msgstr ""
+
+#: templates/exhibitors/settings.html:208
+msgid "Applies to the voucher email sent to exhibitors and sponsors alike."
+msgstr ""
+
+#: templates/exhibitors/settings.html:228
 msgid "Data access"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:139
+#: templates/exhibitors/settings.html:229
 msgid ""
 "In this section, you can control which attendee data is shared with "
 "exhibitors when an exhibitor voucher is used or when the exhibitor uses the "
 "lead scanning app."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:142
+#: templates/exhibitors/settings.html:232
 msgid "Exhibitor vouchers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:158
-msgid "Exhibitor login"
-msgstr ""
-
-#: exhibition/templates/exhibitors/settings.html:160
-msgid ""
-"The access-code email sent to exhibitors is now edited together with the "
-"plugin's other email templates."
-msgstr ""
-
-#: exhibition/templates/exhibitors/settings.html:162
-msgid "Edit email templates"
-msgstr ""
-
-#: exhibition/templates/exhibitors/settings.html:177
+#: templates/exhibitors/settings.html:257
 msgid "Group List"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:180
+#: templates/exhibitors/settings.html:260
 msgid "Add a Group"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:193
+#: templates/exhibitors/settings.html:272
+#: templates/exhibitors/settings.html:354
+msgid "Voucher defaults for this group"
+msgstr ""
+
+#: templates/exhibitors/settings.html:277
 msgid "Add"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:204
+#: templates/exhibitors/settings.html:288
 msgid "Group Name"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:206
+#: templates/exhibitors/settings.html:290
 msgid "Partners"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:207
+#: templates/exhibitors/settings.html:291
 msgid "Front Page"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:220
-#: exhibition/templates/exhibitors/settings.html:226
+#: templates/exhibitors/settings.html:304
+#: templates/exhibitors/settings.html:310
 msgid "Show this sponsor group in the Supported By section on the front page."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:251
+#: templates/exhibitors/settings.html:326
+msgid "Edit sponsor group"
+msgstr ""
+
+#: templates/exhibitors/settings.html:337
 msgid "Reorder sponsor group"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:281
+#: templates/exhibitors/settings.html:371
 msgid "You do not have any sponsor groups yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:8
+#: templates/exhibitors/voucher_bulk_send.html:4
+#: templates/exhibitors/voucher_bulk_send.html:7
+msgid "Send vouchers"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:18
+#, python-format
+msgid "A voucher email will be placed in the outbox for %(counter)s sponsor."
+msgid_plural ""
+"A voucher email will be placed in the outbox for %(counter)s sponsors."
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:24
+#, python-format
+msgid "A voucher email will be placed in the outbox for %(counter)s exhibitor."
+msgid_plural ""
+"A voucher email will be placed in the outbox for %(counter)s exhibitors."
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:37
+#, python-format
+msgid "&mdash; %(counter)s voucher will be created"
+msgid_plural "&mdash; %(counter)s vouchers will be created"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:45
+#, python-format
+msgid "&mdash; %(counter)s existing voucher"
+msgid_plural "&mdash; %(counter)s existing vouchers"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:58
+msgid "None of the sponsors in this list can be emailed yet."
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:60
+msgid "None of the exhibitors in this list can be emailed yet."
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:66
+msgid "Skipped: no email address"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:75
+msgid "Skipped: voucher count is set to 0"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:84
+msgid "Skipped: no vouchers available from their pool"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:86
+msgid ""
+"Check that a voucher pool is selected under Settings → Vouchers and that it "
+"still has unassigned codes."
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:99
+msgid "Queue emails"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:8
 #, python-format
 msgid "Vouchers for %(name)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:13
+#: templates/exhibitors/vouchers.html:13
 msgid ""
-"Issue ticket vouchers for this partner to hand out. Whoever redeems one on "
-"the ticket shop becomes a lead this partner can retrieve, as long as voucher "
+"Hand this exhibitor or sponsor codes from the voucher pool. Whoever redeems "
+"one on the ticket shop becomes a lead they can retrieve, as long as voucher "
 "data access is enabled for them."
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:20
-msgid "Issued vouchers"
+#: templates/exhibitors/vouchers.html:20
+msgid "Assigned vouchers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:24
+#: templates/exhibitors/vouchers.html:24
 msgid "Download codes (CSV)"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:31
+#: templates/exhibitors/vouchers.html:31
 msgid "Code"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:32 exhibition/views.py:1994
+#: templates/exhibitors/vouchers.html:32 utils.py:495
 msgid "Product"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:34 exhibition/views.py:1998
+#: templates/exhibitors/vouchers.html:33 utils.py:496
+msgid "Price effect"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:34 utils.py:499
 msgid "Redeemed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:56
+#: templates/exhibitors/vouchers.html:35 utils.py:498
+msgid "Valid until"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:56
 msgid "Already redeemed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:67
-msgid "No vouchers have been issued for this partner yet."
+#: templates/exhibitors/vouchers.html:62
+msgid "Return to pool"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:76
-msgid "Issue new vouchers"
+#: templates/exhibitors/vouchers.html:74
+msgid "No vouchers have been assigned to this partner yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:86
-msgid "Create vouchers"
+#: templates/exhibitors/vouchers.html:82
+msgid "Take more from the pool"
 msgstr ""
 
-#: exhibition/templates/sponsors/presale_supported_by.html:4
+#: templates/exhibitors/vouchers.html:84
+msgid ""
+"Codes come from the voucher pool chosen under Settings. The email always "
+"carries this partner's complete list of codes, so you can assign some now "
+"and send them together with more later. It is placed in the outbox for you "
+"to review before it goes out."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:92
+#, python-format
+msgid "%(counter)s voucher is left unassigned in the pool."
+msgid_plural "%(counter)s vouchers are left unassigned in the pool."
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/exhibitors/vouchers.html:100 views.py:2230
+msgid "No voucher pool is selected yet. Choose one under Settings → Vouchers."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:106
+msgid "A voucher email for this partner is waiting in the outbox."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:108
+msgid "Go to outbox"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:114
+#, python-format
+msgid "Vouchers were last emailed to this partner on %(sent)s."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:120
+msgid ""
+"This partner has no email address on file, so vouchers cannot be emailed."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:127
+msgid "Assign and prepare email"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:130
+msgid "Assign without emailing"
+msgstr ""
+
+#: templates/sponsors/presale_supported_by.html:4
 msgid "Supported By"
 msgstr ""
 
-#: exhibition/views.py:324
+#: utils.py:493
+msgid "Voucher code"
+msgstr ""
+
+#: utils.py:494
+msgid "Redeem link"
+msgstr ""
+
+#: utils.py:497
+msgid "Value"
+msgstr ""
+
+#: utils.py:500
+msgid "Maximum usages"
+msgstr ""
+
+#: views.py:342
 msgid "Company name"
 msgstr ""
 
-#: exhibition/views.py:325
+#: views.py:343
 msgid "Job title"
 msgstr ""
 
-#: exhibition/views.py:326
+#: views.py:344
 msgid "Address"
 msgstr ""
 
-#: exhibition/views.py:333
+#: views.py:351
 msgid "Attendee Name"
 msgstr ""
 
-#: exhibition/views.py:338
+#: views.py:356
 msgid "Attendee Email"
 msgstr ""
 
-#: exhibition/views.py:377
+#: views.py:395 views.py:412
 msgid "Settings have been saved."
 msgstr ""
 
-#: exhibition/views.py:393
+#: views.py:428
 msgid "Call settings have been saved."
 msgstr ""
 
-#: exhibition/views.py:401
+#: views.py:436
 msgid ""
 "A new secret call link has been generated. The old link no longer works."
 msgstr ""
 
-#: exhibition/views.py:416
+#: views.py:451
 msgid "Sponsor group added."
 msgstr ""
 
-#: exhibition/views.py:437
+#: views.py:454 views.py:477 views.py:853 views.py:1169 views.py:1796
+#: views.py:1918 views.py:2564 views.py:3025
+msgid "We could not save your changes. See below for details."
+msgstr ""
+
+#: views.py:474
 msgid "Sponsor group updated."
 msgstr ""
 
-#: exhibition/views.py:452
+#: views.py:491
 msgid "This sponsor group cannot be deleted while it is assigned to partners."
 msgstr ""
 
-#: exhibition/views.py:460
+#: views.py:499
 msgid "Unknown action."
 msgstr ""
 
-#: exhibition/views.py:505
+#: views.py:544
 msgid "Access key"
 msgstr ""
 
-#: exhibition/views.py:745 exhibition/views.py:1060
+#: views.py:819 views.py:1135
 msgid "Add at least one social media link."
 msgstr ""
 
-#: exhibition/views.py:754 exhibition/views.py:1069
+#: views.py:828 views.py:1144
 msgid "Add at least one extra link."
 msgstr ""
 
-#: exhibition/views.py:809
+#: views.py:884
 msgid "The call for exhibitors is closed."
 msgstr ""
 
-#: exhibition/views.py:837
+#: views.py:912
 msgid "Your request has been saved."
 msgstr ""
 
-#: exhibition/views.py:920 exhibition/views.py:1776
+#: views.py:995 views.py:1914
 msgid "Your changes have been saved."
 msgstr ""
 
-#: exhibition/views.py:953
+#: views.py:1028
 msgid "This proposal can no longer be withdrawn."
 msgstr ""
 
-#: exhibition/views.py:961
+#: views.py:1036
 msgid "Your request has been withdrawn."
 msgstr ""
 
-#: exhibition/views.py:963
+#: views.py:1038
 msgid "This request can no longer be withdrawn."
 msgstr ""
 
-#: exhibition/views.py:989 exhibition/views.py:999
+#: views.py:1064 views.py:1074
 msgid "This request can no longer be reinstated."
 msgstr ""
 
-#: exhibition/views.py:997
+#: views.py:1072
 msgid "Your request has been reinstated and is pending review again."
 msgstr ""
 
-#: exhibition/views.py:1121
+#: views.py:1197
 msgid "Invalid request body."
 msgstr ""
 
-#: exhibition/views.py:1124 exhibition/views.py:1129
+#: views.py:1200 views.py:1205
 msgid "Invalid sponsor group IDs."
 msgstr ""
 
-#: exhibition/views.py:1133
+#: views.py:1209
 msgid "Sponsor group IDs must be unique."
 msgstr ""
 
-#: exhibition/views.py:1141
+#: views.py:1217
 msgid "Reorder request must include each sponsor group exactly once."
 msgstr ""
 
-#: exhibition/views.py:1346
+#: views.py:1422
 msgid "This request can no longer be changed to that state."
 msgstr ""
 
-#: exhibition/views.py:1350
+#: views.py:1426
 msgid "Review details saved."
 msgstr ""
 
-#: exhibition/views.py:1359
+#: views.py:1435
 msgid ""
 "Request approved and partner profile created. An acceptance email was placed "
 "in the outbox."
 msgstr ""
 
-#: exhibition/views.py:1369
+#: views.py:1445
 msgid "Request rejected. A rejection email was placed in the outbox."
 msgstr ""
 
-#: exhibition/views.py:1372
+#: views.py:1448
 msgid "Request withdrawn."
 msgstr ""
 
-#: exhibition/views.py:1375
+#: views.py:1451
 msgid "Request reopened for review."
 msgstr ""
 
-#: exhibition/views.py:1407
+#: views.py:1483
 msgid "No valid action was selected."
 msgstr ""
 
-#: exhibition/views.py:1454
+#: views.py:1530
 #, python-format
 msgid "%(count)d request was approved."
 msgid_plural "%(count)d requests were approved."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1455
+#: views.py:1531
 #, python-format
 msgid "%(count)d request was rejected."
 msgid_plural "%(count)d requests were rejected."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1456
+#: views.py:1532
 #, python-format
 msgid "%(count)d request was withdrawn."
 msgid_plural "%(count)d requests were withdrawn."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1457
+#: views.py:1533
 #, python-format
 msgid "%(count)d request was reopened."
 msgid_plural "%(count)d requests were reopened."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1461
+#: views.py:1537
 msgid "No proposals were updated."
 msgstr ""
 
-#: exhibition/views.py:1464
+#: views.py:1540
 #, python-format
 msgid "%(skipped)d was skipped because it was already processed."
 msgid_plural "%(skipped)d were skipped because they were already processed."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1605
+#: views.py:1681
 msgid "Exhibitor form settings have been saved."
 msgstr ""
 
-#: exhibition/views.py:1730
+#: views.py:1868
 msgid "The requested form field does not exist."
 msgstr ""
 
-#: exhibition/views.py:1791
+#: views.py:1933
 msgid "The field has been reset to its default."
 msgstr ""
 
-#: exhibition/views.py:1829 exhibition/views.py:1900
+#: views.py:1971 views.py:2042
 msgid "An access-credentials email was placed in the outbox."
 msgstr ""
 
-#: exhibition/views.py:1907
+#: views.py:2049
 msgid "Edit Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1908
+#: views.py:2050
 msgid "Edit Exhibitor"
 msgstr ""
 
-#: exhibition/views.py:1909
+#: views.py:2051
 msgid "Edit Exhibitor & Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1910
+#: views.py:2052
 msgid "Edit Exhibitor or Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1940
+#: views.py:2082
 msgid "Delete Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1941
+#: views.py:2083
 msgid "Delete Exhibitor"
 msgstr ""
 
-#: exhibition/views.py:1942
+#: views.py:2084
 msgid "Delete Exhibitor & Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1943
+#: views.py:2085
 msgid "Delete Exhibitor or Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1992
-msgid "Voucher code"
+#: views.py:2164
+msgid "This voucher has already been redeemed and cannot be returned."
 msgstr ""
 
-#: exhibition/views.py:1993
-msgid "Redeem link"
+#: views.py:2170
+msgid ""
+"This code was already included in a voucher email to this partner, so it "
+"cannot be returned to the pool. Delete it under Tickets → Vouchers instead."
 msgstr ""
 
-#: exhibition/views.py:1999
-msgid "Maximum usages"
+#: views.py:2176
+msgid "Voucher returned to the pool."
 msgstr ""
 
-#: exhibition/views.py:2035
-msgid "This voucher has already been redeemed and cannot be removed."
+#: views.py:2207
+msgid "Enter how many vouchers to take from the pool."
 msgstr ""
 
-#: exhibition/views.py:2040
-msgid "Voucher removed."
-msgstr ""
-
-#: exhibition/views.py:2060
+#: views.py:2215
 #, python-format
-msgid "%(count)d voucher created."
-msgid_plural "%(count)d vouchers created."
+msgid "%(count)d voucher taken from the pool."
+msgid_plural "%(count)d vouchers taken from the pool."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2112
+#: views.py:2232
+#, python-format
+msgid ""
+"The pool only has %(remaining)d voucher(s) left, so %(count)d cannot be "
+"taken."
+msgstr ""
+
+#: views.py:2244
+msgid "No email address is on file, so vouchers cannot be emailed."
+msgstr ""
+
+#: views.py:2253
+msgid "This partner holds no vouchers yet, so there is nothing to email."
+msgstr ""
+
+#: views.py:2259
+#, python-format
+msgid "An email with %(count)d voucher code was placed in the outbox."
+msgid_plural "An email with %(count)d voucher codes was placed in the outbox."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2347
+msgid "There is nobody to send vouchers to in this list."
+msgstr ""
+
+#: views.py:2354
+#, python-format
+msgid "%(count)d voucher email was placed in the outbox."
+msgid_plural "%(count)d voucher emails were placed in the outbox."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2371
+#, python-format
+msgid ""
+"%(count)d was skipped because no unassigned codes were available from their "
+"pool."
+msgid_plural ""
+"%(count)d were skipped because no unassigned codes were available from their "
+"pool."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2386
+#, python-format
+msgid "%(count)d sponsor was skipped because it has no email address."
+msgid_plural ""
+"%(count)d sponsors were skipped because they have no email address."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2392
+#, python-format
+msgid "%(count)d exhibitor was skipped because it has no email address."
+msgid_plural ""
+"%(count)d exhibitors were skipped because they have no email address."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2401
+#, python-format
+msgid "%(count)d sponsor was skipped because their voucher count is set to 0."
+msgid_plural ""
+"%(count)d sponsors were skipped because their voucher count is set to 0."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2407
+#, python-format
+msgid ""
+"%(count)d exhibitor was skipped because their voucher count is set to 0."
+msgid_plural ""
+"%(count)d exhibitors were skipped because their voucher count is set to 0."
+msgstr[0] ""
+msgstr[1] ""
+
+#: views.py:2461
 #, python-format
 msgid "%(count)d device added."
 msgid_plural "%(count)d devices added."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2123
+#: views.py:2472
 #, python-format
 msgid ""
 "New setup tokens generated. %(count)d device that was already scanning is "
@@ -2738,79 +3031,95 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2132
+#: views.py:2481
 msgid "New setup tokens generated."
 msgstr ""
 
-#: exhibition/views.py:2194
+#: views.py:2543
 msgid "No applicants matched the selected filters."
 msgstr ""
 
-#: exhibition/views.py:2202
+#: views.py:2551
 #, python-format
 msgid "%(count)d emails have been scheduled."
 msgstr ""
 
-#: exhibition/views.py:2206
+#: views.py:2555
 #, python-format
 msgid "%(count)d emails have been sent."
 msgstr ""
 
-#: exhibition/views.py:2210
+#: views.py:2559
 #, python-format
 msgid "%(count)d emails have been placed in the outbox."
 msgstr ""
 
-#: exhibition/views.py:2385
+#: views.py:2738
 msgid "The emails have been saved and sent."
 msgstr ""
 
-#: exhibition/views.py:2389
+#: views.py:2742
 msgid "The emails have been saved."
 msgstr ""
 
-#: exhibition/views.py:2395
+#: views.py:2748
 msgid "The email has been saved and sent."
 msgstr ""
 
-#: exhibition/views.py:2399
+#: views.py:2752
 msgid "The email has been saved."
 msgstr ""
 
-#: exhibition/views.py:2423 exhibition/views.py:2497
+#: views.py:2776 views.py:2850
 #, python-format
 msgid "%(count)d email has been sent."
 msgid_plural "%(count)d emails have been sent."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2459
+#: views.py:2812
 msgid "The email has been discarded."
 msgstr ""
 
-#: exhibition/views.py:2501 exhibition/views.py:2514 exhibition/views.py:2519
+#: views.py:2854 views.py:2867 views.py:2872
 msgid "No emails were selected."
 msgstr ""
 
-#: exhibition/views.py:2510
+#: views.py:2863
 #, python-format
 msgid "%(count)d email has been discarded."
 msgid_plural "%(count)d emails have been discarded."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2594
+#: views.py:2929
+msgid "Request received (confirmation)"
+msgstr ""
+
+#: views.py:2930
+msgid "Request accepted"
+msgstr ""
+
+#: views.py:2931
+msgid "Request rejected"
+msgstr ""
+
+#: views.py:2932
+msgid "Exhibitor lead scanning key"
+msgstr ""
+
+#: views.py:2948
 msgid "Email templates have been saved."
 msgstr ""
 
-#: exhibition/views.py:2617 exhibition/views.py:2621
+#: views.py:2971 views.py:2975
 msgid "Unknown template."
 msgstr ""
 
-#: exhibition/views.py:2667
+#: views.py:3021
 msgid "Custom template has been created."
 msgstr ""
 
-#: exhibition/views.py:2683
+#: views.py:3041
 msgid "Custom template has been deleted."
 msgstr ""

--- a/exhibition/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/exhibition/locale/zh_Hans/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-29 10:33+0000\n"
+"POT-Creation-Date: 2026-09-11 11:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,595 +18,531 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: exhibition/apps.py:14 exhibition/apps.py:17 exhibition/signals.py:157
-#: exhibition/templates/exhibitors/public_list.html:6
-#: exhibition/templates/exhibitors/public_list.html:14
-#: exhibition/templates/exhibitors/public_list.html:16
+#: apps.py:14 apps.py:17 signals.py:163 templates/exhibitors/public_list.html:6
+#: templates/exhibitors/public_list.html:14
+#: templates/exhibitors/public_list.html:16
 msgid "Exhibition"
 msgstr ""
 
-#: exhibition/apps.py:19
+#: apps.py:19
 msgid "This plugin enables to add and control exhibitors in eventyay"
 msgstr ""
 
-#: exhibition/filters.py:9
+#: filters.py:9
 msgid "Any"
 msgstr ""
 
-#: exhibition/filters.py:10
+#: filters.py:10
 msgid "Enabled"
 msgstr ""
 
-#: exhibition/filters.py:11 exhibition/templates/exhibitors/dashboard.html:127
+#: filters.py:11 templates/exhibitors/dashboard.html:127
 msgid "Disabled"
 msgstr ""
 
-#: exhibition/filters.py:15
+#: filters.py:15
 msgid "All types"
 msgstr ""
 
-#: exhibition/filters.py:16
+#: filters.py:16
 msgid "Exhibitor only"
 msgstr ""
 
-#: exhibition/filters.py:17
+#: filters.py:17
 msgid "Sponsor only"
 msgstr ""
 
-#: exhibition/filters.py:18 exhibition/templates/exhibitors/dashboard.html:89
-#: exhibition/templates/exhibitors/proposal_detail.html:95
-#: exhibition/templates/exhibitors/proposal_list.html:95
+#: filters.py:18 templates/exhibitors/dashboard.html:89
+#: templates/exhibitors/proposal_detail.html:95
+#: templates/exhibitors/proposal_list.html:95
 msgid "Exhibitor and sponsor"
 msgstr ""
 
-#: exhibition/filters.py:80 exhibition/filters.py:81
+#: filters.py:80 filters.py:81
 msgid "Search requests…"
 msgstr ""
 
-#: exhibition/filters.py:81
+#: filters.py:81
 msgid "Search requests"
 msgstr ""
 
-#: exhibition/filters.py:85 exhibition/templates/exhibitors/dashboard.html:75
-#: exhibition/templates/exhibitors/proposal_detail.html:85
-#: exhibition/templates/exhibitors/proposal_list.html:21
-#: exhibition/templates/exhibitors/public_proposal_list.html:12
+#: filters.py:85 templates/exhibitors/dashboard.html:75
+#: templates/exhibitors/proposal_detail.html:85
+#: templates/exhibitors/proposal_list.html:21
+#: templates/exhibitors/public_proposal_list.html:12
 msgid "State"
 msgstr ""
 
-#: exhibition/filters.py:86
+#: filters.py:86
 msgid "All states"
 msgstr ""
 
-#: exhibition/filters.py:90 exhibition/templates/exhibitors/dashboard.html:74
-#: exhibition/templates/exhibitors/proposal_detail.html:91
-#: exhibition/templates/exhibitors/proposal_list.html:62
+#: filters.py:90 templates/exhibitors/dashboard.html:74
+#: templates/exhibitors/proposal_detail.html:91
+#: templates/exhibitors/proposal_list.html:62
 msgid "Type"
 msgstr ""
 
-#: exhibition/filters.py:99 exhibition/filters.py:102
+#: filters.py:99 filters.py:102
 msgid "Search by name…"
 msgstr ""
 
-#: exhibition/filters.py:103
+#: filters.py:103
 msgid "Search requests by name"
 msgstr ""
 
-#: exhibition/filters.py:132 exhibition/filters.py:133
+#: filters.py:132 filters.py:133
 msgid "Search organizations…"
 msgstr ""
 
-#: exhibition/filters.py:133
+#: filters.py:133
 msgid "Search organizations"
 msgstr ""
 
-#: exhibition/filters.py:137
+#: filters.py:137
 msgid "Visibility"
 msgstr ""
 
-#: exhibition/filters.py:139
+#: filters.py:139
 msgid "All organizations"
 msgstr ""
 
-#: exhibition/filters.py:140 exhibition/forms.py:1512
-#: exhibition/templates/exhibitors/call_questions.html:30
+#: filters.py:140 forms.py:1553 templates/exhibitors/call_questions.html:30
 msgid "Active"
 msgstr ""
 
-#: exhibition/filters.py:141
+#: filters.py:141
 msgid "Inactive"
 msgstr ""
 
-#: exhibition/filters.py:146 exhibition/filters.py:207 exhibition/forms.py:207
-#: exhibition/forms.py:1410 exhibition/forms.py:1841
+#: filters.py:146 filters.py:207 forms.py:212 forms.py:1411 forms.py:1888
 msgid "Sponsor group"
 msgstr ""
 
-#: exhibition/filters.py:149 exhibition/filters.py:210
+#: filters.py:149 filters.py:210
 msgid "All groups"
 msgstr ""
 
-#: exhibition/filters.py:152 exhibition/templates/exhibitors/add.html:222
+#: filters.py:152 templates/exhibitors/add.html:226
 msgid "Lead scanning"
 msgstr ""
 
-#: exhibition/filters.py:157
+#: filters.py:157
 msgid "Lead access"
 msgstr ""
 
-#: exhibition/filters.py:162
+#: filters.py:162
 msgid "Voucher access"
 msgstr ""
 
-#: exhibition/filters.py:202 exhibition/filters.py:203
+#: filters.py:202 filters.py:203
 msgid "Search exhibitors…"
 msgstr ""
 
-#: exhibition/filters.py:203
+#: filters.py:203
 msgid "Search exhibitors"
 msgstr ""
 
-#: exhibition/filters.py:240 exhibition/filters.py:241
+#: filters.py:240 filters.py:241
 msgid "Search emails…"
 msgstr ""
 
-#: exhibition/filters.py:241
+#: filters.py:241
 msgid "Search emails"
 msgstr ""
 
-#: exhibition/forms.py:67
+#: forms.py:72
 #, python-format
 msgid "Times are in the event timezone: %(tz)s."
 msgstr ""
 
-#: exhibition/forms.py:128 exhibition/forms.py:139 exhibition/forms.py:933
-#: exhibition/forms.py:944
+#: forms.py:133 forms.py:144 forms.py:934 forms.py:945
 msgid "— No selection —"
 msgstr ""
 
-#: exhibition/forms.py:211
+#: forms.py:216
 msgid "Can view voucher redemptions"
 msgstr ""
 
-#: exhibition/forms.py:213 exhibition/forms.py:397
+#: forms.py:218 forms.py:402
 msgid ""
 "Lets this exhibitor or sponsor retrieve the attendees who redeemed vouchers "
 "issued to them. Separate from lead scanning, which covers attendees scanned "
 "at the booth."
 msgstr ""
 
-#: exhibition/forms.py:219
+#: forms.py:224
 msgid "Can view and export collected leads"
 msgstr ""
 
-#: exhibition/forms.py:221
+#: forms.py:226
 msgid ""
 "Lets this exhibitor retrieve the full list of leads they have already "
 "scanned. Turn this off to let them keep scanning without seeing the "
 "collected attendee data."
 msgstr ""
 
-#: exhibition/forms.py:226
+#: forms.py:231
 msgid "Lead scanning behavior"
 msgstr ""
 
-#: exhibition/forms.py:231
+#: forms.py:236
 msgid ""
 "Every attendee is one lead, even when scanned from multiple devices. Notes "
 "and ratings are shared between devices."
 msgstr ""
 
-#: exhibition/forms.py:238
+#: forms.py:243
 msgid ""
 "Every attendee is a new lead when scanned from a new device. Notes and "
 "ratings are specific to the device."
 msgstr ""
 
-#: exhibition/forms.py:251
+#: forms.py:256
 msgid "Comment"
 msgstr ""
 
-#: exhibition/forms.py:253
+#: forms.py:258
 msgid ""
 "The text entered in this field will not be visible to the user and is "
 "available for your convenience."
 msgstr ""
 
-#: exhibition/forms.py:258 exhibition/forms.py:1427 exhibition/views.py:505
+#: forms.py:263 forms.py:1428 views.py:544
 msgid "Booth ID"
 msgstr ""
 
-#: exhibition/forms.py:291 exhibition/forms.py:1027 exhibition/forms.py:1076
-#: exhibition/models.py:130
+#: forms.py:296 forms.py:1028 forms.py:1077 models.py:130
 msgid "Organization name"
 msgstr ""
 
-#: exhibition/forms.py:292 exhibition/forms.py:1030 exhibition/forms.py:1077
-#: exhibition/models.py:136
+#: forms.py:297 forms.py:1031 forms.py:1078 models.py:136
 msgid "Organization description"
 msgstr ""
 
-#: exhibition/forms.py:293 exhibition/forms.py:1078
+#: forms.py:298 forms.py:1079
 msgid "E-mail"
 msgstr ""
 
-#: exhibition/forms.py:294 exhibition/forms.py:1079 exhibition/models.py:139
+#: forms.py:299 forms.py:1080 models.py:139
 msgid "Contact page URL"
 msgstr ""
 
-#: exhibition/forms.py:295 exhibition/forms.py:1080 exhibition/models.py:140
+#: forms.py:300 forms.py:1081 models.py:140
 msgid "Promotional video URL"
 msgstr ""
 
-#: exhibition/forms.py:296 exhibition/forms.py:1081 exhibition/models.py:141
+#: forms.py:301 forms.py:1082 models.py:141
 msgid "Promotional slides"
 msgstr ""
 
-#: exhibition/forms.py:297 exhibition/forms.py:1082 exhibition/models.py:142
-#: exhibition/models.py:520
-#: exhibition/templates/exhibitors/proposal_detail.html:111
+#: forms.py:302 forms.py:1083 models.py:142 models.py:568
+#: templates/exhibitors/proposal_detail.html:111
 msgid "Logo"
 msgstr ""
 
-#: exhibition/forms.py:298 exhibition/forms.py:1083 exhibition/models.py:145
-#: exhibition/templates/exhibitors/proposal_detail.html:113
+#: forms.py:303 forms.py:1084 models.py:145
+#: templates/exhibitors/proposal_detail.html:113
 msgid "Header image"
 msgstr ""
 
-#: exhibition/forms.py:299 exhibition/forms.py:1084 exhibition/models.py:138
+#: forms.py:304 forms.py:1085 models.py:138
 msgid "Organization website"
 msgstr ""
 
-#: exhibition/forms.py:300
+#: forms.py:305
 msgid "Mark this partner as an exhibitor"
 msgstr ""
 
-#: exhibition/forms.py:301
+#: forms.py:306
 msgid "Mark this partner as an event sponsor"
 msgstr ""
 
-#: exhibition/forms.py:302 exhibition/forms.py:1036 exhibition/forms.py:1085
-#: exhibition/models.py:148 exhibition/models.py:522
+#: forms.py:307 forms.py:1037 forms.py:1086 models.py:148 models.py:570
 msgid "Preferred booth name"
 msgstr ""
 
-#: exhibition/forms.py:303
+#: forms.py:308
 msgid "Can scan attendee badges"
 msgstr ""
 
-#: exhibition/forms.py:307
+#: forms.py:312
 msgid ""
 "Lets this exhibitor sign in to the lead scanning app and scan attendees at "
 "their booth. Turn this off to block scanning entirely."
 msgstr ""
 
-#: exhibition/forms.py:348 exhibition/forms.py:1441
+#: forms.py:353 forms.py:1442
 msgid "No sponsor group"
 msgstr ""
 
-#: exhibition/forms.py:385
+#: forms.py:390
 msgid ""
 "Lets this exhibitor retrieve the attendees who redeemed vouchers issued to "
 "them. Separate from lead scanning, which covers attendees scanned at the "
 "booth."
 msgstr ""
 
-#: exhibition/forms.py:389
+#: forms.py:394
 msgid ""
 "Lets this sponsor retrieve the attendees who redeemed vouchers issued to "
 "them. Separate from lead scanning, which covers attendees scanned at the "
 "booth."
 msgstr ""
 
-#: exhibition/forms.py:393
+#: forms.py:398
 msgid ""
 "Lets this exhibitor and sponsor retrieve the attendees who redeemed vouchers "
 "issued to them. Separate from lead scanning, which covers attendees scanned "
 "at the booth."
 msgstr ""
 
-#: exhibition/forms.py:466 exhibition/forms.py:553 exhibition/forms.py:1361
-#: exhibition/forms.py:1375
+#: forms.py:471 forms.py:558 forms.py:1362 forms.py:1376 forms.py:1855
+#: forms.py:1924 forms.py:1930 forms.py:1932 forms.py:1934
 msgid "This field is required."
 msgstr ""
 
-#: exhibition/forms.py:511 exhibition/forms.py:516
+#: forms.py:516 forms.py:521
 msgid "Slides upload must be a PDF file."
 msgstr ""
 
-#: exhibition/forms.py:540
+#: forms.py:545
 msgid "A partner must be marked as an exhibitor, a sponsor, or both."
 msgstr ""
 
-#: exhibition/forms.py:615
+#: forms.py:620
 msgid "Devices to add"
 msgstr ""
 
-#: exhibition/forms.py:617
+#: forms.py:622
 msgid ""
 "How many new devices to provision now, in addition to any already listed "
 "above. Each device gets its own single-use setup token and QR code."
 msgstr ""
 
-#: exhibition/forms.py:627
-msgid "Select a product…"
+#: forms.py:635
+msgid "Vouchers to take from the pool"
 msgstr ""
 
-#: exhibition/forms.py:628
-msgid "Ticket product"
+#: forms.py:636
+msgid ""
+"Set to 0 to email the codes this partner already has without taking any more."
 msgstr ""
 
-#: exhibition/forms.py:629
-msgid "The product a redeemed voucher applies to."
-msgstr ""
-
-#: exhibition/forms.py:635
-msgid "Number of vouchers"
-msgstr ""
-
-#: exhibition/forms.py:640
-msgid "Maximum usages per voucher"
-msgstr ""
-
-#: exhibition/forms.py:645 exhibition/templates/exhibitors/vouchers.html:33
-#: exhibition/views.py:1995
-msgid "Price effect"
-msgstr ""
-
-#: exhibition/forms.py:651 exhibition/views.py:1996
-msgid "Value"
-msgstr ""
-
-#: exhibition/forms.py:652
-msgid "Amount or percentage, depending on the selected price effect."
-msgstr ""
-
-#: exhibition/forms.py:657 exhibition/templates/exhibitors/vouchers.html:35
-#: exhibition/views.py:1997
-msgid "Valid until"
-msgstr ""
-
-#: exhibition/forms.py:673
-msgid "Enter a value for the selected price effect."
-msgstr ""
-
-#: exhibition/forms.py:678 exhibition/models.py:295
-#: exhibition/templates/exhibitors/settings.html:205
+#: forms.py:647 models.py:326 templates/exhibitors/settings.html:289
 msgid "Level"
 msgstr ""
 
-#: exhibition/forms.py:685 exhibition/models.py:294
+#: forms.py:654 models.py:325
 msgid "Group name"
 msgstr ""
 
-#: exhibition/forms.py:718
+#: forms.py:677 models.py:225
+msgid "Exhibitor voucher pool"
+msgstr ""
+
+#: forms.py:678 models.py:232
+msgid "Sponsor voucher pool"
+msgstr ""
+
+#: forms.py:698
+msgid "— No pool selected —"
+msgstr ""
+
+#: forms.py:699
+msgid "— Use the exhibitor pool —"
+msgstr ""
+
+#: forms.py:719
 msgid "Enable call"
 msgstr ""
 
-#: exhibition/forms.py:719
+#: forms.py:720
 msgid "Hide call page after the deadline"
 msgstr ""
 
-#: exhibition/forms.py:720
+#: forms.py:721
 msgid "Make this call private (accessible only via a secret link)"
 msgstr ""
 
-#: exhibition/forms.py:724
+#: forms.py:725
 msgid ""
 "Turn the call on. Keep it enabled for private calls too, otherwise the "
 "secret link stops working."
 msgstr ""
 
-#: exhibition/forms.py:727
+#: forms.py:728
 msgid ""
 "The call page is not linked anywhere public and can only be opened with the "
 "secret link shown below."
 msgstr ""
 
-#: exhibition/forms.py:868
+#: forms.py:869
 msgid "Your answer"
 msgstr ""
 
-#: exhibition/forms.py:1024 exhibition/models.py:563
-#: exhibition/templates/exhibitors/proposal_detail.html:88
+#: forms.py:1025 models.py:611 templates/exhibitors/proposal_detail.html:88
 msgid "Language"
 msgstr ""
 
-#: exhibition/forms.py:1025
+#: forms.py:1026
 msgid "The language you are filling in this form with."
 msgstr ""
 
-#: exhibition/forms.py:1086 exhibition/models.py:151 exhibition/models.py:523
-#: exhibition/models.py:602
+#: forms.py:1087 models.py:151 models.py:571 models.py:650
 msgid "Message to the organizers"
 msgstr ""
 
-#: exhibition/forms.py:1149
+#: forms.py:1150
 msgid ""
 "The organization name is locked after acceptance. Contact the organizers to "
 "change it."
 msgstr ""
 
-#: exhibition/forms.py:1425
+#: forms.py:1426
 msgid "Approve as exhibitor"
 msgstr ""
 
-#: exhibition/forms.py:1426
+#: forms.py:1427
 msgid "Approve as sponsor"
 msgstr ""
 
-#: exhibition/forms.py:1428 exhibition/models.py:352 exhibition/models.py:596
-#: exhibition/models.py:966 exhibition/views.py:505
+#: forms.py:1429 models.py:383 models.py:644 models.py:1014 views.py:544
 msgid "Booth name"
 msgstr ""
 
-#: exhibition/forms.py:1429 exhibition/forms.py:1459 exhibition/models.py:607
+#: forms.py:1430 forms.py:1460 models.py:655
 msgid "Internal review notes"
 msgstr ""
 
-#: exhibition/forms.py:1470
+#: forms.py:1471
 msgid "Field label"
 msgstr ""
 
-#: exhibition/forms.py:1475 exhibition/forms.py:1510
+#: forms.py:1476 forms.py:1551
 msgid "Help text"
 msgstr ""
 
-#: exhibition/forms.py:1476
+#: forms.py:1477
 msgid "Shown below the field on the exhibitor form."
 msgstr ""
 
-#: exhibition/forms.py:1483
+#: forms.py:1484
 #, python-format
 msgid "Leave empty to use the default: %(label)s"
 msgstr ""
 
-#: exhibition/forms.py:1492
-msgid "Options"
-msgstr ""
-
-#: exhibition/forms.py:1493
-msgid "For choice fields, enter one option per line."
-msgstr ""
-
-#: exhibition/forms.py:1508
-msgid "Field type"
-msgstr ""
-
-#: exhibition/forms.py:1509 exhibition/models.py:878
-msgid "Custom question"
-msgstr ""
-
-#: exhibition/forms.py:1511
-#: exhibition/templates/exhibitors/call_questions.html:31
-#: exhibition/templates/exhibitors/call_questions.html:63
-msgid "Required"
-msgstr ""
-
-#: exhibition/forms.py:1535
+#: forms.py:1523
 msgid "Please provide at least one option for this question type."
 msgstr ""
 
-#: exhibition/forms.py:1576 exhibition/forms.py:1665
+#: forms.py:1549
+msgid "Field type"
+msgstr ""
+
+#: forms.py:1550 models.py:926
+msgid "Custom question"
+msgstr ""
+
+#: forms.py:1552 templates/exhibitors/call_questions.html:31
+#: templates/exhibitors/call_questions.html:63
+msgid "Required"
+msgstr ""
+
+#: forms.py:1583 forms.py:1672
 msgid "Choose social platform"
 msgstr ""
 
-#: exhibition/forms.py:1578 exhibition/forms.py:1667
+#: forms.py:1585 forms.py:1674
 msgid "Social platform"
 msgstr ""
 
-#: exhibition/forms.py:1582 exhibition/forms.py:1671
+#: forms.py:1589 forms.py:1678
 msgid "Profile or path"
 msgstr ""
 
-#: exhibition/forms.py:1596 exhibition/forms.py:1685
+#: forms.py:1603 forms.py:1692
 msgid "Profile, handle, or full URL"
 msgstr ""
 
-#: exhibition/forms.py:1616 exhibition/forms.py:1705
+#: forms.py:1623 forms.py:1712
 msgid "Please enter a profile, handle, or URL or remove this row."
 msgstr ""
 
-#: exhibition/forms.py:1622 exhibition/forms.py:1711
+#: forms.py:1629 forms.py:1718
 msgid "Please choose a social platform."
 msgstr ""
 
-#: exhibition/forms.py:1626 exhibition/forms.py:1715
+#: forms.py:1633 forms.py:1722
 msgid "Please enter a profile, handle, or URL."
 msgstr ""
 
-#: exhibition/forms.py:1648 exhibition/forms.py:1737
+#: forms.py:1655 forms.py:1744
 msgid "Link label"
 msgstr ""
 
-#: exhibition/forms.py:1654 exhibition/forms.py:1743
+#: forms.py:1661 forms.py:1750
 msgid "https://example.com"
 msgstr ""
 
-#: exhibition/forms.py:1807
+#: forms.py:1848
 msgid ""
 "Leave empty to keep this in the outbox until sent manually. Time is "
 "interpreted in the event timezone."
 msgstr ""
 
-#: exhibition/forms.py:1814 exhibition/forms.py:1877
+#: forms.py:1861 forms.py:1940
 msgid "The scheduled time must be in the future."
 msgstr ""
 
-#: exhibition/forms.py:1822
+#: forms.py:1869
 msgid "Exhibitors and sponsors"
 msgstr ""
 
-#: exhibition/forms.py:1823
+#: forms.py:1870
 msgid "Exhibitors only"
 msgstr ""
 
-#: exhibition/forms.py:1824
+#: forms.py:1871
 msgid "Sponsors only"
 msgstr ""
 
-#: exhibition/forms.py:1828
+#: forms.py:1875
 msgid "Application state"
 msgstr ""
 
-#: exhibition/forms.py:1836
+#: forms.py:1883
 msgid "Partner type"
 msgstr ""
 
-#: exhibition/forms.py:1844
+#: forms.py:1891
 msgid "Any sponsor group"
 msgstr ""
 
-#: exhibition/forms.py:1846 exhibition/models.py:1035 exhibition/models.py:1089
-#: exhibition/templates/exhibitors/_email_outbox_body.html:6
-#: exhibition/templates/exhibitors/_email_sent_body.html:6
+#: forms.py:1893 forms.py:1953 models.py:1084 models.py:1146
+#: templates/exhibitors/_email_outbox_body.html:6
+#: templates/exhibitors/_email_sent_body.html:6
 msgid "Subject"
 msgstr ""
 
-#: exhibition/forms.py:1848
+#: forms.py:1895
 msgid "Send at"
 msgstr ""
 
-#: exhibition/forms.py:1851
+#: forms.py:1898
 msgid "Leave empty to send immediately or save to the outbox."
 msgstr ""
 
-#: exhibition/forms.py:1859 exhibition/models.py:1036 exhibition/models.py:1090
+#: forms.py:1906 forms.py:1960 models.py:1085 models.py:1147
 msgid "Body"
 msgstr ""
 
-#: exhibition/forms.py:1885 exhibition/views.py:2576
-msgid "Request received (confirmation)"
-msgstr ""
-
-#: exhibition/forms.py:1886 exhibition/views.py:2577
-msgid "Request accepted"
-msgstr ""
-
-#: exhibition/forms.py:1887 exhibition/views.py:2578
-msgid "Request rejected"
-msgstr ""
-
-#: exhibition/forms.py:1888 exhibition/views.py:2579
-msgid "Exhibitor lead scanning key"
-msgstr ""
-
-#: exhibition/forms.py:1897
-#, python-format
-msgid "%(role)s — subject"
-msgstr ""
-
-#: exhibition/forms.py:1904
-#, python-format
-msgid "%(role)s — body"
-msgstr ""
-
-#: exhibition/mail.py:57
+#: mail.py:59
 #, python-brace-format
 msgid "We received your request for {event_name}"
 msgstr ""
 
-#: exhibition/mail.py:59
+#: mail.py:61
 #, python-brace-format
 msgid ""
 "Hello,\n"
@@ -621,12 +557,12 @@ msgid ""
 "The {event_name} team"
 msgstr ""
 
-#: exhibition/mail.py:69
+#: mail.py:71
 #, python-brace-format
 msgid "Your request for {event_name} has been accepted"
 msgstr ""
 
-#: exhibition/mail.py:71
+#: mail.py:73
 #, python-brace-format
 msgid ""
 "Hello,\n"
@@ -638,12 +574,12 @@ msgid ""
 "The {event_name} team"
 msgstr ""
 
-#: exhibition/mail.py:80
+#: mail.py:82
 #, python-brace-format
 msgid "Update on your request for {event_name}"
 msgstr ""
 
-#: exhibition/mail.py:82
+#: mail.py:84
 #, python-brace-format
 msgid ""
 "Hello,\n"
@@ -657,12 +593,12 @@ msgid ""
 "The {event_name} team"
 msgstr ""
 
-#: exhibition/mail.py:91
+#: mail.py:93
 #, python-brace-format
 msgid "Lead Scanning Access for {event_name}"
 msgstr ""
 
-#: exhibition/mail.py:93
+#: mail.py:95
 #, python-brace-format
 msgid ""
 "Hello {exhibitor_name},\n"
@@ -688,983 +624,1079 @@ msgid ""
 "The {event_name} Team"
 msgstr ""
 
-#: exhibition/mail.py:174
+#: mail.py:110
+#, python-brace-format
+msgid "Your vouchers for {event_name} — {exhibitor_name}"
+msgstr ""
+
+#: mail.py:112
+#, python-brace-format
+msgid ""
+"Dear {exhibitor_name},\n"
+"\n"
+"Thank you for participating in {event_name}. Please share the voucher codes "
+"below with your audience — anyone who uses one gets credited to you as a "
+"lead.\n"
+"\n"
+"{voucher_list}\n"
+"\n"
+"They can redeem a code on the event ticket shop at checkout.\n"
+"\n"
+"If you have any questions, please don't hesitate to reach out.\n"
+"\n"
+"Best regards,\n"
+"The {event_name} Team"
+msgstr ""
+
+#: mail.py:190
 msgid "This value will be replaced based on dynamic parameters."
 msgstr ""
 
-#: exhibition/models.py:137 exhibition/models.py:515
+#: mail.py:312
+#, python-format
+msgid "…and %(count)d more voucher code in the attached CSV file."
+msgid_plural "…and %(count)d more voucher codes in the attached CSV file."
+msgstr[0] ""
+
+#: models.py:137 models.py:563
 msgid "Contact email"
 msgstr ""
 
-#: exhibition/models.py:156
-#: exhibition/templates/exhibitors/proposal_detail.html:132
+#: models.py:156 templates/exhibitors/proposal_detail.html:132
 msgid "Social media"
 msgstr ""
 
-#: exhibition/models.py:161
-#: exhibition/templates/exhibitors/proposal_detail.html:140
+#: models.py:161 templates/exhibitors/proposal_detail.html:140
 msgid "Extra links"
 msgstr ""
 
-#: exhibition/models.py:216
+#: models.py:212
+msgid "Vouchers per exhibitor"
+msgstr ""
+
+#: models.py:226
+msgid ""
+"The voucher tag created under Tickets → Vouchers that exhibitors draw their "
+"codes from."
+msgstr ""
+
+#: models.py:233
+msgid "Leave empty to draw sponsor codes from the exhibitor pool as well."
+msgstr ""
+
+#: models.py:239
+msgid "Attach voucher list as CSV"
+msgstr ""
+
+#: models.py:240
+msgid ""
+"Adds a spreadsheet of the recipient's own voucher codes to the voucher email."
+msgstr ""
+
+#: models.py:247
 msgid "Call headline"
 msgstr ""
 
-#: exhibition/models.py:220
+#: models.py:251
 msgid "Call text"
 msgstr ""
 
-#: exhibition/models.py:225
+#: models.py:256
 msgid "Submission deadline"
 msgstr ""
 
-#: exhibition/models.py:298
+#: models.py:329
 msgid "Show this sponsor group on the front page."
 msgstr ""
 
-#: exhibition/models.py:314 exhibition/models.py:558
-#: exhibition/templates/exhibitors/dashboard.html:73
-#: exhibition/templates/exhibitors/exhibitor_info.html:69
-#: exhibition/templates/exhibitors/proposal_list.html:19
-#: exhibition/templates/exhibitors/public_proposal_list.html:11
-#: exhibition/views.py:505
+#: models.py:345 models.py:606 templates/exhibitors/dashboard.html:73
+#: templates/exhibitors/exhibitor_info.html:79
+#: templates/exhibitors/proposal_list.html:19
+#: templates/exhibitors/public_proposal_list.html:11 views.py:544
 msgid "Name"
 msgstr ""
 
-#: exhibition/models.py:315 exhibition/models.py:559
-#: exhibition/templates/exhibitors/proposal_detail.html:117
+#: models.py:346 models.py:607 templates/exhibitors/proposal_detail.html:117
 msgid "Description"
 msgstr ""
 
-#: exhibition/models.py:316 exhibition/models.py:419 exhibition/models.py:435
-#: exhibition/models.py:565 exhibition/models.py:815 exhibition/models.py:831
-#: exhibition/models.py:844
-#: exhibition/templates/exhibitors/proposal_detail.html:103
+#: models.py:347 models.py:467 models.py:483 models.py:613 models.py:863
+#: models.py:879 models.py:892 templates/exhibitors/proposal_detail.html:103
 msgid "URL"
 msgstr ""
 
-#: exhibition/models.py:317 exhibition/models.py:566
-#: exhibition/templates/exhibitors/proposal_detail.html:77
-#: exhibition/views.py:505
+#: models.py:348 models.py:614 templates/exhibitors/proposal_detail.html:77
+#: views.py:544
 msgid "Email"
 msgstr ""
 
-#: exhibition/models.py:318 exhibition/models.py:567
-#: exhibition/templates/exhibitors/proposal_detail.html:105
+#: models.py:349 models.py:615 templates/exhibitors/proposal_detail.html:105
 msgid "Contact URL"
 msgstr ""
 
-#: exhibition/models.py:319 exhibition/models.py:568
-#: exhibition/templates/exhibitors/proposal_detail.html:107
+#: models.py:350 models.py:616 templates/exhibitors/proposal_detail.html:107
 msgid "Video URL"
 msgstr ""
 
-#: exhibition/models.py:322 exhibition/models.py:571
-#: exhibition/templates/exhibitors/proposal_detail.html:109
+#: models.py:353 models.py:619 templates/exhibitors/proposal_detail.html:109
 msgid "Slides"
 msgstr ""
 
-#: exhibition/models.py:326 exhibition/models.py:575
+#: models.py:357 models.py:623
 msgid "Slides URL"
 msgstr ""
 
-#: exhibition/models.py:328 exhibition/models.py:577
+#: models.py:359 models.py:625
 msgid "Logo URL"
 msgstr ""
 
-#: exhibition/models.py:330 exhibition/models.py:579
+#: models.py:361 models.py:627
 msgid "Header image URL"
 msgstr ""
 
-#: exhibition/models.py:434 exhibition/models.py:830
+#: models.py:482 models.py:878
 msgid "Label"
 msgstr ""
 
-#: exhibition/models.py:445
+#: models.py:493
 msgid "draft"
 msgstr ""
 
-#: exhibition/models.py:446
+#: models.py:494
 msgid "submitted"
 msgstr ""
 
-#: exhibition/models.py:447
+#: models.py:495
 msgid "accepted"
 msgstr ""
 
-#: exhibition/models.py:448
+#: models.py:496
 msgid "rejected"
 msgstr ""
 
-#: exhibition/models.py:449
+#: models.py:497
 msgid "withdrawn"
 msgstr ""
 
-#: exhibition/models.py:514
+#: models.py:562
 msgid "Organization Description"
 msgstr ""
 
-#: exhibition/models.py:516
+#: models.py:564
 msgid "Organization Website"
 msgstr ""
 
-#: exhibition/models.py:517
+#: models.py:565
 msgid "Contact Page URL"
 msgstr ""
 
-#: exhibition/models.py:518
+#: models.py:566
 msgid "Promotional Video URL"
 msgstr ""
 
-#: exhibition/models.py:519
+#: models.py:567
 msgid "Promotional Slides"
 msgstr ""
 
-#: exhibition/models.py:521
+#: models.py:569
 msgid "Header Image"
 msgstr ""
 
-#: exhibition/models.py:524 exhibition/templates/exhibitors/add.html:29
-#: exhibition/templates/exhibitors/public_proposal_form.html:38
+#: models.py:572 templates/exhibitors/add.html:29
+#: templates/exhibitors/public_proposal_form.html:38
 msgid "Social Media"
 msgstr ""
 
-#: exhibition/models.py:525 exhibition/templates/exhibitors/add.html:92
-#: exhibition/templates/exhibitors/public_proposal_form.html:91
+#: models.py:573 templates/exhibitors/add.html:92
+#: templates/exhibitors/public_proposal_form.html:91
 msgid "Extra Links"
 msgstr ""
 
-#: exhibition/models.py:841
+#: models.py:889
 msgid "Number"
 msgstr ""
 
-#: exhibition/models.py:842
+#: models.py:890
 msgid "Text (one line)"
 msgstr ""
 
-#: exhibition/models.py:843
+#: models.py:891
 msgid "Multiline text"
 msgstr ""
 
-#: exhibition/models.py:845
+#: models.py:893
 msgid "Email address"
 msgstr ""
 
-#: exhibition/models.py:846
+#: models.py:894
 msgid "Confirm Checkbox"
 msgstr ""
 
-#: exhibition/models.py:847
+#: models.py:895
 msgid "Radio button (Choose one option)"
 msgstr ""
 
-#: exhibition/models.py:848
+#: models.py:896
 msgid "Dropdown (Choose one option)"
 msgstr ""
 
-#: exhibition/models.py:849
+#: models.py:897
 msgid "Checkbox (Choose one or several options)"
 msgstr ""
 
-#: exhibition/models.py:850
+#: models.py:898
 msgid "File upload"
 msgstr ""
 
-#: exhibition/models.py:851
+#: models.py:899
 msgid "Date"
 msgstr ""
 
-#: exhibition/models.py:852
+#: models.py:900
 msgid "Time"
 msgstr ""
 
-#: exhibition/models.py:853
+#: models.py:901
 msgid "Date and time"
 msgstr ""
 
-#: exhibition/models.py:854
+#: models.py:902
 msgid "Country code (ISO 3166-1 alpha-2)"
 msgstr ""
 
-#: exhibition/models.py:855
+#: models.py:903
 msgid "Phone number"
 msgstr ""
 
-#: exhibition/models.py:883
+#: models.py:931
 msgid "help text"
 msgstr ""
 
-#: exhibition/models.py:885 exhibition/templates/exhibitors/add.html:29
-#: exhibition/templates/exhibitors/add.html:92
-#: exhibition/templates/exhibitors/public_proposal_form.html:38
-#: exhibition/templates/exhibitors/public_proposal_form.html:91
+#: models.py:933 templates/exhibitors/add.html:29
+#: templates/exhibitors/add.html:92
+#: templates/exhibitors/public_proposal_form.html:38
+#: templates/exhibitors/public_proposal_form.html:91
 msgid "required"
 msgstr ""
 
-#: exhibition/models.py:886
+#: models.py:934
 msgid "active"
 msgstr ""
 
-#: exhibition/models.py:906
+#: models.py:954
 msgid "Response"
 msgstr ""
 
-#: exhibition/models.py:938
+#: models.py:986
 msgid "Yes"
 msgstr ""
 
-#: exhibition/models.py:940
+#: models.py:988
 msgid "No"
 msgstr ""
 
-#: exhibition/models.py:1034
-#: exhibition/templates/exhibitors/_email_outbox_body.html:5
-#: exhibition/templates/exhibitors/_email_sent_body.html:5
+#: models.py:1083 templates/exhibitors/_email_outbox_body.html:5
+#: templates/exhibitors/_email_sent_body.html:5
 msgid "Recipient"
 msgstr ""
 
-#: exhibition/models.py:1045
+#: models.py:1101
 msgid "Queued email"
 msgstr ""
 
-#: exhibition/models.py:1046
+#: models.py:1102
 msgid "Queued emails"
 msgstr ""
 
-#: exhibition/models.py:1088
+#: models.py:1145
 msgid "Template name"
 msgstr ""
 
-#: exhibition/models.py:1095
+#: models.py:1152
 msgid "Custom email template"
 msgstr ""
 
-#: exhibition/models.py:1096
+#: models.py:1153
 msgid "Custom email templates"
 msgstr ""
 
-#: exhibition/signals.py:75
+#: signals.py:81
 msgid "Screen and evaluate exhibitor and sponsor requests for the event."
 msgstr ""
 
-#: exhibition/signals.py:76
+#: signals.py:82
 msgid "Request Review Dashboard"
 msgstr ""
 
-#: exhibition/signals.py:80
+#: signals.py:86
 msgid ""
 "Manage exhibitors and sponsors, maintain booth details, and create partner "
 "profiles for the event."
 msgstr ""
 
-#: exhibition/signals.py:82
+#: signals.py:88
 msgid "Exhibitors & Sponsors Dashboard"
 msgstr ""
 
-#: exhibition/signals.py:88 exhibition/templates/exhibitors/base.html:5
-#: exhibition/templates/exhibitors/base.html:125
-#: exhibition/templates/exhibitors/exhibitor_info.html:4
-#: exhibition/templates/exhibitors/exhibitor_info.html:15
+#: signals.py:94 templates/exhibitors/base.html:6
+#: templates/exhibitors/base.html:136
+#: templates/exhibitors/exhibitor_info.html:4
+#: templates/exhibitors/exhibitor_info.html:15
 msgid "Exhibitors & Sponsors"
 msgstr ""
 
-#: exhibition/signals.py:90
+#: signals.py:96
 msgid "Go to"
 msgstr ""
 
-#: exhibition/signals.py:166 exhibition/templates/exhibitors/call_base.html:4
-#: exhibition/templates/exhibitors/call_base.html:7
-#: exhibition/templates/exhibitors/public_call.html:7
-#: exhibition/templates/exhibitors/settings.html:8
-#: exhibition/templates/exhibitors/settings.html:25
+#: signals.py:172 templates/exhibitors/call_base.html:4
+#: templates/exhibitors/call_base.html:7
+#: templates/exhibitors/public_call.html:7 templates/exhibitors/settings.html:8
+#: templates/exhibitors/settings.html:27
 msgid "Call for Exhibitors"
 msgstr ""
 
-#: exhibition/signals.py:207 exhibition/signals.py:231
+#: signals.py:213 signals.py:237
 msgid "Acme Corp"
 msgstr ""
 
-#: exhibition/signals.py:225
+#: signals.py:231
 msgid "Jane Doe"
 msgstr ""
 
-#: exhibition/signals.py:293 exhibition/templates/exhibitors/base.html:62
-#: exhibition/templates/exhibitors/proposal_list.html:5
-#: exhibition/templates/exhibitors/proposal_list.html:15
+#: signals.py:305 templates/exhibitors/base.html:73
+#: templates/exhibitors/proposal_list.html:5
+#: templates/exhibitors/proposal_list.html:15
 msgid "Exhibition requests"
 msgstr ""
 
-#: exhibition/signals.py:298
+#: signals.py:310
 msgid "Exhibition request approved."
 msgstr ""
 
-#: exhibition/signals.py:299
+#: signals.py:311
 msgid "Exhibition request rejected."
 msgstr ""
 
-#: exhibition/signals.py:300
+#: signals.py:312
 msgid "Exhibition request withdrawn."
 msgstr ""
 
-#: exhibition/signals.py:301
+#: signals.py:313
 msgid "Exhibition request reopened for review."
 msgstr ""
 
-#: exhibition/signals.py:302
+#: signals.py:314
 msgid "Exhibition request changed."
 msgstr ""
 
-#: exhibition/signals.py:303
+#: signals.py:315
 msgid "Organization profile created from an approved request."
 msgstr ""
 
-#: exhibition/signals.py:304
+#: signals.py:316
 msgid "Organization profile reactivated after re-approval."
 msgstr ""
 
-#: exhibition/signals.py:305
+#: signals.py:317
 msgid "Organization profile updated from the submitter's changes."
 msgstr ""
 
-#: exhibition/signals.py:306
+#: signals.py:318
 msgid "Organization profile created."
 msgstr ""
 
-#: exhibition/signals.py:307
+#: signals.py:319
 msgid "Organization profile changed."
 msgstr ""
 
-#: exhibition/signals.py:308
+#: signals.py:320
 msgid "Organization profile deleted."
 msgstr ""
 
-#: exhibition/signals.py:309
+#: signals.py:321
 msgid "Exhibition settings changed."
 msgstr ""
 
-#: exhibition/signals.py:310
+#: signals.py:322
 msgid "Call for exhibitors settings changed."
 msgstr ""
 
-#: exhibition/signals.py:311
+#: signals.py:323
 msgid "Private call link regenerated."
 msgstr ""
 
-#: exhibition/signals.py:312
+#: signals.py:324
 msgid "Sponsor group created."
 msgstr ""
 
-#: exhibition/signals.py:313
+#: signals.py:325
 msgid "Sponsor group changed."
 msgstr ""
 
-#: exhibition/signals.py:314 exhibition/views.py:457
+#: signals.py:326 views.py:496
 msgid "Sponsor group deleted."
 msgstr ""
 
-#: exhibition/signals.py:315
+#: signals.py:327
 msgid "Exhibitor form question created."
 msgstr ""
 
-#: exhibition/signals.py:316
+#: signals.py:328
 msgid "Exhibitor form question changed."
 msgstr ""
 
-#: exhibition/signals.py:317
+#: signals.py:329
 msgid "Exhibitor form question deleted."
 msgstr ""
 
-#: exhibition/signals.py:318
+#: signals.py:330
 msgid "Email sent."
 msgstr ""
 
-#: exhibition/signals.py:337
+#: signals.py:349
 #, python-brace-format
 msgid "Updated: {fields}."
 msgstr ""
 
-#: exhibition/signals.py:360
+#: signals.py:372
 #, python-brace-format
 msgid "State changed from {old} to {new}."
 msgstr ""
 
-#: exhibition/signals.py:382
+#: signals.py:394
 #, python-brace-format
 msgid "Exhibition request {val}"
 msgstr ""
 
-#: exhibition/signals.py:391
+#: signals.py:403
 #, python-brace-format
 msgid "Organization profile {val}"
 msgstr ""
 
-#: exhibition/signals.py:400
+#: signals.py:412
 #, python-brace-format
 msgid "Exhibitor form question {val}"
 msgstr ""
 
-#: exhibition/signals.py:409
+#: signals.py:421
 #, python-brace-format
 msgid "Sponsor group {val}"
 msgstr ""
 
-#: exhibition/social_links.py:36
+#: social_links.py:36
 msgid "Facebook"
 msgstr ""
 
-#: exhibition/social_links.py:43
+#: social_links.py:43
 msgid "Flickr"
 msgstr ""
 
-#: exhibition/social_links.py:50
+#: social_links.py:50
 msgid "GitHub"
 msgstr ""
 
-#: exhibition/social_links.py:57
+#: social_links.py:57
 msgid "GitLab"
 msgstr ""
 
-#: exhibition/social_links.py:64
+#: social_links.py:64
 msgid "Gitter"
 msgstr ""
 
-#: exhibition/social_links.py:71
+#: social_links.py:71
 msgid "Google Groups"
 msgstr ""
 
-#: exhibition/social_links.py:78
+#: social_links.py:78
 msgid "Instagram"
 msgstr ""
 
-#: exhibition/social_links.py:85
+#: social_links.py:85
 msgid "LinkedIn"
 msgstr ""
 
-#: exhibition/social_links.py:92
+#: social_links.py:92
 msgid "Mastodon"
 msgstr ""
 
-#: exhibition/social_links.py:99
+#: social_links.py:99
 msgid "Patreon"
 msgstr ""
 
-#: exhibition/social_links.py:106
+#: social_links.py:106
 msgid "Telegram"
 msgstr ""
 
-#: exhibition/social_links.py:113
+#: social_links.py:113
 msgid "Vimeo"
 msgstr ""
 
-#: exhibition/social_links.py:120
+#: social_links.py:120
 msgid "VK"
 msgstr ""
 
-#: exhibition/social_links.py:127
+#: social_links.py:127
 msgid "Weibo"
 msgstr ""
 
-#: exhibition/social_links.py:134
+#: social_links.py:134
 msgid "X"
 msgstr ""
 
-#: exhibition/social_links.py:141
+#: social_links.py:141
 msgid "Xing"
 msgstr ""
 
-#: exhibition/social_links.py:148
+#: social_links.py:148
 msgid "YouTube"
 msgstr ""
 
-#: exhibition/social_links.py:155
+#: social_links.py:155
 msgid "YouTube Privacy"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:7
+#: templates/exhibitors/_email_outbox_body.html:7
 msgid "Created"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:14
+#: templates/exhibitors/_email_outbox_body.html:14
 msgid "Send selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:17
+#: templates/exhibitors/_email_outbox_body.html:17
 msgid "Discard selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:20
+#: templates/exhibitors/_email_outbox_body.html:20
 msgid "Send all"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:23
+#: templates/exhibitors/_email_outbox_body.html:23
 msgid "Discard all"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:35
+#: templates/exhibitors/_email_outbox_body.html:35
 msgid "Scheduled"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:36
-#: exhibition/templates/exhibitors/proposal_list.html:65
+#: templates/exhibitors/_email_outbox_body.html:36
+#: templates/exhibitors/proposal_list.html:65
 msgid "Actions"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:67
-msgid "Send this email"
+#: templates/exhibitors/_email_outbox_body.html:68
+msgid "Send"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:73
-msgid "Edit this email"
+#: templates/exhibitors/_email_outbox_body.html:75
+#: templates/exhibitors/_partner_row.html:54
+#: templates/exhibitors/call_questions.html:73
+#: templates/exhibitors/call_questions.html:76
+#: templates/exhibitors/dashboard.html:120
+#: templates/exhibitors/email_compose.html:55
+#: templates/exhibitors/email_custom_template_form.html:30
+#: templates/exhibitors/email_templates.html:50
+#: templates/exhibitors/email_templates.html:97
+#: templates/exhibitors/public_proposal_list.html:32
+#: templates/exhibitors/settings.html:59
+msgid "Edit"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:79
-msgid "Discard this email"
+#: templates/exhibitors/_email_outbox_body.html:82
+#: templates/exhibitors/email_bulk_discard.html:30
+#: templates/exhibitors/email_delete.html:31
+msgid "Discard"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:91
-#: exhibition/templates/exhibitors/_email_sent_body.html:34
+#: templates/exhibitors/_email_outbox_body.html:95
+#: templates/exhibitors/_email_sent_body.html:35
 msgid "No emails match your search."
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_outbox_body.html:93
+#: templates/exhibitors/_email_outbox_body.html:97
 msgid "The outbox is empty."
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_sent_body.html:7
-#: exhibition/templates/exhibitors/base.html:105
+#: templates/exhibitors/_email_sent_body.html:7
+#: templates/exhibitors/_partner_row.html:45 templates/exhibitors/base.html:116
 msgid "Sent"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_email_sent_body.html:36
+#: templates/exhibitors/_email_sent_body.html:37
 msgid "No emails have been sent yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:12
-#: exhibition/templates/exhibitors/public_list.html:29
+#: templates/exhibitors/_filter_form.html:12
+#: templates/exhibitors/public_list.html:29
 msgid "Search"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:18
-#: exhibition/templates/exhibitors/_filter_form.html:20
+#: templates/exhibitors/_filter_form.html:18
+#: templates/exhibitors/_filter_form.html:21
 msgid "Clear filters"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:29
+#: templates/exhibitors/_filter_form.html:30
 msgid "Filters"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_filter_form.html:50
+#: templates/exhibitors/_filter_form.html:51
 msgid "Apply filters"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:5
+#: templates/exhibitors/_image_preview_dialog.html:11
+msgid "Close preview"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:5
 #, python-format
 msgid "Select %(name)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:33
+#: templates/exhibitors/_partner_row.html:33
 msgid "Untitled"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:40
+#: templates/exhibitors/_partner_row.html:40
+msgid "Waiting in the outbox"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:41
+msgid "In outbox"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:44
+#, python-format
+msgid "Last sent %(sent)s"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:48
+msgid "Not sent"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:55
 msgid "Copied!"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:40
+#: templates/exhibitors/_partner_row.html:55
 msgid "Copy failed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:40
+#: templates/exhibitors/_partner_row.html:55
 msgid "Key"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:41
-#: exhibition/templates/exhibitors/add.html:231
-#: exhibition/templates/exhibitors/vouchers.html:5
+#: templates/exhibitors/_partner_row.html:56 templates/exhibitors/add.html:235
+#: templates/exhibitors/base.html:42
+#: templates/exhibitors/exhibitor_info.html:95
+#: templates/exhibitors/exhibitor_info.html:125
+#: templates/exhibitors/vouchers.html:5 views.py:2933
 msgid "Vouchers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:42
-#: exhibition/templates/exhibitors/devices.html:5
+#: templates/exhibitors/_partner_row.html:57
+#: templates/exhibitors/devices.html:5
 msgid "Lead-scanning devices"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_partner_row.html:45
+#: templates/exhibitors/_partner_row.html:58
+#: templates/exhibitors/call_question_delete.html:19
+#: templates/exhibitors/call_questions.html:74
+#: templates/exhibitors/delete.html:19
+#: templates/exhibitors/email_custom_template_delete.html:19
+#: templates/exhibitors/settings.html:335
+msgid "Delete"
+msgstr ""
+
+#: templates/exhibitors/_partner_row.html:60
 msgid "Move"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_sort_header.html:7
+#: templates/exhibitors/_sort_header.html:7
 msgid "Sort ascending"
 msgstr ""
 
-#: exhibition/templates/exhibitors/_sort_header.html:10
+#: templates/exhibitors/_sort_header.html:10
 msgid "Sort descending"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:24
+#: templates/exhibitors/add.html:24
 msgid "Profile"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:29
-#: exhibition/templates/exhibitors/add.html:92
-#: exhibition/templates/exhibitors/call_questions.html:62
-#: exhibition/templates/exhibitors/settings.html:50
+#: templates/exhibitors/add.html:29 templates/exhibitors/add.html:92
+#: templates/exhibitors/call_questions.html:62
+#: templates/exhibitors/settings.html:54
 msgid "Optional"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:80
-#: exhibition/templates/exhibitors/public_proposal_form.html:79
+#: templates/exhibitors/add.html:80
+#: templates/exhibitors/public_proposal_form.html:79
 msgid "Add social media link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:137
-#: exhibition/templates/exhibitors/public_proposal_form.html:120
+#: templates/exhibitors/add.html:137
+#: templates/exhibitors/public_proposal_form.html:120
 msgid "Add extra link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:157
-#: exhibition/templates/exhibitors/add.html:160
-#: exhibition/templates/exhibitors/public_proposal_form.html:140
-#: exhibition/templates/exhibitors/public_proposal_form.html:143
+#: templates/exhibitors/add.html:157 templates/exhibitors/add.html:161
+#: templates/exhibitors/public_proposal_form.html:140
+#: templates/exhibitors/public_proposal_form.html:144
 msgid "Logo preview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:162
-#: exhibition/templates/exhibitors/add.html:180
-#: exhibition/templates/exhibitors/public_proposal_form.html:145
-#: exhibition/templates/exhibitors/public_proposal_form.html:163
+#: templates/exhibitors/add.html:164 templates/exhibitors/add.html:184
+#: templates/exhibitors/public_proposal_form.html:147
+#: templates/exhibitors/public_proposal_form.html:167
 msgid "We could not load this image preview."
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:175
-#: exhibition/templates/exhibitors/add.html:178
-#: exhibition/templates/exhibitors/public_proposal_form.html:158
-#: exhibition/templates/exhibitors/public_proposal_form.html:161
+#: templates/exhibitors/add.html:177 templates/exhibitors/add.html:181
+#: templates/exhibitors/public_proposal_form.html:160
+#: templates/exhibitors/public_proposal_form.html:164
 msgid "Header image preview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:196
+#: templates/exhibitors/add.html:200
 msgid "Organizer only"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:237
+#: templates/exhibitors/add.html:241
 msgid "Internal notes"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:244
-#: exhibition/templates/exhibitors/email_edit.html:38
-#: exhibition/templates/exhibitors/public_proposal_form.html:182
-#: exhibition/templates/exhibitors/public_proposal_form.html:186
+#: templates/exhibitors/add.html:248 templates/exhibitors/email_edit.html:38
+#: templates/exhibitors/public_proposal_form.html:186
+#: templates/exhibitors/public_proposal_form.html:190
 msgid "Save changes"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:246
-#: exhibition/templates/exhibitors/call_default_field_form.html:21
-#: exhibition/templates/exhibitors/call_question_form.html:30
-#: exhibition/templates/exhibitors/call_questions.html:96
-#: exhibition/templates/exhibitors/email_custom_template_form.html:51
-#: exhibition/templates/exhibitors/email_templates.html:123
-#: exhibition/templates/exhibitors/proposal_detail.html:188
-#: exhibition/templates/exhibitors/settings.html:85
-#: exhibition/templates/exhibitors/settings.html:170
-#: exhibition/templates/exhibitors/settings.html:269
+#: templates/exhibitors/add.html:250
+#: templates/exhibitors/call_default_field_form.html:21
+#: templates/exhibitors/call_question_form.html:114
+#: templates/exhibitors/call_questions.html:96
+#: templates/exhibitors/email_custom_template_form.html:51
+#: templates/exhibitors/email_templates.html:123
+#: templates/exhibitors/proposal_detail.html:188
+#: templates/exhibitors/settings.html:89 templates/exhibitors/settings.html:217
+#: templates/exhibitors/settings.html:250
+#: templates/exhibitors/settings.html:359
 msgid "Save"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:255
-#: exhibition/templates/exhibitors/call_default_field_form.html:23
-#: exhibition/templates/exhibitors/call_default_field_reset.html:24
-#: exhibition/templates/exhibitors/call_question_delete.html:21
-#: exhibition/templates/exhibitors/call_question_form.html:32
-#: exhibition/templates/exhibitors/delete.html:24
-#: exhibition/templates/exhibitors/email_bulk_discard.html:27
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:21
-#: exhibition/templates/exhibitors/email_custom_template_form.html:53
-#: exhibition/templates/exhibitors/email_delete.html:28
-#: exhibition/templates/exhibitors/proposal_list.html:174
-#: exhibition/templates/exhibitors/public_proposal_form.html:176
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:16
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:21
-#: exhibition/templates/exhibitors/settings.html:194
-#: exhibition/templates/exhibitors/settings.html:270
+#: templates/exhibitors/add.html:259
+#: templates/exhibitors/call_default_field_form.html:23
+#: templates/exhibitors/call_default_field_reset.html:24
+#: templates/exhibitors/call_question_delete.html:21
+#: templates/exhibitors/call_question_form.html:116
+#: templates/exhibitors/delete.html:24
+#: templates/exhibitors/email_bulk_discard.html:27
+#: templates/exhibitors/email_custom_template_delete.html:21
+#: templates/exhibitors/email_custom_template_form.html:53
+#: templates/exhibitors/email_delete.html:28
+#: templates/exhibitors/proposal_list.html:175
+#: templates/exhibitors/public_proposal_form.html:180
+#: templates/exhibitors/public_proposal_reinstate.html:16
+#: templates/exhibitors/public_proposal_withdraw.html:21
+#: templates/exhibitors/settings.html:278
+#: templates/exhibitors/settings.html:360
+#: templates/exhibitors/voucher_bulk_send.html:96
 msgid "Cancel"
 msgstr ""
 
-#: exhibition/templates/exhibitors/add.html:262
-#: exhibition/templates/exhibitors/proposal_detail.html:208
+#: templates/exhibitors/add.html:266
+#: templates/exhibitors/proposal_detail.html:208
 msgid "History"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:11
+#: templates/exhibitors/base.html:17
 msgid "Overview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:18
-#: exhibition/templates/exhibitors/call_questions.html:33
+#: templates/exhibitors/base.html:24
+#: templates/exhibitors/call_questions.html:33
 msgid "Settings"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:26
-#: exhibition/templates/exhibitors/base.html:70
-#: exhibition/templates/exhibitors/dashboard.html:21
-#: exhibition/templates/exhibitors/exhibitor_info.html:4
-#: exhibition/templates/exhibitors/exhibitor_info.html:15
+#: templates/exhibitors/base.html:32 templates/exhibitors/base.html:81
+#: templates/exhibitors/dashboard.html:21
+#: templates/exhibitors/exhibitor_info.html:4
+#: templates/exhibitors/exhibitor_info.html:15
 msgid "Exhibitors"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:31
-#: exhibition/templates/exhibitors/base.html:76
-#: exhibition/templates/exhibitors/dashboard.html:29
-#: exhibition/templates/exhibitors/exhibitor_info.html:4
-#: exhibition/templates/exhibitors/exhibitor_info.html:15
+#: templates/exhibitors/base.html:37 templates/exhibitors/base.html:87
+#: templates/exhibitors/dashboard.html:29
+#: templates/exhibitors/exhibitor_info.html:4
+#: templates/exhibitors/exhibitor_info.html:15
 msgid "Sponsors"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:39
-#: exhibition/templates/exhibitors/dashboard.html:117
+#: templates/exhibitors/base.html:50 templates/exhibitors/dashboard.html:117
 msgid "Call for exhibitors"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:47
+#: templates/exhibitors/base.html:58
 msgid "Content"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:52
-#: exhibition/templates/exhibitors/call_questions.html:5
-#: exhibition/templates/exhibitors/call_questions.html:16
+#: templates/exhibitors/base.html:63 templates/exhibitors/call_questions.html:5
+#: templates/exhibitors/call_questions.html:16
 msgid "Exhibitor form"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:85
+#: templates/exhibitors/base.html:96
 msgid "Message center"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:94
+#: templates/exhibitors/base.html:105
 msgid "Compose"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:99
+#: templates/exhibitors/base.html:110
 msgid "Outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:111
+#: templates/exhibitors/base.html:122
 msgid "Templates"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:130
+#: templates/exhibitors/base.html:141
 msgid "Home"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:134
+#: templates/exhibitors/base.html:145
 msgid "Tickets"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:138
+#: templates/exhibitors/base.html:149
 msgid "Talks"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:143
+#: templates/exhibitors/base.html:154
 msgid "Access videos related to this event"
 msgstr ""
 
-#: exhibition/templates/exhibitors/base.html:144
+#: templates/exhibitors/base.html:155
 msgid "Videos"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_form.html:5
-#: exhibition/templates/exhibitors/call_default_field_form.html:8
-#: exhibition/templates/exhibitors/call_question_form.html:11
-#: exhibition/templates/exhibitors/call_question_form.html:14
+#: templates/exhibitors/call_default_field_form.html:5
+#: templates/exhibitors/call_default_field_form.html:8
+#: templates/exhibitors/call_question_form.html:14
+#: templates/exhibitors/call_question_form.html:17
 msgid "Form field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:4
-#: exhibition/templates/exhibitors/call_default_field_reset.html:7
+#: templates/exhibitors/call_default_field_reset.html:4
+#: templates/exhibitors/call_default_field_reset.html:7
 msgid "Reset form field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:14
+#: templates/exhibitors/call_default_field_reset.html:14
 #, python-format
 msgid ""
 "Are you sure you want to reset \"%(label)s\" back to the default "
 "\"%(default_label)s\"?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:19
+#: templates/exhibitors/call_default_field_reset.html:19
 msgid ""
 "This clears the custom label and help text. Default fields are part of the "
 "form and cannot be deleted; turn the field off with the Active toggle to "
 "hide it."
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_default_field_reset.html:22
-#: exhibition/templates/exhibitors/public_list.html:32
+#: templates/exhibitors/call_default_field_reset.html:22
 msgid "Reset"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_question_delete.html:4
-#: exhibition/templates/exhibitors/call_question_delete.html:7
+#: templates/exhibitors/call_question_delete.html:4
+#: templates/exhibitors/call_question_delete.html:7
 msgid "Delete form field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_question_delete.html:14
+#: templates/exhibitors/call_question_delete.html:14
 #, python-format
 msgid "Are you sure you want to delete the question \"%(question)s\"?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_question_delete.html:19
-#: exhibition/templates/exhibitors/call_questions.html:74
-#: exhibition/templates/exhibitors/delete.html:19
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:19
-msgid "Delete"
+#: templates/exhibitors/call_question_form.html:31
+msgid "Answer options"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:23
+#: templates/exhibitors/call_question_form.html:34
+msgid "Only applicable if you choose a choice field type above."
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:48
+#, python-format
+msgid "Answer option %(id)s"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:56
+#: templates/exhibitors/call_question_form.html:58
+#: templates/exhibitors/call_question_form.html:87
+#: templates/exhibitors/call_question_form.html:89
+msgid "Move option up"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:60
+#: templates/exhibitors/call_question_form.html:62
+#: templates/exhibitors/call_question_form.html:91
+#: templates/exhibitors/call_question_form.html:93
+msgid "Move option down"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:64
+#: templates/exhibitors/call_question_form.html:66
+#: templates/exhibitors/call_question_form.html:95
+#: templates/exhibitors/call_question_form.html:97
+msgid "Delete option"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:81
+msgid "New answer option"
+msgstr ""
+
+#: templates/exhibitors/call_question_form.html:106
+msgid "Add a new option"
+msgstr ""
+
+#: templates/exhibitors/call_questions.html:23
 msgid "Form fields"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:24
+#: templates/exhibitors/call_questions.html:24
 msgid ""
 "Choose which fields are shown on the exhibitor form and drag any row to "
 "reorder it."
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:29
-#: exhibition/templates/exhibitors/proposal_detail.html:38
+#: templates/exhibitors/call_questions.html:29
+#: templates/exhibitors/proposal_detail.html:38
 msgid "Field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:32
+#: templates/exhibitors/call_questions.html:32
 msgid "Answers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:42
+#: templates/exhibitors/call_questions.html:42
 msgid "Custom"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:48
+#: templates/exhibitors/call_questions.html:48
 #, python-format
 msgid "Toggle active state for %(field)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:61
+#: templates/exhibitors/call_questions.html:61
 #, python-format
 msgid "Required status for %(field)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:73
-#: exhibition/templates/exhibitors/call_questions.html:76
-#: exhibition/templates/exhibitors/dashboard.html:120
-#: exhibition/templates/exhibitors/email_compose.html:55
-#: exhibition/templates/exhibitors/email_custom_template_form.html:30
-#: exhibition/templates/exhibitors/email_templates.html:50
-#: exhibition/templates/exhibitors/email_templates.html:97
-#: exhibition/templates/exhibitors/public_proposal_list.html:32
-#: exhibition/templates/exhibitors/settings.html:55
-msgid "Edit"
-msgstr ""
-
-#: exhibition/templates/exhibitors/call_questions.html:77
+#: templates/exhibitors/call_questions.html:77
 msgid "Reset to default"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:79
+#: templates/exhibitors/call_questions.html:79
 msgid "Move field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/call_questions.html:90
+#: templates/exhibitors/call_questions.html:90
 msgid "New custom field"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:5
-#: exhibition/templates/exhibitors/dashboard.html:9
+#: templates/exhibitors/dashboard.html:5 templates/exhibitors/dashboard.html:9
 msgid "Exhibition overview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:39
+#: templates/exhibitors/dashboard.html:39
 msgid "Requests awaiting review"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:48
+#: templates/exhibitors/dashboard.html:48
 msgid "Emails in outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:61
+#: templates/exhibitors/dashboard.html:61
 msgid "Recent requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:64
+#: templates/exhibitors/dashboard.html:64
 msgid "View all"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:76
+#: templates/exhibitors/dashboard.html:76
 msgid "Submitted"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:91
-#: exhibition/templates/exhibitors/proposal_detail.html:97
-#: exhibition/templates/exhibitors/proposal_list.html:97
+#: templates/exhibitors/dashboard.html:91
+#: templates/exhibitors/proposal_detail.html:97
+#: templates/exhibitors/proposal_list.html:97
 msgid "Sponsor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:93
-#: exhibition/templates/exhibitors/proposal_detail.html:99
-#: exhibition/templates/exhibitors/proposal_list.html:99
+#: templates/exhibitors/dashboard.html:93
+#: templates/exhibitors/proposal_detail.html:99
+#: templates/exhibitors/proposal_list.html:99
 msgid "Exhibitor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:105
+#: templates/exhibitors/dashboard.html:105
 msgid "No requests have been submitted yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:128
+#: templates/exhibitors/dashboard.html:128
 msgid "The call is not published, so nobody can submit a request."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:131
+#: templates/exhibitors/dashboard.html:131
 msgid "Open"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:134
+#: templates/exhibitors/dashboard.html:134
 #, python-format
 msgid "Closes on %(deadline)s."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:139
+#: templates/exhibitors/dashboard.html:139
 msgid "No deadline set."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:142
+#: templates/exhibitors/dashboard.html:142
 msgid "Closed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:144
+#: templates/exhibitors/dashboard.html:144
 #, python-format
 msgid "The deadline passed on %(deadline)s."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:151
+#: templates/exhibitors/dashboard.html:151
 msgid "Private — reachable only with the secret link."
 msgstr ""
 
-#: exhibition/templates/exhibitors/dashboard.html:157
-#: exhibition/templates/exhibitors/settings.html:90
-#: exhibition/templates/exhibitors/settings.html:94
+#: templates/exhibitors/dashboard.html:157
+#: templates/exhibitors/settings.html:94 templates/exhibitors/settings.html:98
 msgid "View call page"
 msgstr ""
 
-#: exhibition/templates/exhibitors/delete.html:11
+#: templates/exhibitors/delete.html:11
 #, python-format
 msgid ""
 "Are you sure you want to delete “%(name)s”? This action cannot be undone."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:8
+#: templates/exhibitors/devices.html:8
 #, python-format
 msgid "Lead-scanning devices for %(name)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:13
+#: templates/exhibitors/devices.html:13
 #, python-brace-format
 msgid ""
 "Provision check-in app devices for this partner. Each device gets its own "
@@ -1672,66 +1704,64 @@ msgid ""
 "through the {device_tokens} placeholder."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:21
+#: templates/exhibitors/devices.html:21
 msgid ""
 "Provisioning devices requires organizer-level permissions. Ask an organizer "
 "admin to create the devices for this partner."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:29
+#: templates/exhibitors/devices.html:29
 msgid "Provisioned devices"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:35
+#: templates/exhibitors/devices.html:35
 msgid "Device"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:36
+#: templates/exhibitors/devices.html:36
 msgid "Setup token"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:37
+#: templates/exhibitors/devices.html:37
 msgid "Status"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:47
+#: templates/exhibitors/devices.html:47
 msgid "Connected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:49
+#: templates/exhibitors/devices.html:49
 msgid "Awaiting setup"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:60
+#: templates/exhibitors/devices.html:60
 msgid ""
 "Generate new setup tokens? Any device that is already scanning will be "
 "disconnected and must be set up again."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:65
+#: templates/exhibitors/devices.html:65
 msgid "Generate new setup tokens"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:70
+#: templates/exhibitors/devices.html:70
 msgid "No devices have been provisioned for this partner yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:80
-#: exhibition/templates/exhibitors/devices.html:85
+#: templates/exhibitors/devices.html:80 templates/exhibitors/devices.html:85
 msgid "Add devices"
 msgstr ""
 
-#: exhibition/templates/exhibitors/devices.html:87
-#: exhibition/templates/exhibitors/vouchers.html:88
+#: templates/exhibitors/devices.html:87 templates/exhibitors/vouchers.html:133
 msgid "Back"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_bulk_discard.html:4
-#: exhibition/templates/exhibitors/email_bulk_discard.html:7
+#: templates/exhibitors/email_bulk_discard.html:4
+#: templates/exhibitors/email_bulk_discard.html:7
 msgid "Discard emails"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_bulk_discard.html:19
+#: templates/exhibitors/email_bulk_discard.html:19
 #, python-format
 msgid ""
 "Are you sure you want to discard %(counter)s queued email? This cannot be "
@@ -1742,80 +1772,80 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/templates/exhibitors/email_bulk_discard.html:30
-#: exhibition/templates/exhibitors/email_delete.html:31
-msgid "Discard"
-msgstr ""
-
-#: exhibition/templates/exhibitors/email_compose.html:7
-#: exhibition/templates/exhibitors/email_compose.html:16
+#: templates/exhibitors/email_compose.html:7
+#: templates/exhibitors/email_compose.html:16
 msgid "Compose email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:21
+#: templates/exhibitors/email_compose.html:21
 msgid ""
 "Send an update to a group of applicants. One email is queued per recipient, "
 "with placeholders resolved individually."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:26
+#: templates/exhibitors/email_compose.html:26
 msgid "Load from template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:28
+#: templates/exhibitors/email_compose.html:28
 msgid "Select a saved template…"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:33
+#: templates/exhibitors/email_compose.html:33
 msgid "Load"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:41
-#: exhibition/templates/exhibitors/email_edit.html:23
+#: templates/exhibitors/email_compose.html:41
+#: templates/exhibitors/email_edit.html:23
 msgid "Recipients"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:47
+#: templates/exhibitors/email_compose.html:47
 msgid "Message"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:58
-#: exhibition/templates/exhibitors/email_custom_template_form.html:33
-#: exhibition/templates/exhibitors/email_templates.html:53
-#: exhibition/templates/exhibitors/email_templates.html:100
-#: exhibition/templates/exhibitors/settings.html:58
+#: templates/exhibitors/email_compose.html:51
+msgctxt "form"
+msgid "required"
+msgstr ""
+
+#: templates/exhibitors/email_compose.html:58
+#: templates/exhibitors/email_custom_template_form.html:33
+#: templates/exhibitors/email_templates.html:53
+#: templates/exhibitors/email_templates.html:100
+#: templates/exhibitors/settings.html:62
 msgid "Preview"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:80
+#: templates/exhibitors/email_compose.html:80
 msgid "Save to outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_compose.html:83
+#: templates/exhibitors/email_compose.html:83
 msgid "Send / Schedule"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:4
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:7
+#: templates/exhibitors/email_custom_template_delete.html:4
+#: templates/exhibitors/email_custom_template_delete.html:7
 msgid "Delete custom template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_custom_template_delete.html:14
+#: templates/exhibitors/email_custom_template_delete.html:14
 #, python-format
 msgid "Are you sure you want to delete the custom template \"%(name)s\"?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_custom_template_form.html:7
-#: exhibition/templates/exhibitors/email_custom_template_form.html:15
+#: templates/exhibitors/email_custom_template_form.html:7
+#: templates/exhibitors/email_custom_template_form.html:15
 msgid "Custom template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_delete.html:4
-#: exhibition/templates/exhibitors/email_delete.html:7
+#: templates/exhibitors/email_delete.html:4
+#: templates/exhibitors/email_delete.html:7
 msgid "Discard email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_delete.html:15
+#: templates/exhibitors/email_delete.html:15
 #, python-format
 msgid ""
 "Are you sure you want to discard the email “%(subject)s” to %(counter)s "
@@ -1826,908 +1856,1156 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/templates/exhibitors/email_delete.html:21
+#: templates/exhibitors/email_delete.html:21
 #, python-format
 msgid ""
 "Are you sure you want to discard the email “%(subject)s” to %(to)s? This "
 "cannot be undone."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:5
+#: templates/exhibitors/email_edit.html:5
 msgid "Edit email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:8
+#: templates/exhibitors/email_edit.html:8
 msgid "Preview / edit email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:14
+#: templates/exhibitors/email_edit.html:14
 msgid "Back to outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_edit.html:41
+#: templates/exhibitors/email_edit.html:41
 msgid "Save & send"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_outbox.html:12
-#: exhibition/templates/exhibitors/email_outbox.html:15
+#: templates/exhibitors/email_outbox.html:12
+#: templates/exhibitors/email_outbox.html:15
 msgid "Email outbox"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_outbox.html:20
+#: templates/exhibitors/email_outbox.html:20
 msgid ""
 "Emails waiting to be sent. Review, edit, or discard them before sending."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_sent.html:12
-#: exhibition/templates/exhibitors/email_sent.html:15
+#: templates/exhibitors/email_sent.html:12
+#: templates/exhibitors/email_sent.html:15
 msgid "Sent emails"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:7
-#: exhibition/templates/exhibitors/email_templates.html:16
+#: templates/exhibitors/email_templates.html:7
+#: templates/exhibitors/email_templates.html:16
 msgid "Email templates"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:22
+#: templates/exhibitors/email_templates.html:22
 msgid "New template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:27
+#: templates/exhibitors/email_templates.html:27
 msgid ""
 "These templates are used for the confirmation email sent when an applicant "
 "submits a request, and for the accept/reject emails you send from the outbox."
 msgstr ""
 
-#: exhibition/templates/exhibitors/email_templates.html:81
+#: templates/exhibitors/email_templates.html:81
 msgid "Discard this template"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:31
+#: templates/exhibitors/exhibitor_info.html:31
 msgid "No organizations match your filters."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:33
+#: templates/exhibitors/exhibitor_info.html:33
 msgid "You don't have any sponsors yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:35
+#: templates/exhibitors/exhibitor_info.html:35
 msgid "You don't have any exhibitors yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:37
+#: templates/exhibitors/exhibitor_info.html:37
 msgid "You don't have any exhibitors or sponsors yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:43
-#: exhibition/templates/exhibitors/exhibitor_info.html:52
-#: exhibition/views.py:1837
+#: templates/exhibitors/exhibitor_info.html:43
+#: templates/exhibitors/exhibitor_info.html:57 views.py:1979
 msgid "Add a Sponsor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:43
-#: exhibition/templates/exhibitors/exhibitor_info.html:52
-#: exhibition/views.py:1838
+#: templates/exhibitors/exhibitor_info.html:43
+#: templates/exhibitors/exhibitor_info.html:57 views.py:1980
 msgid "Add an Exhibitor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:43
-#: exhibition/templates/exhibitors/exhibitor_info.html:52
-#: exhibition/views.py:1839
+#: templates/exhibitors/exhibitor_info.html:43
+#: templates/exhibitors/exhibitor_info.html:57 views.py:1981
 msgid "Add an Exhibitor or Sponsor"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:48
-#: exhibition/templates/exhibitors/proposal_list.html:169
+#: templates/exhibitors/exhibitor_info.html:48
+#: templates/exhibitors/proposal_list.html:170
 msgid "selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:54
+#: templates/exhibitors/exhibitor_info.html:59
 msgid "Download access keys as CSV"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:56
+#: templates/exhibitors/exhibitor_info.html:61
 msgid "Download sponsor keys"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:56
+#: templates/exhibitors/exhibitor_info.html:61
 msgid "Download exhibitor keys"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:56
+#: templates/exhibitors/exhibitor_info.html:61
 msgid "Download access keys"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:65
+#: templates/exhibitors/exhibitor_info.html:64
+msgid "Queue a voucher email for everyone in this list"
+msgstr ""
+
+#: templates/exhibitors/exhibitor_info.html:65
+msgid "Send vouchers to all"
+msgstr ""
+
+#: templates/exhibitors/exhibitor_info.html:75
 msgid ""
 "Drag-and-drop ordering is available only on the unfiltered, single-page list."
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:70
+#: templates/exhibitors/exhibitor_info.html:80
 msgid "Booth"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:78
-#: exhibition/templates/exhibitors/exhibitor_info.html:106
+#: templates/exhibitors/exhibitor_info.html:88
+#: templates/exhibitors/exhibitor_info.html:117
 msgid "Select all partners"
 msgstr ""
 
-#: exhibition/templates/exhibitors/exhibitor_info.html:84
-#: exhibition/templates/exhibitors/exhibitor_info.html:112
+#: templates/exhibitors/exhibitor_info.html:94
+#: templates/exhibitors/exhibitor_info.html:123
 msgid "Group"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:12
-#: exhibition/templates/exhibitors/proposal_detail.html:15
+#: templates/exhibitors/proposal_detail.html:12
+#: templates/exhibitors/proposal_detail.html:15
 msgid "Review exhibition request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:21
+#: templates/exhibitors/proposal_detail.html:21
 msgid "Back to exhibition requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:29
+#: templates/exhibitors/proposal_detail.html:29
 #, python-format
 msgid "Changes made by the applicant after acceptance (%(when)s)"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:39
+#: templates/exhibitors/proposal_detail.html:39
 msgid "Before acceptance"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:40
+#: templates/exhibitors/proposal_detail.html:40
 msgid "After edit"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:55
+#: templates/exhibitors/proposal_detail.html:55
 msgid "The applicant edited the profile, but the tracked fields are unchanged."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:57
+#: templates/exhibitors/proposal_detail.html:57
 msgid ""
 "This profile was edited before change tracking was available, so the "
 "original values are not recorded."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:69
-#: exhibition/templates/exhibitors/proposal_list.html:20
+#: templates/exhibitors/proposal_detail.html:69
+#: templates/exhibitors/proposal_list.html:20
 msgid "Submitter"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:80
+#: templates/exhibitors/proposal_detail.html:80
 msgid "Hidden"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:121
+#: templates/exhibitors/proposal_detail.html:121
 msgid "Message to organizers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:129
+#: templates/exhibitors/proposal_detail.html:129
 msgid "Links"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:152
+#: templates/exhibitors/proposal_detail.html:152
 msgid "Download"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:154
+#: templates/exhibitors/proposal_detail.html:154
 msgid "Custom answers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:176
+#: templates/exhibitors/proposal_detail.html:176
 msgid "Review"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:192
-#: exhibition/templates/exhibitors/proposal_list.html:117
-#: exhibition/templates/exhibitors/proposal_list.html:164
+#: templates/exhibitors/proposal_detail.html:192
+#: templates/exhibitors/proposal_list.html:118
+#: templates/exhibitors/proposal_list.html:165
 msgid "Approve"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:195
-#: exhibition/templates/exhibitors/proposal_list.html:122
-#: exhibition/templates/exhibitors/proposal_list.html:165
+#: templates/exhibitors/proposal_detail.html:195
+#: templates/exhibitors/proposal_list.html:123
+#: templates/exhibitors/proposal_list.html:166
 msgid "Reject"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_detail.html:200
+#: templates/exhibitors/proposal_detail.html:200
 msgid "Open profile"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:22
+#: templates/exhibitors/proposal_list.html:22
 msgid "Updated"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:33
+#: templates/exhibitors/proposal_list.html:33
 msgid "Select at least one request."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:34
+#: templates/exhibitors/proposal_list.html:34
 msgid "None of the selected requests can be approved."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:35
+#: templates/exhibitors/proposal_list.html:35
 msgid "None of the selected requests can be rejected."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:36
+#: templates/exhibitors/proposal_list.html:36
 #, python-brace-format
 msgid "{count} selected requests cannot be approved and will be skipped."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:37
+#: templates/exhibitors/proposal_list.html:37
 #, python-brace-format
 msgid "{count} selected requests cannot be rejected and will be skipped."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:41
+#: templates/exhibitors/proposal_list.html:41
 msgid "Approve selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:44
+#: templates/exhibitors/proposal_list.html:44
 msgid "Reject selected"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:55
+#: templates/exhibitors/proposal_list.html:55
 msgid "Select all matching requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:75
+#: templates/exhibitors/proposal_list.html:75
 msgid "Select request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:106
+#: templates/exhibitors/proposal_list.html:106
 msgid "Edited after acceptance, see detail view for changes."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:127
-#: exhibition/templates/exhibitors/proposal_list.html:166
-#: exhibition/templates/exhibitors/public_proposal_list.html:39
+#: templates/exhibitors/proposal_list.html:128
+#: templates/exhibitors/proposal_list.html:167
+#: templates/exhibitors/public_proposal_list.html:39
 msgid "Withdraw"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:132
-#: exhibition/templates/exhibitors/proposal_list.html:167
+#: templates/exhibitors/proposal_list.html:133
+#: templates/exhibitors/proposal_list.html:168
 msgid "Reopen for review"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:137
-#: exhibition/templates/exhibitors/public_proposal_list.html:34
+#: templates/exhibitors/proposal_list.html:138
+#: templates/exhibitors/public_proposal_list.html:34
 msgid "View"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:149
+#: templates/exhibitors/proposal_list.html:150
 msgid "No exhibition requests match your filters."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:151
+#: templates/exhibitors/proposal_list.html:152
 msgid "No exhibition requests have been submitted yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:159
+#: templates/exhibitors/proposal_list.html:160
 msgid "Approve the selected requests and create their partner profiles?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:160
+#: templates/exhibitors/proposal_list.html:161
 msgid "Reject the selected requests?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:161
+#: templates/exhibitors/proposal_list.html:162
 msgid "Reject this request?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:162
+#: templates/exhibitors/proposal_list.html:163
 msgid "Withdraw this request?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:163
+#: templates/exhibitors/proposal_list.html:164
 msgid "Reopen this request for review?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:168
+#: templates/exhibitors/proposal_list.html:169
 msgid "The action could not be completed. Please try again."
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:170
+#: templates/exhibitors/proposal_list.html:171
 msgid ""
 "Approve every request matching the current filters, including those on other "
 "pages?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:171
+#: templates/exhibitors/proposal_list.html:172
 msgid ""
 "Reject every request matching the current filters, including those on other "
 "pages?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:172
+#: templates/exhibitors/proposal_list.html:173
 msgid "Please confirm"
 msgstr ""
 
-#: exhibition/templates/exhibitors/proposal_list.html:173
+#: templates/exhibitors/proposal_list.html:174
 msgid "Confirm"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:14
+#: templates/exhibitors/public_call.html:14
 msgid "Submit a request to become an exhibitor for this event."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:20
+#: templates/exhibitors/public_call.html:20
 #, python-format
 msgid "You can submit requests until %(deadline)s (%(timezone)s)."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:24
+#: templates/exhibitors/public_call.html:24
 #, python-format
 msgid "This call closed on %(deadline)s (%(timezone)s)."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:34
+#: templates/exhibitors/public_call.html:34
 msgid "View your requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:40
-#: exhibition/templates/exhibitors/public_proposal_form.html:18
-#: exhibition/templates/exhibitors/public_proposal_list.html:65
+#: templates/exhibitors/public_call.html:40
+#: templates/exhibitors/public_proposal_form.html:18
+#: templates/exhibitors/public_proposal_list.html:65
 msgid "Submit a request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_call.html:42
+#: templates/exhibitors/public_call.html:42
 msgid "Requests are closed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:21
-#: exhibition/templates/exhibitors/public_detail.html:94
+#: templates/exhibitors/public_detail.html:21
+#: templates/exhibitors/public_detail.html:93
 msgid "Previous"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:24
-#: exhibition/templates/exhibitors/public_detail.html:98
+#: templates/exhibitors/public_detail.html:24
+#: templates/exhibitors/public_detail.html:97
 msgid "Next"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:47
+#: templates/exhibitors/public_detail.html:47
 msgid "Get In Touch"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:87
-#: exhibition/templates/exhibitors/public_detail.html:103
+#: templates/exhibitors/public_detail.html:87
+#: templates/exhibitors/public_detail.html:102
 msgid "Open slides PDF"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:88
-#, python-brace-format
-msgid "Slide {current} of {total}"
-msgstr ""
-
-#: exhibition/templates/exhibitors/public_detail.html:112
+#: templates/exhibitors/public_detail.html:111
 msgid "Send email"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_detail.html:126
+#: templates/exhibitors/public_detail.html:125
 msgid "Visit website"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_list.html:54
+#: templates/exhibitors/public_list.html:32
+msgid "Clear"
+msgstr ""
+
+#: templates/exhibitors/public_list.html:54
 msgid "No exhibitors match your search."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_list.html:56
+#: templates/exhibitors/public_list.html:56
 msgid "No exhibitors are currently available."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:16
+#: templates/exhibitors/public_proposal_form.html:16
 msgid "Edit request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:23
-#: exhibition/views.py:883
+#: templates/exhibitors/public_proposal_form.html:23 views.py:958
 msgid "This request can no longer be edited."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:186
+#: templates/exhibitors/public_proposal_form.html:190
 msgid "Submit request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:189
+#: templates/exhibitors/public_proposal_form.html:193
 msgid "or save as draft for now"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_form.html:199
+#: templates/exhibitors/public_proposal_form.html:203
 msgid "Back to your requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:5
+#: templates/exhibitors/public_proposal_list.html:5
 msgid "Your exhibition requests"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:13
+#: templates/exhibitors/public_proposal_list.html:13
 msgid "Last modified"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:23
+#: templates/exhibitors/public_proposal_list.html:23
 msgid "Withdrawn"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:44
+#: templates/exhibitors/public_proposal_list.html:44
 msgid "Reinstate"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:56
+#: templates/exhibitors/public_proposal_list.html:56
 msgid "Create a new request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_list.html:61
+#: templates/exhibitors/public_proposal_list.html:61
 msgid "You have not submitted an exhibition request yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:5
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:21
+#: templates/exhibitors/public_proposal_reinstate.html:5
+#: templates/exhibitors/public_proposal_reinstate.html:21
 msgid "Reinstate request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_reinstate.html:7
+#: templates/exhibitors/public_proposal_reinstate.html:7
 #, python-format
 msgid ""
 "Do you want to reinstate your withdrawn request “%(name)s”? It will be "
 "pending review again."
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:5
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:26
+#: templates/exhibitors/public_proposal_withdraw.html:5
+#: templates/exhibitors/public_proposal_withdraw.html:26
 msgid "Withdraw request"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:7
+#: templates/exhibitors/public_proposal_withdraw.html:7
 #, python-format
 msgid "Are you sure you want to withdraw your request “%(name)s”?"
 msgstr ""
 
-#: exhibition/templates/exhibitors/public_proposal_withdraw.html:13
+#: templates/exhibitors/public_proposal_withdraw.html:13
 msgid ""
 "This request has already been approved. Withdrawing it will hide the "
 "exhibitor or sponsor profile created from it from public listings."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:10
-#: exhibition/templates/exhibitors/settings.html:27
+#: templates/exhibitors/settings.html:10 templates/exhibitors/settings.html:29
 msgid "Sponsor Settings"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:12
-#: exhibition/templates/exhibitors/settings.html:29
+#: templates/exhibitors/settings.html:12 templates/exhibitors/settings.html:31
+msgid "Voucher Settings"
+msgstr ""
+
+#: templates/exhibitors/settings.html:14 templates/exhibitors/settings.html:33
 msgid "Exhibitor Settings"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:42
+#: templates/exhibitors/settings.html:46
 msgid "Publish your call"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:43
+#: templates/exhibitors/settings.html:47
 msgid "Publish a login-required application form for exhibitors."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:72
+#: templates/exhibitors/settings.html:76
 msgid ""
 "This panel renders unsaved draft text using the same styling as the live "
 "public call page."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:104
+#: templates/exhibitors/settings.html:108
 msgid "Secret call link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:107
+#: templates/exhibitors/settings.html:111
 msgid ""
 "This call is private: it is not linked anywhere public. Share the link below "
 "with the organizations you want to invite. Anyone who has it can open the "
 "call and apply."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:113
+#: templates/exhibitors/settings.html:117
 msgid "Copied"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:113
+#: templates/exhibitors/settings.html:117
 msgid "Copy to clipboard"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:114
+#: templates/exhibitors/settings.html:118
 msgid "Copy"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:119
+#: templates/exhibitors/settings.html:123
 msgid ""
 "Regenerate the secret link? The current link will stop working immediately."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:125
+#: templates/exhibitors/settings.html:129
 msgid "Regenerate link"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:127
+#: templates/exhibitors/settings.html:131
 msgid "Regenerating immediately invalidates the current link."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:138
+#: templates/exhibitors/settings.html:143
+msgid "Voucher pools"
+msgstr ""
+
+#: templates/exhibitors/settings.html:147
+msgid ""
+"Create the voucher codes under Tickets → Vouchers and give them a tag, then "
+"pick that tag here. Exhibitors and sponsors are handed codes from the pool "
+"you choose. Reload this page to pick up a tag you just created."
+msgstr ""
+
+#: templates/exhibitors/settings.html:157
+msgid "Create vouchers pool"
+msgstr ""
+
+#: templates/exhibitors/settings.html:159
+msgid "(opens in a new tab)"
+msgstr ""
+
+#: templates/exhibitors/settings.html:168
+#: templates/exhibitors/settings.html:182
+#, python-format
+msgid "%(counter)s voucher in this pool is not assigned to anyone yet."
+msgid_plural ""
+"%(counter)s vouchers in this pool are not assigned to anyone yet."
+msgstr[0] ""
+
+#: templates/exhibitors/settings.html:194
+msgid "How many each one gets"
+msgstr ""
+
+#: templates/exhibitors/settings.html:196
+msgid ""
+"Applies to any exhibitor or sponsor that does not belong to a sponsor group. "
+"Sponsor groups set their own number on the Sponsors page, and an individual "
+"exhibitor or sponsor can be given a different number on their own voucher "
+"page."
+msgstr ""
+
+#: templates/exhibitors/settings.html:206
+msgid "Voucher email"
+msgstr ""
+
+#: templates/exhibitors/settings.html:208
+msgid "Applies to the voucher email sent to exhibitors and sponsors alike."
+msgstr ""
+
+#: templates/exhibitors/settings.html:228
 msgid "Data access"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:139
+#: templates/exhibitors/settings.html:229
 msgid ""
 "In this section, you can control which attendee data is shared with "
 "exhibitors when an exhibitor voucher is used or when the exhibitor uses the "
 "lead scanning app."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:142
+#: templates/exhibitors/settings.html:232
 msgid "Exhibitor vouchers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:158
-msgid "Exhibitor login"
-msgstr ""
-
-#: exhibition/templates/exhibitors/settings.html:160
-msgid ""
-"The access-code email sent to exhibitors is now edited together with the "
-"plugin's other email templates."
-msgstr ""
-
-#: exhibition/templates/exhibitors/settings.html:162
-msgid "Edit email templates"
-msgstr ""
-
-#: exhibition/templates/exhibitors/settings.html:177
+#: templates/exhibitors/settings.html:257
 msgid "Group List"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:180
+#: templates/exhibitors/settings.html:260
 msgid "Add a Group"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:193
+#: templates/exhibitors/settings.html:272
+#: templates/exhibitors/settings.html:354
+msgid "Voucher defaults for this group"
+msgstr ""
+
+#: templates/exhibitors/settings.html:277
 msgid "Add"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:204
+#: templates/exhibitors/settings.html:288
 msgid "Group Name"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:206
+#: templates/exhibitors/settings.html:290
 msgid "Partners"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:207
+#: templates/exhibitors/settings.html:291
 msgid "Front Page"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:220
-#: exhibition/templates/exhibitors/settings.html:226
+#: templates/exhibitors/settings.html:304
+#: templates/exhibitors/settings.html:310
 msgid "Show this sponsor group in the Supported By section on the front page."
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:251
+#: templates/exhibitors/settings.html:326
+msgid "Edit sponsor group"
+msgstr ""
+
+#: templates/exhibitors/settings.html:337
 msgid "Reorder sponsor group"
 msgstr ""
 
-#: exhibition/templates/exhibitors/settings.html:281
+#: templates/exhibitors/settings.html:371
 msgid "You do not have any sponsor groups yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:8
+#: templates/exhibitors/voucher_bulk_send.html:4
+#: templates/exhibitors/voucher_bulk_send.html:7
+msgid "Send vouchers"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:18
+#, python-format
+msgid "A voucher email will be placed in the outbox for %(counter)s sponsor."
+msgid_plural ""
+"A voucher email will be placed in the outbox for %(counter)s sponsors."
+msgstr[0] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:24
+#, python-format
+msgid "A voucher email will be placed in the outbox for %(counter)s exhibitor."
+msgid_plural ""
+"A voucher email will be placed in the outbox for %(counter)s exhibitors."
+msgstr[0] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:37
+#, python-format
+msgid "&mdash; %(counter)s voucher will be created"
+msgid_plural "&mdash; %(counter)s vouchers will be created"
+msgstr[0] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:45
+#, python-format
+msgid "&mdash; %(counter)s existing voucher"
+msgid_plural "&mdash; %(counter)s existing vouchers"
+msgstr[0] ""
+
+#: templates/exhibitors/voucher_bulk_send.html:58
+msgid "None of the sponsors in this list can be emailed yet."
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:60
+msgid "None of the exhibitors in this list can be emailed yet."
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:66
+msgid "Skipped: no email address"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:75
+msgid "Skipped: voucher count is set to 0"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:84
+msgid "Skipped: no vouchers available from their pool"
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:86
+msgid ""
+"Check that a voucher pool is selected under Settings → Vouchers and that it "
+"still has unassigned codes."
+msgstr ""
+
+#: templates/exhibitors/voucher_bulk_send.html:99
+msgid "Queue emails"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:8
 #, python-format
 msgid "Vouchers for %(name)s"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:13
+#: templates/exhibitors/vouchers.html:13
 msgid ""
-"Issue ticket vouchers for this partner to hand out. Whoever redeems one on "
-"the ticket shop becomes a lead this partner can retrieve, as long as voucher "
+"Hand this exhibitor or sponsor codes from the voucher pool. Whoever redeems "
+"one on the ticket shop becomes a lead they can retrieve, as long as voucher "
 "data access is enabled for them."
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:20
-msgid "Issued vouchers"
+#: templates/exhibitors/vouchers.html:20
+msgid "Assigned vouchers"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:24
+#: templates/exhibitors/vouchers.html:24
 msgid "Download codes (CSV)"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:31
+#: templates/exhibitors/vouchers.html:31
 msgid "Code"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:32 exhibition/views.py:1994
+#: templates/exhibitors/vouchers.html:32 utils.py:495
 msgid "Product"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:34 exhibition/views.py:1998
+#: templates/exhibitors/vouchers.html:33 utils.py:496
+msgid "Price effect"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:34 utils.py:499
 msgid "Redeemed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:56
+#: templates/exhibitors/vouchers.html:35 utils.py:498
+msgid "Valid until"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:56
 msgid "Already redeemed"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:67
-msgid "No vouchers have been issued for this partner yet."
+#: templates/exhibitors/vouchers.html:62
+msgid "Return to pool"
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:76
-msgid "Issue new vouchers"
+#: templates/exhibitors/vouchers.html:74
+msgid "No vouchers have been assigned to this partner yet."
 msgstr ""
 
-#: exhibition/templates/exhibitors/vouchers.html:86
-msgid "Create vouchers"
+#: templates/exhibitors/vouchers.html:82
+msgid "Take more from the pool"
 msgstr ""
 
-#: exhibition/templates/sponsors/presale_supported_by.html:4
+#: templates/exhibitors/vouchers.html:84
+msgid ""
+"Codes come from the voucher pool chosen under Settings. The email always "
+"carries this partner's complete list of codes, so you can assign some now "
+"and send them together with more later. It is placed in the outbox for you "
+"to review before it goes out."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:92
+#, python-format
+msgid "%(counter)s voucher is left unassigned in the pool."
+msgid_plural "%(counter)s vouchers are left unassigned in the pool."
+msgstr[0] ""
+
+#: templates/exhibitors/vouchers.html:100 views.py:2230
+msgid "No voucher pool is selected yet. Choose one under Settings → Vouchers."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:106
+msgid "A voucher email for this partner is waiting in the outbox."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:108
+msgid "Go to outbox"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:114
+#, python-format
+msgid "Vouchers were last emailed to this partner on %(sent)s."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:120
+msgid ""
+"This partner has no email address on file, so vouchers cannot be emailed."
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:127
+msgid "Assign and prepare email"
+msgstr ""
+
+#: templates/exhibitors/vouchers.html:130
+msgid "Assign without emailing"
+msgstr ""
+
+#: templates/sponsors/presale_supported_by.html:4
 msgid "Supported By"
 msgstr ""
 
-#: exhibition/views.py:324
+#: utils.py:493
+msgid "Voucher code"
+msgstr ""
+
+#: utils.py:494
+msgid "Redeem link"
+msgstr ""
+
+#: utils.py:497
+msgid "Value"
+msgstr ""
+
+#: utils.py:500
+msgid "Maximum usages"
+msgstr ""
+
+#: views.py:342
 msgid "Company name"
 msgstr ""
 
-#: exhibition/views.py:325
+#: views.py:343
 msgid "Job title"
 msgstr ""
 
-#: exhibition/views.py:326
+#: views.py:344
 msgid "Address"
 msgstr ""
 
-#: exhibition/views.py:333
+#: views.py:351
 msgid "Attendee Name"
 msgstr ""
 
-#: exhibition/views.py:338
+#: views.py:356
 msgid "Attendee Email"
 msgstr ""
 
-#: exhibition/views.py:377
+#: views.py:395 views.py:412
 msgid "Settings have been saved."
 msgstr ""
 
-#: exhibition/views.py:393
+#: views.py:428
 msgid "Call settings have been saved."
 msgstr ""
 
-#: exhibition/views.py:401
+#: views.py:436
 msgid ""
 "A new secret call link has been generated. The old link no longer works."
 msgstr ""
 
-#: exhibition/views.py:416
+#: views.py:451
 msgid "Sponsor group added."
 msgstr ""
 
-#: exhibition/views.py:437
+#: views.py:454 views.py:477 views.py:853 views.py:1169 views.py:1796
+#: views.py:1918 views.py:2564 views.py:3025
+msgid "We could not save your changes. See below for details."
+msgstr ""
+
+#: views.py:474
 msgid "Sponsor group updated."
 msgstr ""
 
-#: exhibition/views.py:452
+#: views.py:491
 msgid "This sponsor group cannot be deleted while it is assigned to partners."
 msgstr ""
 
-#: exhibition/views.py:460
+#: views.py:499
 msgid "Unknown action."
 msgstr ""
 
-#: exhibition/views.py:505
+#: views.py:544
 msgid "Access key"
 msgstr ""
 
-#: exhibition/views.py:745 exhibition/views.py:1060
+#: views.py:819 views.py:1135
 msgid "Add at least one social media link."
 msgstr ""
 
-#: exhibition/views.py:754 exhibition/views.py:1069
+#: views.py:828 views.py:1144
 msgid "Add at least one extra link."
 msgstr ""
 
-#: exhibition/views.py:809
+#: views.py:884
 msgid "The call for exhibitors is closed."
 msgstr ""
 
-#: exhibition/views.py:837
+#: views.py:912
 msgid "Your request has been saved."
 msgstr ""
 
-#: exhibition/views.py:920 exhibition/views.py:1776
+#: views.py:995 views.py:1914
 msgid "Your changes have been saved."
 msgstr ""
 
-#: exhibition/views.py:953
+#: views.py:1028
 msgid "This proposal can no longer be withdrawn."
 msgstr ""
 
-#: exhibition/views.py:961
+#: views.py:1036
 msgid "Your request has been withdrawn."
 msgstr ""
 
-#: exhibition/views.py:963
+#: views.py:1038
 msgid "This request can no longer be withdrawn."
 msgstr ""
 
-#: exhibition/views.py:989 exhibition/views.py:999
+#: views.py:1064 views.py:1074
 msgid "This request can no longer be reinstated."
 msgstr ""
 
-#: exhibition/views.py:997
+#: views.py:1072
 msgid "Your request has been reinstated and is pending review again."
 msgstr ""
 
-#: exhibition/views.py:1121
+#: views.py:1197
 msgid "Invalid request body."
 msgstr ""
 
-#: exhibition/views.py:1124 exhibition/views.py:1129
+#: views.py:1200 views.py:1205
 msgid "Invalid sponsor group IDs."
 msgstr ""
 
-#: exhibition/views.py:1133
+#: views.py:1209
 msgid "Sponsor group IDs must be unique."
 msgstr ""
 
-#: exhibition/views.py:1141
+#: views.py:1217
 msgid "Reorder request must include each sponsor group exactly once."
 msgstr ""
 
-#: exhibition/views.py:1346
+#: views.py:1422
 msgid "This request can no longer be changed to that state."
 msgstr ""
 
-#: exhibition/views.py:1350
+#: views.py:1426
 msgid "Review details saved."
 msgstr ""
 
-#: exhibition/views.py:1359
+#: views.py:1435
 msgid ""
 "Request approved and partner profile created. An acceptance email was placed "
 "in the outbox."
 msgstr ""
 
-#: exhibition/views.py:1369
+#: views.py:1445
 msgid "Request rejected. A rejection email was placed in the outbox."
 msgstr ""
 
-#: exhibition/views.py:1372
+#: views.py:1448
 msgid "Request withdrawn."
 msgstr ""
 
-#: exhibition/views.py:1375
+#: views.py:1451
 msgid "Request reopened for review."
 msgstr ""
 
-#: exhibition/views.py:1407
+#: views.py:1483
 msgid "No valid action was selected."
 msgstr ""
 
-#: exhibition/views.py:1454
+#: views.py:1530
 #, python-format
 msgid "%(count)d request was approved."
 msgid_plural "%(count)d requests were approved."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1455
+#: views.py:1531
 #, python-format
 msgid "%(count)d request was rejected."
 msgid_plural "%(count)d requests were rejected."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1456
+#: views.py:1532
 #, python-format
 msgid "%(count)d request was withdrawn."
 msgid_plural "%(count)d requests were withdrawn."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1457
+#: views.py:1533
 #, python-format
 msgid "%(count)d request was reopened."
 msgid_plural "%(count)d requests were reopened."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1461
+#: views.py:1537
 msgid "No proposals were updated."
 msgstr ""
 
-#: exhibition/views.py:1464
+#: views.py:1540
 #, python-format
 msgid "%(skipped)d was skipped because it was already processed."
 msgid_plural "%(skipped)d were skipped because they were already processed."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:1605
+#: views.py:1681
 msgid "Exhibitor form settings have been saved."
 msgstr ""
 
-#: exhibition/views.py:1730
+#: views.py:1868
 msgid "The requested form field does not exist."
 msgstr ""
 
-#: exhibition/views.py:1791
+#: views.py:1933
 msgid "The field has been reset to its default."
 msgstr ""
 
-#: exhibition/views.py:1829 exhibition/views.py:1900
+#: views.py:1971 views.py:2042
 msgid "An access-credentials email was placed in the outbox."
 msgstr ""
 
-#: exhibition/views.py:1907
+#: views.py:2049
 msgid "Edit Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1908
+#: views.py:2050
 msgid "Edit Exhibitor"
 msgstr ""
 
-#: exhibition/views.py:1909
+#: views.py:2051
 msgid "Edit Exhibitor & Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1910
+#: views.py:2052
 msgid "Edit Exhibitor or Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1940
+#: views.py:2082
 msgid "Delete Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1941
+#: views.py:2083
 msgid "Delete Exhibitor"
 msgstr ""
 
-#: exhibition/views.py:1942
+#: views.py:2084
 msgid "Delete Exhibitor & Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1943
+#: views.py:2085
 msgid "Delete Exhibitor or Sponsor"
 msgstr ""
 
-#: exhibition/views.py:1992
-msgid "Voucher code"
+#: views.py:2164
+msgid "This voucher has already been redeemed and cannot be returned."
 msgstr ""
 
-#: exhibition/views.py:1993
-msgid "Redeem link"
+#: views.py:2170
+msgid ""
+"This code was already included in a voucher email to this partner, so it "
+"cannot be returned to the pool. Delete it under Tickets → Vouchers instead."
 msgstr ""
 
-#: exhibition/views.py:1999
-msgid "Maximum usages"
+#: views.py:2176
+msgid "Voucher returned to the pool."
 msgstr ""
 
-#: exhibition/views.py:2035
-msgid "This voucher has already been redeemed and cannot be removed."
+#: views.py:2207
+msgid "Enter how many vouchers to take from the pool."
 msgstr ""
 
-#: exhibition/views.py:2040
-msgid "Voucher removed."
-msgstr ""
-
-#: exhibition/views.py:2060
+#: views.py:2215
 #, python-format
-msgid "%(count)d voucher created."
-msgid_plural "%(count)d vouchers created."
+msgid "%(count)d voucher taken from the pool."
+msgid_plural "%(count)d vouchers taken from the pool."
 msgstr[0] ""
-msgstr[1] ""
 
-#: exhibition/views.py:2112
+#: views.py:2232
+#, python-format
+msgid ""
+"The pool only has %(remaining)d voucher(s) left, so %(count)d cannot be "
+"taken."
+msgstr ""
+
+#: views.py:2244
+msgid "No email address is on file, so vouchers cannot be emailed."
+msgstr ""
+
+#: views.py:2253
+msgid "This partner holds no vouchers yet, so there is nothing to email."
+msgstr ""
+
+#: views.py:2259
+#, python-format
+msgid "An email with %(count)d voucher code was placed in the outbox."
+msgid_plural "An email with %(count)d voucher codes was placed in the outbox."
+msgstr[0] ""
+
+#: views.py:2347
+msgid "There is nobody to send vouchers to in this list."
+msgstr ""
+
+#: views.py:2354
+#, python-format
+msgid "%(count)d voucher email was placed in the outbox."
+msgid_plural "%(count)d voucher emails were placed in the outbox."
+msgstr[0] ""
+
+#: views.py:2371
+#, python-format
+msgid ""
+"%(count)d was skipped because no unassigned codes were available from their "
+"pool."
+msgid_plural ""
+"%(count)d were skipped because no unassigned codes were available from their "
+"pool."
+msgstr[0] ""
+
+#: views.py:2386
+#, python-format
+msgid "%(count)d sponsor was skipped because it has no email address."
+msgid_plural ""
+"%(count)d sponsors were skipped because they have no email address."
+msgstr[0] ""
+
+#: views.py:2392
+#, python-format
+msgid "%(count)d exhibitor was skipped because it has no email address."
+msgid_plural ""
+"%(count)d exhibitors were skipped because they have no email address."
+msgstr[0] ""
+
+#: views.py:2401
+#, python-format
+msgid "%(count)d sponsor was skipped because their voucher count is set to 0."
+msgid_plural ""
+"%(count)d sponsors were skipped because their voucher count is set to 0."
+msgstr[0] ""
+
+#: views.py:2407
+#, python-format
+msgid ""
+"%(count)d exhibitor was skipped because their voucher count is set to 0."
+msgid_plural ""
+"%(count)d exhibitors were skipped because their voucher count is set to 0."
+msgstr[0] ""
+
+#: views.py:2461
 #, python-format
 msgid "%(count)d device added."
 msgid_plural "%(count)d devices added."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2123
+#: views.py:2472
 #, python-format
 msgid ""
 "New setup tokens generated. %(count)d device that was already scanning is "
@@ -2738,79 +3016,95 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2132
+#: views.py:2481
 msgid "New setup tokens generated."
 msgstr ""
 
-#: exhibition/views.py:2194
+#: views.py:2543
 msgid "No applicants matched the selected filters."
 msgstr ""
 
-#: exhibition/views.py:2202
+#: views.py:2551
 #, python-format
 msgid "%(count)d emails have been scheduled."
 msgstr ""
 
-#: exhibition/views.py:2206
+#: views.py:2555
 #, python-format
 msgid "%(count)d emails have been sent."
 msgstr ""
 
-#: exhibition/views.py:2210
+#: views.py:2559
 #, python-format
 msgid "%(count)d emails have been placed in the outbox."
 msgstr ""
 
-#: exhibition/views.py:2385
+#: views.py:2738
 msgid "The emails have been saved and sent."
 msgstr ""
 
-#: exhibition/views.py:2389
+#: views.py:2742
 msgid "The emails have been saved."
 msgstr ""
 
-#: exhibition/views.py:2395
+#: views.py:2748
 msgid "The email has been saved and sent."
 msgstr ""
 
-#: exhibition/views.py:2399
+#: views.py:2752
 msgid "The email has been saved."
 msgstr ""
 
-#: exhibition/views.py:2423 exhibition/views.py:2497
+#: views.py:2776 views.py:2850
 #, python-format
 msgid "%(count)d email has been sent."
 msgid_plural "%(count)d emails have been sent."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2459
+#: views.py:2812
 msgid "The email has been discarded."
 msgstr ""
 
-#: exhibition/views.py:2501 exhibition/views.py:2514 exhibition/views.py:2519
+#: views.py:2854 views.py:2867 views.py:2872
 msgid "No emails were selected."
 msgstr ""
 
-#: exhibition/views.py:2510
+#: views.py:2863
 #, python-format
 msgid "%(count)d email has been discarded."
 msgid_plural "%(count)d emails have been discarded."
 msgstr[0] ""
 msgstr[1] ""
 
-#: exhibition/views.py:2594
+#: views.py:2929
+msgid "Request received (confirmation)"
+msgstr ""
+
+#: views.py:2930
+msgid "Request accepted"
+msgstr ""
+
+#: views.py:2931
+msgid "Request rejected"
+msgstr ""
+
+#: views.py:2932
+msgid "Exhibitor lead scanning key"
+msgstr ""
+
+#: views.py:2948
 msgid "Email templates have been saved."
 msgstr ""
 
-#: exhibition/views.py:2617 exhibition/views.py:2621
+#: views.py:2971 views.py:2975
 msgid "Unknown template."
 msgstr ""
 
-#: exhibition/views.py:2667
+#: views.py:3021
 msgid "Custom template has been created."
 msgstr ""
 
-#: exhibition/views.py:2683
+#: views.py:3041
 msgid "Custom template has been deleted."
 msgstr ""


### PR DESCRIPTION
Generates translation catalogs for #68 and other PRs' changes.

## Summary by Sourcery

Enhancements:
- Regenerate the gettext translation template and locale catalogs to reflect the current application source strings across all supported languages.